### PR TITLE
Moved GameConsole initialization and update to EngineLoop

### DIFF
--- a/LambdaEngine/Include/Game/GameConsole.h
+++ b/LambdaEngine/Include/Game/GameConsole.h
@@ -25,7 +25,7 @@ namespace LambdaEngine
 		bool Init();
 		bool Release();
 
-		void Render();
+		void Tick();
 		
 		void BindCommand(ConsoleCommand cmd, std::function<void(CallbackInput&)> callback);
 

--- a/LambdaEngine/Source/Engine/EngineLoop.cpp
+++ b/LambdaEngine/Source/Engine/EngineLoop.cpp
@@ -31,6 +31,8 @@
 
 #include "Utilities/RuntimeStats.h"
 
+#include "Game/GameConsole.h"
+
 namespace LambdaEngine
 {
 	/*
@@ -74,6 +76,8 @@ namespace LambdaEngine
 	{
 		RuntimeStats::SetFrameTime((float)delta.AsSeconds());
 		Input::Tick();
+
+		GameConsole::Get().Tick();
 
 		Thread::Join();
 
@@ -136,6 +140,11 @@ namespace LambdaEngine
 			return false;
 		}
 
+		if (!GameConsole::Get().Init())
+		{
+			return false;
+		}
+
 		if (!PlatformNetworkUtils::Init())
 		{
 			return false;
@@ -181,6 +190,11 @@ namespace LambdaEngine
 	bool EngineLoop::Release()
 	{
 		Input::Release();
+
+		if (!GameConsole::Get().Release())
+		{
+			return false;
+		}
 
 		if (!Renderer::Release())
 		{

--- a/LambdaEngine/Source/Game/GameConsole.cpp
+++ b/LambdaEngine/Source/Game/GameConsole.cpp
@@ -35,6 +35,23 @@ namespace LambdaEngine
 			m_Items.Clear();
 		});
 
+		// Test Command
+		ConsoleCommand cmd;
+		cmd.Init("clo", true);
+		cmd.AddArg(Arg::EType::STRING);
+		cmd.AddFlag("l", Arg::EType::INT);
+		cmd.AddFlag("i", Arg::EType::EMPTY);
+		cmd.AddDescription("Does blah and do bar.");
+		GameConsole::Get().BindCommand(cmd, [](GameConsole::CallbackInput& input)->void {
+			std::string s1 = input.Arguments.GetFront().Value.Str;
+			std::string s2 = input.Flags.find("i") == input.Flags.end() ? "no set" : "set";
+			std::string s3 = "no set";
+			auto it = input.Flags.find("l");
+			if (it != input.Flags.end())
+				s3 = "set with a value of " + std::to_string(it->second.Arg.Value.I);
+			LOG_INFO("Command Called with argument '%s' and flag i was %s and flag l was %s.", s1.c_str(), s2.c_str(), s3.c_str());
+			});
+
 		return true;
 	}
 
@@ -43,7 +60,7 @@ namespace LambdaEngine
 		return true;
 	}
 
-	void GameConsole::Render()
+	void GameConsole::Tick()
 	{
 		// Toggle console when pressing § (Button beneath Escape)
 		static bool s_Active = false;
@@ -109,11 +126,11 @@ namespace LambdaEngine
 						hasFocus = true;
 					}
 
-						if (s_Active || hasFocus)
-						{
-							ImGui::SetItemDefaultFocus();
-							ImGui::SetKeyboardFocusHere(-1); // Set focus to the text field.
-						}
+					if (s_Active || hasFocus)
+					{
+						ImGui::SetItemDefaultFocus();
+						ImGui::SetKeyboardFocusHere(-1); // Set focus to the text field.
+					}
 
 				}
 				ImGui::End();

--- a/Sandbox/Source/Sandbox.cpp
+++ b/Sandbox/Source/Sandbox.cpp
@@ -321,23 +321,6 @@ Sandbox::Sandbox()
 		m_pRenderGraphEditor->InitGUI();	//Must Be called after Renderer is initialized
 	}
 
-	GameConsole::Get().Init();
-	ConsoleCommand cmd;
-	cmd.Init("clo", true);
-	cmd.AddArg(Arg::EType::STRING);
-	cmd.AddFlag("l", Arg::EType::INT);
-	cmd.AddFlag("i", Arg::EType::EMPTY);
-	cmd.AddDescription("Does blah and do bar.");
-	GameConsole::Get().BindCommand(cmd, [](GameConsole::CallbackInput& input)->void {
-		std::string s1 = input.Arguments.GetFront().Value.Str;
-		std::string s2 = input.Flags.find("i") == input.Flags.end() ? "no set" : "set";
-		std::string s3 = "no set";
-		auto it = input.Flags.find("l");
-		if (it != input.Flags.end())
-			s3 = "set with a value of " + std::to_string(it->second.Arg.Value.I);
-		LOG_INFO("Command Called with argument '%s' and flag i was %s and flag l was %s.", s1.c_str(), s2.c_str(), s3.c_str());
-	});
-
 	ConsoleCommand cmd1;
 	cmd1.Init("render_graph", true);
 	cmd1.AddArg(Arg::EType::BOOL);
@@ -362,7 +345,6 @@ Sandbox::Sandbox()
 		m_DebuggingWindow = input.Arguments.GetFront().Value.B;
 		});
 
-
 	return;
 }
 
@@ -373,8 +355,6 @@ Sandbox::~Sandbox()
 	SAFEDELETE(m_pCamera);
 
 	SAFEDELETE(m_pRenderGraphEditor);
-
-	LambdaEngine::GameConsole::Get().Release();
 }
 
 void Sandbox::OnKeyPressed(LambdaEngine::EKey key, uint32 modifierMask, bool isRepeat)
@@ -487,8 +467,6 @@ void Sandbox::Render(LambdaEngine::Timestamp delta)
 			}
 			
 		});
-
-		GameConsole::Get().Render();
 	}
 
 	Renderer::Render();

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -60,7 +60,7 @@ Collapsed=0
 
 [Window][Console]
 Pos=0,0
-Size=558,231
+Size=563,313
 Collapsed=0
 
 [Window][Example: Console]


### PR DESCRIPTION
- Changed the name of the Render function in GameConsole to Tick.

- Moved the Example command into GameConsole.

- Initialization, deletion, and update of GameConsole has been moved into EngineLoop