### PR TITLE
Disable-able input and camera track

### DIFF
--- a/CrazyCanvas/Include/CameraTrack.h
+++ b/CrazyCanvas/Include/CameraTrack.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Math/Math.h"
+
+#include <vector>
+
+namespace LambdaEngine
+{
+    class Camera;
+}
+
+class CameraTrack
+{
+public:
+    CameraTrack() = default;
+    ~CameraTrack() = default;
+
+    bool Init(LambdaEngine::Camera* pCamera, const std::vector<glm::vec3>& track);
+    void Tick(float dt);
+
+private:
+    bool hasReachedEnd() const { return m_CurrentTrackIndex == m_Track.size() - 1; }
+    glm::vec3 getCurrentGradient(const glm::uvec4& splineIndices) const;
+    glm::uvec4 getCurrentSplineIndices() const;
+
+private:
+    LambdaEngine::Camera* m_pCamera;
+    std::vector<glm::vec3> m_Track;
+
+    size_t m_CurrentTrackIndex  = 0;
+    float m_CurrentTrackT       = 0.0f;
+};

--- a/CrazyCanvas/Include/CrazyCanvas.h
+++ b/CrazyCanvas/Include/CrazyCanvas.h
@@ -2,6 +2,7 @@
 #include "Game/Game.h"
 
 #include "Application/API/EventHandler.h"
+#include "CameraTrack.h"
 
 #include "Containers/TArray.h"
 
@@ -53,6 +54,8 @@ private:
 	bool InitRendererForVisBuf();
 
 private:
+	CameraTrack m_CameraTrack;
+
 	uint32									m_AudioListenerIndex	= 0;
 
 	GUID_Lambda								m_ToneSoundEffectGUID;

--- a/CrazyCanvas/Source/CameraTrack.cpp
+++ b/CrazyCanvas/Source/CameraTrack.cpp
@@ -1,0 +1,65 @@
+#include "CameraTrack.h"
+
+#include "Game/Camera.h"
+
+bool CameraTrack::Init(LambdaEngine::Camera* pCamera, const std::vector<glm::vec3>& track)
+{
+	m_pCamera = pCamera;
+	m_Track = track;
+	return pCamera;
+}
+
+void CameraTrack::Tick(float dt)
+{
+	if (hasReachedEnd())
+	{
+		return;
+	}
+
+	constexpr const float cameraSpeed = 1.4f;
+	glm::uvec4 splineIndices = getCurrentSplineIndices();
+	const float tPerSecond = cameraSpeed / glm::length(getCurrentGradient(splineIndices));
+
+	m_CurrentTrackT     += dt * tPerSecond;
+	m_CurrentTrackIndex += (size_t)m_CurrentTrackT;
+	splineIndices       = getCurrentSplineIndices();
+	m_CurrentTrackT     = std::modf(m_CurrentTrackT, &m_CurrentTrackT); // Remove integer part
+
+	if (hasReachedEnd())
+	{
+		return;
+	}
+
+	glm::vec3 oldPos = m_pCamera->GetPosition();
+	m_pCamera->SetPosition(glm::catmullRom(
+		m_Track[splineIndices.x],
+		m_Track[splineIndices.y],
+		m_Track[splineIndices.z],
+		m_Track[splineIndices.w],
+		m_CurrentTrackT));
+
+	m_pCamera->SetDirection(glm::normalize(getCurrentGradient(splineIndices)));
+}
+
+glm::vec3 CameraTrack::getCurrentGradient(const glm::uvec4& splineIndices) const
+{
+	const float tt = m_CurrentTrackT * m_CurrentTrackT;
+	const float ttt = tt * m_CurrentTrackT;
+
+	const float weight1 = -3.0f * tt + 4.0f * m_CurrentTrackT - 1.0f;
+	const float weight2 = 9.0f * tt - 10.0f * m_CurrentTrackT;
+	const float weight3 = -9.0f * tt + 8.0f * m_CurrentTrackT + 1.0f;
+	const float weight4 = 3.0f * tt - 2.0f * m_CurrentTrackT;
+
+	return 0.5f * (m_Track[splineIndices[0]] * weight1 + m_Track[splineIndices[1]] * weight2 + m_Track[splineIndices[2]] * weight3 + m_Track[splineIndices[3]] * weight4);
+}
+
+glm::uvec4 CameraTrack::getCurrentSplineIndices() const
+{
+	return {
+		std::max(0, (int)m_CurrentTrackIndex - 1),
+		m_CurrentTrackIndex,
+		std::min(m_Track.size() - 1, m_CurrentTrackIndex + 1),
+		std::min(m_Track.size() - 1, m_CurrentTrackIndex + 2)
+	};
+}

