### PR TITLE
Pull from docs repo if it is already cloned

### DIFF
--- a/.github/workflows/update-charts.py
+++ b/.github/workflows/update-charts.py
@@ -13,8 +13,13 @@ def print_help(helpString, args):
     print(f'Used flags: {str(args)}')
 
 def pull_pages_repo(repo_URL):
-    print(f'Cloning pages repo into {REPO_DIR}/')
-    subprocess.run(f'git clone {repo_URL} {REPO_DIR}', shell=True, check=True)
+    if not os.path.exists(REPO_DIR):
+        print(f'Cloning pages repo into {REPO_DIR}/')
+        subprocess.run(f'git clone {repo_URL} {REPO_DIR}', shell=True, check=True)
+    else:
+        print(f'Pages repo already cloned, pulling latest changes')
+        # -C Changes git's working directory
+        subprocess.run(f'git -C {REPO_DIR} pull {repo_URL} {REPO_DIR}', shell=True, check=True)
 
 # Gets information regarding a commit in the game repository
 def get_commit_info(commit_ID):


### PR DESCRIPTION
Fixes an issue where updating the benchmark graphs would crash. It happens if the GitHub pages repo already exists, and the action runner attempts to clone it again. The solution is to check if it already exists, and do 'git pull' if it does.