### PR TITLE
Added more RenderGraph options + Fixed Ray Tracing Stage Shaders

### DIFF
--- a/Assets/RenderGraphs/DEMO.lrg
+++ b/Assets/RenderGraphs/DEMO.lrg
@@ -320,6 +320,9 @@
                 }
             },
             "depth_test_enabled": true,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",

--- a/Assets/RenderGraphs/TRT_DEFERRED_SIMPLE.lrg
+++ b/Assets/RenderGraphs/TRT_DEFERRED_SIMPLE.lrg
@@ -477,6 +477,9 @@
                 }
             },
             "depth_test_enabled": true,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -749,6 +752,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",

--- a/Assets/RenderGraphs/TRT_DEFERRED_SVGF.lrg
+++ b/Assets/RenderGraphs/TRT_DEFERRED_SVGF.lrg
@@ -869,6 +869,9 @@
                 }
             },
             "depth_test_enabled": true,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -1009,6 +1012,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -1089,6 +1095,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -1307,6 +1316,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -1411,6 +1423,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -1473,6 +1488,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -1541,6 +1559,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",
@@ -1603,6 +1624,9 @@
                 "draw_type": "FULLSCREEN_QUAD"
             },
             "depth_test_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
                 "mesh_shader": "",

--- a/LambdaEngine/Include/Rendering/Core/API/GraphicsHelpers.h
+++ b/LambdaEngine/Include/Rendering/Core/API/GraphicsHelpers.h
@@ -193,11 +193,70 @@ namespace LambdaEngine
 		}
 	}
 
-	FORCEINLINE EMemoryType MemoryTypeFromString(const String string)
+	FORCEINLINE EMemoryType MemoryTypeFromString(const String& string)
 	{
 		if (string == "MEMORY_TYPE_CPU_VISIBLE")		return EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
 		if (string == "MEMORY_TYPE_GPU")				return EMemoryType::MEMORY_TYPE_GPU;
 
 		return EMemoryType::MEMORY_TYPE_NONE;
+	}
+
+	FORCEINLINE String PrimitiveTopologyToString(EPrimitiveTopology primitiveTopology)
+	{
+		switch (primitiveTopology)
+		{
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST:	return "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST";
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_LINE_LIST:		return "PRIMITIVE_TOPOLOGY_LINE_LIST";
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_POINT_LIST:		return "PRIMITIVE_TOPOLOGY_POINT_LIST";
+		default:													return "NONE";
+		}
+	}
+
+	FORCEINLINE EPrimitiveTopology PrimitiveTopologyFromString(const String& string)
+	{
+		if (string == "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST")	return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+		if (string == "PRIMITIVE_TOPOLOGY_LINE_LIST")		return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_LINE_LIST;
+		if (string == "PRIMITIVE_TOPOLOGY_POINT_LIST")		return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_POINT_LIST;
+
+		return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_NONE;
+	}
+
+	FORCEINLINE String PolygonModeToString(EPolygonMode polygonMode)
+	{
+		switch (polygonMode)
+		{
+		case EPolygonMode::POLYGON_MODE_FILL:	return "POLYGON_MODE_FILL";
+		case EPolygonMode::POLYGON_MODE_LINE:	return "POLYGON_MODE_LINE";
+		case EPolygonMode::POLYGON_MODE_POINT:	return "POLYGON_MODE_POINT";
+		default:								return "NONE";
+		}
+	}
+
+	FORCEINLINE EPolygonMode PolygonModeFromString(const String& string)
+	{
+		if (string == "POLYGON_MODE_FILL")		return EPolygonMode::POLYGON_MODE_FILL;
+		if (string == "POLYGON_MODE_LINE")		return EPolygonMode::POLYGON_MODE_LINE;
+		if (string == "POLYGON_MODE_POINT")		return EPolygonMode::POLYGON_MODE_POINT;
+
+		return EPolygonMode::POLYGON_MODE_NONE;
+	}
+
+	FORCEINLINE String CullModeToString(ECullMode cullMode)
+	{
+		switch (cullMode)
+		{
+		case ECullMode::CULL_MODE_NONE:		return "CULL_MODE_NONE";
+		case ECullMode::CULL_MODE_BACK:		return "CULL_MODE_BACK";
+		case ECullMode::CULL_MODE_FRONT:	return "CULL_MODE_FRONT";
+		default:							return "NONE";
+		}
+	}
+
+	FORCEINLINE ECullMode CullModeFromString(const String& string)
+	{
+		if (string == "CULL_MODE_NONE")		return ECullMode::CULL_MODE_NONE;
+		if (string == "CULL_MODE_BACK")		return ECullMode::CULL_MODE_BACK;
+		if (string == "CULL_MODE_FRONT")	return ECullMode::CULL_MODE_FRONT;
+		return ECullMode::CULL_MODE_NONE;
 	}
 }