--- a/CrazyCanvas/Source/CrazyCanvas.cpp
+++ b/CrazyCanvas/Source/CrazyCanvas.cpp
@@ -58,6 +58,7 @@ CrazyCanvas::CrazyCanvas()
 {
 	using namespace LambdaEngine;
 
+	Input::Disable();
 	CommonApplication::Get()->AddEventHandler(this);
 
 	m_pScene = DBG_NEW Scene(RenderSystem::GetDevice(), AudioSystem::GetDevice());
@@ -144,6 +145,19 @@ CrazyCanvas::CrazyCanvas()
 
 	m_pCamera->Init(cameraDesc);
 	m_pCamera->Update();
+
+	std::vector<glm::vec3> cameraTrack = {
+        {-2.0f, 1.6f, 1.0f},
+        {9.8f, 1.6f, 0.8f},
+		{9.4f, 1.6f, -3.8f},
+        {-9.8f, 1.6f, -3.9f},
+        {-11.6f, 1.6f, -1.1f},
+        {9.8f, 6.1f, -0.8f},
+        {9.4f, 6.1f, 3.8f},
+        {-9.8f, 6.1f, 3.9f}
+    };
+
+	m_CameraTrack.Init(m_pCamera, cameraTrack);
 
 	SamplerDesc samplerLinearDesc = {};
 	samplerLinearDesc.Name					= "Linear Sampler";
@@ -301,6 +315,7 @@ void CrazyCanvas::FixedTick(LambdaEngine::Timestamp delta)
 	}
 
 	m_pCamera->Update();
+	m_CameraTrack.Tick(dt);
 	m_pScene->UpdateCamera(m_pCamera);
 
 	AudioListenerDesc listenerDesc = {};

--- a/LambdaEngine/Include/Input/API/Input.h
+++ b/LambdaEngine/Include/Input/API/Input.h
@@ -27,12 +27,15 @@ namespace LambdaEngine
 		static void Release();
 
 		static void Tick();
-        
+
+        static void Enable() { s_pInstance->m_InputEnabled = true; };
+        static void Disable();
+
         FORCEINLINE static bool IsKeyDown(EKey key)
         {
             return s_pInstance->m_KeyboardState.IsKeyDown(key);
         }
-        
+
         FORCEINLINE static bool IsKeyUp(EKey key)
         {
             return s_pInstance->m_KeyboardState.IsKeyUp(key);
@@ -42,7 +45,7 @@ namespace LambdaEngine
         {
             return s_pInstance->m_KeyboardState;
         }
-        
+
 		FORCEINLINE static const MouseState& GetMouseState()
         {
             return s_pInstance->m_MouseState;
@@ -51,7 +54,8 @@ namespace LambdaEngine
     private:
         KeyboardState	m_KeyboardState = { };
 		MouseState		m_MouseState    = { };
-	
+        bool m_InputEnabled = true;
+
     private:
 		static Input* s_pInstance;
 	};

--- a/LambdaEngine/Include/Math/Math.h
+++ b/LambdaEngine/Include/Math/Math.h
@@ -11,6 +11,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/hash.hpp>
 #include <glm/gtx/norm.hpp>
+#include <glm/gtx/spline.hpp>
 #include <glm/gtx/string_cast.hpp>
 #include <glm/gtc/type_ptr.hpp>
 

--- a/LambdaEngine/Source/Input/API/Input.cpp
+++ b/LambdaEngine/Source/Input/API/Input.cpp
@@ -13,7 +13,7 @@ namespace LambdaEngine
 	void Input::OnButtonPressed(EMouseButton button, uint32 modifierMask)
 	{
 		UNREFERENCED_VARIABLE(modifierMask);
-		m_MouseState.ButtonStates[button] = true;
+		m_MouseState.ButtonStates[button] = m_InputEnabled;
 	}
 
 	void Input::OnButtonReleased(EMouseButton button)
@@ -23,24 +23,26 @@ namespace LambdaEngine
 
 	void Input::OnMouseMoved(int32 x, int32 y)
 	{
-		m_MouseState.x = x;
-		m_MouseState.y = y;
+		if (m_InputEnabled)
+		{
+			m_MouseState.x = x;
+			m_MouseState.y = y;
+		}
 	}
 
 	void Input::OnMouseScrolled(int32 deltaX, int32 deltaY)
 	{
-		m_MouseState.ScrollX = deltaX;
-		m_MouseState.ScrollY = deltaY;
+		if (m_InputEnabled)
+		{
+			m_MouseState.ScrollX = deltaX;
+			m_MouseState.ScrollY = deltaY;
+		}
 	}
 
 	void Input::OnKeyPressed(EKey key, uint32 modifierMask, bool isRepeat)
 	{
 		UNREFERENCED_VARIABLE(modifierMask);
-
-		if (!isRepeat)
-		{
-			m_KeyboardState.KeyStates[key] = true;
-		}
+		m_KeyboardState.KeyStates[key] = m_InputEnabled && !isRepeat;
 	}
 
 	void Input::OnKeyReleased(EKey key)
@@ -68,5 +70,12 @@ namespace LambdaEngine
 
 	void Input::Tick()
 	{
+	}
+
+	void Input::Disable()
+	{
+		s_pInstance->m_InputEnabled = false;
+		std::fill_n(s_pInstance->m_KeyboardState.KeyStates, EKey::KEY_LAST, false);
+		std::fill_n(s_pInstance->m_MouseState.ButtonStates, EMouseButton::MOUSE_BUTTON_COUNT, false);
 	}
 }


### PR DESCRIPTION
One of the first steps towards enabling benchmark runs.

Input should be disabled when running benchmarks, so that benchmark runs can't be affected by external input.