### PR TITLE
Set whole engine config when benchmarking

### DIFF
--- a/.github/workflows/benchmark.py
+++ b/.github/workflows/benchmark.py
@@ -7,6 +7,18 @@ BENCHMARK_RESULTS_PATH_RT_OFF   = 'benchmark_results_rt_off.json'
 ENGINE_CONFIG_PATH      = '../engine_config.json'
 TEMP_ENGINE_CONFIG_PATH = '../engine_config_copy.json'
 
+ENGINE_CONFIG = {
+	'WindowSize': [1920, 1080],
+	'FixedTimestep': 60,
+	'RayTracingEnabled': True,
+	'ShowRenderGraph': False,
+	'ShowDemo': False,
+	'Debugging': False,
+	'CameraFOV': 90.0,
+	'CameraNearPlane': 0.001,
+	'CameraFarPlane': 1000.0
+}
+
 def print_help(help_string, args):
 	print('Intended usage:')
 	print(help_string)
@@ -18,8 +30,8 @@ def remove_existing_benchmark_files():
 			os.remove(file_name)
 
 def set_engine_config(ray_tracing_enabled):
-	with open(ENGINE_CONFIG_PATH, 'w+') as cfgFile:
-		config = {}
+	with open(ENGINE_CONFIG_PATH, 'w+', newline='\n') as cfgFile:
+		config = ENGINE_CONFIG
 		config['RayTracingEnabled'] = ray_tracing_enabled
 		cfgFile.seek(0)
 		json.dump(config, cfgFile, indent=4)

--- a/Sandbox/Source/Sandbox.cpp
+++ b/Sandbox/Source/Sandbox.cpp
@@ -69,7 +69,7 @@ Sandbox::Sandbox()
 {
 	using namespace LambdaEngine;
 
-	m_RenderGraphWindow = EngineConfig::GetBoolProperty("RenderGraph");
+	m_RenderGraphWindow = EngineConfig::GetBoolProperty("ShowRenderGraph");
 	m_ShowDemoWindow = EngineConfig::GetBoolProperty("ShowDemo");
 	m_DebuggingWindow = EngineConfig::GetBoolProperty("Debugging");
 
@@ -340,7 +340,7 @@ Sandbox::Sandbox()
 			m_InstanceIndicesAndTransforms.PushBack(instanceIndexAndTransform);
 		}
 	}
-	
+
 
 	m_pScene->Finalize();
 	Renderer::SetScene(m_pScene);
@@ -477,7 +477,7 @@ void Sandbox::Render(LambdaEngine::Timestamp delta)
 			{
 				Profiler::Render(delta);
 			}
-			
+
 		});
 	}
 

--- a/engine_config.json
+++ b/engine_config.json
@@ -1,8 +1,11 @@
 {
-    "WindowSize": [1920, 1080],
+    "WindowSize": [
+        1920,
+        1080
+    ],
     "FixedTimestep": 60,
     "RayTracingEnabled": true,
-    "RenderGraph": false,
+    "ShowRenderGraph": false,
     "ShowDemo": false,
     "Debugging": false,
     "CameraFOV": 90.0,


### PR DESCRIPTION
`benchmark.py` writes a new engine config file for each run, and since some members weren't being set, the benchmarked application would crash when trying to load the missing members.