--- a/LambdaEngine/Include/Rendering/Core/API/GraphicsTypes.h
+++ b/LambdaEngine/Include/Rendering/Core/API/GraphicsTypes.h
@@ -82,6 +82,8 @@ namespace LambdaEngine
 	{
 		PRIMITIVE_TOPOLOGY_NONE				= 0,
 		PRIMITIVE_TOPOLOGY_TRIANGLE_LIST	= 1,
+		PRIMITIVE_TOPOLOGY_LINE_LIST		= 2,
+		PRIMITIVE_TOPOLOGY_POINT_LIST		= 3,
 	};
 
 	enum class EPolygonMode : uint8

--- a/LambdaEngine/Include/Rendering/Core/Vulkan/VulkanHelpers.h
+++ b/LambdaEngine/Include/Rendering/Core/Vulkan/VulkanHelpers.h
@@ -410,6 +410,8 @@ namespace LambdaEngine
 	{
 		switch (topology)
 		{
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_POINT_LIST:		return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_LINE_LIST:		return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
 		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST:	return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_NONE:
 		default:													return VkPrimitiveTopology(0);

--- a/LambdaEngine/Include/Rendering/RenderGraphEditor.h
+++ b/LambdaEngine/Include/Rendering/RenderGraphEditor.h
@@ -36,6 +36,7 @@ namespace LambdaEngine
 		void InitDefaultResources();
 
 		void RenderResourceView(float textWidth, float textHeight);
+		void RenderNewRenderGraphConfirmationView();
 		void RenderAddResourceView();
 		void RenderEditResourceView();
 		void InternalRenderEditResourceView(RenderGraphResourceDesc* pResource, char* pNameBuffer, int32 nameBufferLength);
@@ -92,6 +93,7 @@ namespace LambdaEngine
 		TArray<String>										m_FilesInShaderDirectory;
 
 		RenderGraphStructureDesc							m_ParsedRenderGraphStructure	= {};
+		bool												m_ParsedGraphValid				= true;
 		bool												m_ParsedGraphDirty				= true;
 		bool												m_ParsedGraphRenderDirty		= true;
 		bool												m_ApplyRenderGraph				= false;

--- a/LambdaEngine/Include/Rendering/RenderGraphEditorHelpers.h
+++ b/LambdaEngine/Include/Rendering/RenderGraphEditorHelpers.h
@@ -1,0 +1,242 @@
+#pragma once
+
+#include "RenderGraphTypes.h"
+#include "Rendering/Core/API/GraphicsTypes.h"
+
+namespace LambdaEngine
+{
+	constexpr const char* TEXTURE_FORMAT_NAMES[] =
+	{
+		"FORMAT_R32G32_SFLOAT",
+		"FORMAT_R8G8B8A8_UNORM",
+		"FORMAT_B8G8R8A8_UNORM",
+		"FORMAT_R8G8B8A8_SNORM",
+		"FORMAT_R16G16B16A16_SFLOAT",
+		"FORMAT_D24_UNORM_S8_UINT",
+		"FORMAT_R16_UNORM",
+		"FORMAT_R32G32B32A32_SFLOAT",
+		"FORMAT_R16_SFLOAT",
+		"FORMAT_R32G32B32A32_UINT",
+	};
+
+	static EFormat TextureFormatIndexToFormat(int32 index)
+	{
+		switch (index)
+		{
+		case 0: return EFormat::FORMAT_R32G32_SFLOAT;
+		case 1: return EFormat::FORMAT_R8G8B8A8_UNORM;
+		case 2: return EFormat::FORMAT_B8G8R8A8_UNORM;
+		case 3: return EFormat::FORMAT_R8G8B8A8_SNORM;
+		case 4: return EFormat::FORMAT_R16G16B16A16_SFLOAT;
+		case 5: return EFormat::FORMAT_D24_UNORM_S8_UINT;
+		case 6: return EFormat::FORMAT_R16_UNORM;
+		case 7: return EFormat::FORMAT_R32G32B32A32_SFLOAT;
+		case 8: return EFormat::FORMAT_R16_SFLOAT;
+		case 9: return EFormat::FORMAT_R32G32B32A32_UINT;
+		}
+
+		return EFormat::FORMAT_NONE;
+	}
+
+	static int32 TextureFormatToFormatIndex(EFormat format)
+	{
+		switch (format)
+		{
+		case EFormat::FORMAT_R32G32_SFLOAT:			return 0;
+		case EFormat::FORMAT_R8G8B8A8_UNORM:		return 1;
+		case EFormat::FORMAT_B8G8R8A8_UNORM:		return 2;
+		case EFormat::FORMAT_R8G8B8A8_SNORM:		return 3;
+		case EFormat::FORMAT_R16G16B16A16_SFLOAT:	return 4;
+		case EFormat::FORMAT_D24_UNORM_S8_UINT:		return 5;
+		case EFormat::FORMAT_R16_UNORM:				return 6;
+		case EFormat::FORMAT_R32G32B32A32_SFLOAT:	return 7;
+		case EFormat::FORMAT_R16_SFLOAT:			return 8;
+		case EFormat::FORMAT_R32G32B32A32_UINT:		return 9;
+		}
+
+		return -1;
+	}
+
+	constexpr const char* DIMENSION_NAMES[] =
+	{
+		"CONSTANT",
+		"EXTERNAL",
+		"RELATIVE",
+		"RELATIVE_1D",
+	};
+
+	ERenderGraphDimensionType DimensionTypeIndexToDimensionType(int32 index)
+	{
+		switch (index)
+		{
+		case 0: return ERenderGraphDimensionType::CONSTANT;
+		case 1: return ERenderGraphDimensionType::EXTERNAL;
+		case 2: return ERenderGraphDimensionType::RELATIVE;
+		case 3: return ERenderGraphDimensionType::RELATIVE_1D;
+		}
+
+		return ERenderGraphDimensionType::NONE;
+	}
+
+	int32 DimensionTypeToDimensionTypeIndex(ERenderGraphDimensionType dimensionType)
+	{
+		switch (dimensionType)
+		{
+		case ERenderGraphDimensionType::CONSTANT:		return 0;
+		case ERenderGraphDimensionType::EXTERNAL:		return 1;
+		case ERenderGraphDimensionType::RELATIVE:		return 2;
+		case ERenderGraphDimensionType::RELATIVE_1D:	return 3;
+		}
+
+		return -1;
+	}
+
+	constexpr const char* SAMPLER_NAMES[] =
+	{
+		"LINEAR",
+		"NEAREST",
+	};
+
+	ERenderGraphSamplerType SamplerTypeIndexToSamplerType(int32 index)
+	{
+		switch (index)
+		{
+		case 0: return ERenderGraphSamplerType::LINEAR;
+		case 1: return ERenderGraphSamplerType::NEAREST;
+		}
+
+		return ERenderGraphSamplerType::NONE;
+	}
+
+	int32 SamplerTypeToSamplerTypeIndex(ERenderGraphSamplerType samplerType)
+	{
+		switch (samplerType)
+		{
+		case ERenderGraphSamplerType::LINEAR:	return 0;
+		case ERenderGraphSamplerType::NEAREST:	return 1;
+		}
+
+		return -1;
+	}
+
+	constexpr const char* MEMORY_TYPE_NAMES[] =
+	{
+		"MEMORY_TYPE_CPU_VISIBLE",
+		"MEMORY_TYPE_GPU",
+	};
+
+	EMemoryType MemoryTypeIndexToMemoryType(int32 index)
+	{
+		switch (index)
+		{
+		case 0: return EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
+		case 1: return EMemoryType::MEMORY_TYPE_GPU;
+		}
+
+		return EMemoryType::MEMORY_TYPE_NONE;
+	}
+
+	int32 MemoryTypeToMemoryTypeIndex(EMemoryType memoryType)
+	{
+		switch (memoryType)
+		{
+		case EMemoryType::MEMORY_TYPE_CPU_VISIBLE:	return 0;
+		case EMemoryType::MEMORY_TYPE_GPU:			return 1;
+		}
+
+		return -1;
+	}
+
+	constexpr const char* PRIMITIVE_TOPOLOGY_NAMES[] =
+	{
+		"PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
+		"PRIMITIVE_TOPOLOGY_LINE_LIST",
+		"PRIMITIVE_TOPOLOGY_POINT_LIST",
+	};
+
+	EPrimitiveTopology PrimitiveTopologyIndexToPrimitiveTopology(int32 index)
+	{
+		switch (index)
+		{
+		case 0: return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+		case 1: return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_LINE_LIST;
+		case 2: return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_POINT_LIST;
+		}
+
+		return EPrimitiveTopology::PRIMITIVE_TOPOLOGY_NONE;
+	}
+
+	int32 PrimitiveTopologyToPrimitiveTopologyIndex(EPrimitiveTopology primitiveTopology)
+	{
+		switch (primitiveTopology)
+		{
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST:	return 0;
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_LINE_LIST:		return 1;
+		case EPrimitiveTopology::PRIMITIVE_TOPOLOGY_POINT_LIST:		return 2;
+		}
+
+		return -1;
+	}
+
+	constexpr const char* POLYGON_MODE_NAMES[] =
+	{
+		"POLYGON_MODE_FILL",
+		"POLYGON_MODE_LINE",
+		"POLYGON_MODE_POINT",
+	};
+
+	EPolygonMode PolygonModeIndexToPolygonMode(int32 index)
+	{
+		switch (index)
+		{
+		case 0: return EPolygonMode::POLYGON_MODE_FILL;
+		case 1: return EPolygonMode::POLYGON_MODE_LINE;
+		case 2: return EPolygonMode::POLYGON_MODE_POINT;
+		}
+
+		return EPolygonMode::POLYGON_MODE_NONE;
+	}
+
+	int32 PolygonModeToPolygonModeIndex(EPolygonMode primitiveTopology)
+	{
+		switch (primitiveTopology)
+		{
+		case EPolygonMode::POLYGON_MODE_FILL:	return 0;
+		case EPolygonMode::POLYGON_MODE_LINE:	return 1;
+		case EPolygonMode::POLYGON_MODE_POINT:	return 2;
+		}
+
+		return -1;
+	}
+
+	constexpr const char* CULL_MODE_NAMES[] =
+	{
+		"CULL_MODE_BACK",
+		"CULL_MODE_FRONT",
+		"CULL_MODE_NONE",
+	};
+
+	ECullMode CullModeIndexToCullMode(int32 index)
+	{
+		switch (index)
+		{
+		case 0: return ECullMode::CULL_MODE_BACK;
+		case 1: return ECullMode::CULL_MODE_FRONT;
+		case 2: return ECullMode::CULL_MODE_NONE;
+		}
+
+		return ECullMode::CULL_MODE_NONE;
+	}
+
+	int32 CullModeToCullModeIndex(ECullMode primitiveTopology)
+	{
+		switch (primitiveTopology)
+		{
+		case ECullMode::CULL_MODE_BACK:		return 0;
+		case ECullMode::CULL_MODE_FRONT:	return 1;
+		case ECullMode::CULL_MODE_NONE:		return 2;
+		}
+
+		return -1;
+	}
+}

--- a/LambdaEngine/Include/Rendering/RenderGraphTypes.h
+++ b/LambdaEngine/Include/Rendering/RenderGraphTypes.h
@@ -186,21 +186,24 @@ namespace LambdaEngine
 
 		struct
 		{
-			GraphicsShaderNames			Shaders;
-			ERenderStageDrawType		DrawType;
-			String						IndexBufferName;
-			String						IndirectArgsBufferName;
-			bool						DepthTestEnabled;
+			GraphicsShaderNames		Shaders;
+			ERenderStageDrawType	DrawType				= ERenderStageDrawType::NONE;
+			String					IndexBufferName			= "";
+			String					IndirectArgsBufferName	= "";
+			bool					DepthTestEnabled		= true;
+			ECullMode				CullMode				= ECullMode::CULL_MODE_BACK;
+			EPolygonMode			PolygonMode				= EPolygonMode::POLYGON_MODE_FILL;
+			EPrimitiveTopology		PrimitiveTopology		= EPrimitiveTopology::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 		} Graphics;
 
 		struct
-		{	
-			String						ShaderName	= "";
+		{
+			String					ShaderName	= "";
 		} Compute;
 
 		struct
 		{
-			RayTracingShaderNames		Shaders;
+			RayTracingShaderNames	Shaders;
 		} RayTracing;
 	};
 
@@ -283,21 +286,24 @@ namespace LambdaEngine
 
 		struct
 		{
-			GraphicsShaderNames			Shaders;
-			ERenderStageDrawType		DrawType;
-			int32						IndexBufferAttributeIndex;
-			int32						IndirectArgsBufferAttributeIndex;
-			bool						DepthTestEnabled;
+			GraphicsShaderNames		Shaders;
+			ERenderStageDrawType	DrawType							= ERenderStageDrawType::NONE;
+			int32					IndexBufferAttributeIndex			= -1;
+			int32					IndirectArgsBufferAttributeIndex	= -1;
+			bool					DepthTestEnabled					= true;
+			ECullMode				CullMode							= ECullMode::CULL_MODE_BACK;
+			EPolygonMode			PolygonMode							= EPolygonMode::POLYGON_MODE_FILL;
+			EPrimitiveTopology		PrimitiveTopology					= EPrimitiveTopology::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 		} Graphics;
 
 		struct
 		{
-			String						ShaderName = "";
+			String					ShaderName = "";
 		} Compute;
 
 		struct
 		{
-			RayTracingShaderNames		Shaders;
+			RayTracingShaderNames	Shaders;
 		} RayTracing;
 
 		TArray<EditorResourceStateIdent>		ResourceStateIdents;

--- a/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
@@ -948,7 +948,6 @@ namespace LambdaEngine
 		colorAttachmentDesc.FinalState		= pBackBufferAttachmentDesc->FinalState;
 
 		RenderPassSubpassDesc subpassDesc = {};
-		subpassDesc.RenderTargetStates.Reserve(512);
 		subpassDesc.RenderTargetStates			= { ETextureState::TEXTURE_STATE_RENDER_TARGET };
 		subpassDesc.DepthStencilAttachmentState	= ETextureState::TEXTURE_STATE_DONT_CARE;
 
@@ -962,7 +961,6 @@ namespace LambdaEngine
 
 		RenderPassDesc renderPassDesc = {};
 		renderPassDesc.DebugName			= "ImGui Render Pass";
-		renderPassDesc.Attachments.Reserve(256);
 		renderPassDesc.Attachments			= { colorAttachmentDesc };
 		renderPassDesc.Subpasses			= { subpassDesc };
 		renderPassDesc.SubpassDependencies	= { subpassDependencyDesc };

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -1410,11 +1410,9 @@ namespace LambdaEngine
 
 				Resource* pResource = &resourceIt->second;
 
-				//Create Initital Transition Barrier and Params
-				if (!isImGuiStage)
+				//Create Initital Transition Barrier and Params, we don't want to create them for the ImGui stage because it "backtransitions" unless it is the only stage
+				if (!isImGuiStage || m_RenderStageCount == 1)
 				{
-					
-
 					if (pResource->Type == ERenderGraphResourceType::TEXTURE && !pResource->IsBackBuffer)
 					{
 						uint32 numInitialBarriers = 0;
@@ -1589,7 +1587,6 @@ namespace LambdaEngine
 			if (pRenderStageDesc->CustomRenderer)
 			{
 				ICustomRenderer* pCustomRenderer = nullptr;
-				bool initializeCustomRenderer = true;
 
 				if (isImGuiStage)
 				{
@@ -1618,7 +1615,6 @@ namespace LambdaEngine
 					else
 					{
 						pCustomRenderer = *imGuiRenderStageIt;
-						initializeCustomRenderer = false;
 					}
 				}
 				else
@@ -1628,18 +1624,15 @@ namespace LambdaEngine
 					m_CustomRenderers.PushBack(pRenderStageDesc->CustomRenderer.pCustomRenderer);*/
 				}
 
-				if (initializeCustomRenderer)
-				{
-					CustomRendererRenderGraphInitDesc customRendererInitDesc = {};
-					customRendererInitDesc.pColorAttachmentDesc			= renderPassAttachmentDescriptions.GetData();
-					customRendererInitDesc.ColorAttachmentCount			= (uint32)renderPassAttachmentDescriptions.GetSize();
-					customRendererInitDesc.pDepthStencilAttachmentDesc	= renderPassDepthStencilDescription.Format != EFormat::FORMAT_NONE ? &renderPassDepthStencilDescription : nullptr;
+				CustomRendererRenderGraphInitDesc customRendererInitDesc = {};
+				customRendererInitDesc.pColorAttachmentDesc			= renderPassAttachmentDescriptions.GetData();
+				customRendererInitDesc.ColorAttachmentCount			= (uint32)renderPassAttachmentDescriptions.GetSize();
+				customRendererInitDesc.pDepthStencilAttachmentDesc	= renderPassDepthStencilDescription.Format != EFormat::FORMAT_NONE ? &renderPassDepthStencilDescription : nullptr;
 
-					if (!pCustomRenderer->RenderGraphInit(&customRendererInitDesc))
-					{
-						LOG_ERROR("[RenderGraph] Could not initialize Custom Renderer");
-						return false;
-					}
+				if (!pCustomRenderer->RenderGraphInit(&customRendererInitDesc))
+				{
+					LOG_ERROR("[RenderGraph] Could not initialize Custom Renderer");
+					return false;
 				}
 
 				pRenderStage->UsesCustomRenderer	= true;
@@ -1758,11 +1751,13 @@ namespace LambdaEngine
 					pipelineDesc.DomainShader.ShaderGUID			= pRenderStageDesc->Graphics.Shaders.DomainShaderName.empty()	? GUID_NONE : ResourceManager::LoadShaderFromFile(pRenderStageDesc->Graphics.Shaders.DomainShaderName,		FShaderStageFlags::SHADER_STAGE_FLAG_DOMAIN_SHADER,		EShaderLang::SHADER_LANG_GLSL);
 					pipelineDesc.PixelShader.ShaderGUID				= pRenderStageDesc->Graphics.Shaders.PixelShaderName.empty()	? GUID_NONE : ResourceManager::LoadShaderFromFile(pRenderStageDesc->Graphics.Shaders.PixelShaderName,		FShaderStageFlags::SHADER_STAGE_FLAG_PIXEL_SHADER,		EShaderLang::SHADER_LANG_GLSL);
 					pipelineDesc.BlendState.BlendAttachmentStates	= renderPassBlendAttachmentStates;
+					pipelineDesc.RasterizerState.CullMode			= pRenderStageDesc->Graphics.CullMode;
+					pipelineDesc.RasterizerState.PolygonMode		= pRenderStageDesc->Graphics.PolygonMode;
+					pipelineDesc.InputAssembly.PrimitiveTopology	= pRenderStageDesc->Graphics.PrimitiveTopology;
 
 					//Create RenderPass
 					{
 						RenderPassSubpassDesc renderPassSubpassDesc = { };
-						renderPassSubpassDesc.RenderTargetStates.Reserve(64);
 						renderPassSubpassDesc.RenderTargetStates			= renderPassRenderTargetStates;
 						renderPassSubpassDesc.DepthStencilAttachmentState	= pDepthStencilResource != nullptr ? ETextureState::TEXTURE_STATE_DEPTH_STENCIL_ATTACHMENT : ETextureState::TEXTURE_STATE_DONT_CARE;
 
@@ -1779,7 +1774,6 @@ namespace LambdaEngine
 
 						RenderPassDesc renderPassDesc = {};
 						renderPassDesc.DebugName			= "";
-						renderPassDesc.Attachments.Reserve(128);
 						renderPassDesc.Attachments			= renderPassAttachmentDescriptions;
 						renderPassDesc.Subpasses			= { renderPassSubpassDesc };
 						renderPassDesc.SubpassDependencies	= { renderPassSubpassDependencyDesc };

--- a/LambdaEngine/Source/Rendering/RenderGraphParser.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraphParser.cpp
@@ -1051,6 +1051,10 @@ namespace LambdaEngine
 			pDstRenderStage->Graphics.Shaders					= pSrcRenderStage->Graphics.Shaders;
 			pDstRenderStage->Graphics.DrawType					= pSrcRenderStage->Graphics.DrawType;
 			pDstRenderStage->Graphics.DepthTestEnabled			= pSrcRenderStage->Graphics.DepthTestEnabled;
+			pDstRenderStage->Graphics.CullMode					= pSrcRenderStage->Graphics.CullMode;
+			pDstRenderStage->Graphics.PolygonMode				= pSrcRenderStage->Graphics.PolygonMode;
+			pDstRenderStage->Graphics.PrimitiveTopology			= pSrcRenderStage->Graphics.PrimitiveTopology;
+
 			if (pDstRenderStage->Graphics.DrawType == ERenderStageDrawType::SCENE_INDIRECT)
 			{
 				pDstRenderStage->Graphics.IndexBufferName			= indexBufferResourceStateIt != resourceStatesByHalfAttributeIndex.end()		? indexBufferResourceStateIt->second.ResourceName			: "";

--- a/LambdaEngine/Source/Rendering/RenderGraphSerializer.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraphSerializer.cpp
@@ -413,6 +413,15 @@ namespace LambdaEngine
 
 							writer.String("depth_test_enabled");
 							writer.Bool(renderStageIt->second.Graphics.DepthTestEnabled);
+
+							writer.String("cull_mode");
+							writer.String(CullModeToString(renderStageIt->second.Graphics.CullMode).c_str());
+
+							writer.String("polygon_mode");
+							writer.String(PolygonModeToString(renderStageIt->second.Graphics.PolygonMode).c_str());
+
+							writer.String("primitive_topology");
+							writer.String(PrimitiveTopologyToString(renderStageIt->second.Graphics.PrimitiveTopology).c_str());					
 						}
 
 						writer.String("shaders");
@@ -960,7 +969,10 @@ namespace LambdaEngine
 							}
 						}
 
-						renderStage.Graphics.DepthTestEnabled			= renderStageObject["depth_test_enabled"].GetBool();
+						renderStage.Graphics.DepthTestEnabled					= renderStageObject["depth_test_enabled"].GetBool();
+						if (renderStageObject.HasMember("cull_mode"))			renderStage.Graphics.CullMode			= CullModeFromString(renderStageObject["cull_mode"].GetString());
+						if (renderStageObject.HasMember("polygon_mode"))		renderStage.Graphics.PolygonMode		= PolygonModeFromString(renderStageObject["polygon_mode"].GetString());
+						if (renderStageObject.HasMember("primitive_topology"))	renderStage.Graphics.PrimitiveTopology	= PrimitiveTopologyFromString(renderStageObject["primitive_topology"].GetString());
 
 						renderStage.Graphics.Shaders.TaskShaderName		= shadersObject["task_shader"].GetString();
 						renderStage.Graphics.Shaders.MeshShaderName		= shadersObject["mesh_shader"].GetString();

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -4,7 +4,7 @@ Size=400,400
 Collapsed=0
 
 [Window][Render Graph Editor]
-Pos=129,61
+Pos=108,70
 Size=1605,884
 Collapsed=0
 
@@ -44,17 +44,27 @@ Size=466,311
 Collapsed=0
 
 [Window][Load Render Graph ##Popup]
-Pos=842,340
+Pos=855,340
 Size=360,400
 Collapsed=0
 
 [Window][Save Render Graph ##Popup]
-Pos=780,480
+Pos=789,480
 Size=360,120
 Collapsed=0
 
 [Window][Add Resource ##Popup]
 Pos=731,190
 Size=460,700
+Collapsed=0
+
+[Window][New Render Graph Confirmation ##Popup]
+Pos=728,458
+Size=460,105
+Collapsed=0
+
+[Window][Add Render Stage ##Popup]
+Pos=782,290
+Size=360,500
 Collapsed=0
 


### PR DESCRIPTION
Closes: 
- 102 : Add primitive topology as option for renderstage
- 130 : Fix Remove/Adding mismatching Miss and Closest Hit Shaders in editor Shader 

Also Adds/Fixes:
- Polygon Mode as RenderStage Option
- Cull Mode as RenderStage Option
- Bugged Ray Tracing Shader Editing in RenderGraphEditor