### PR TITLE
Add TransformHandler and CameraHandler

### DIFF
--- a/LambdaEngine/Include/ECS/Component.h
+++ b/LambdaEngine/Include/ECS/Component.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <typeindex>
+
+#define TID(type) std::type_index(typeid(type))

--- a/LambdaEngine/Include/ECS/ComponentHandler.h
+++ b/LambdaEngine/Include/ECS/ComponentHandler.h
@@ -51,7 +51,7 @@ namespace LambdaEngine
         void RegisterHandler(const ComponentHandlerRegistration& handlerRegistration);
 
         // Tell the system subscriber a component has been created
-        void RegisterComponent(Entity entity, std::type_index componentType);
+        static void RegisterComponent(Entity entity, std::type_index componentType);
 
     protected:
         TArray<std::type_index> m_HandledTypes;

--- a/LambdaEngine/Include/ECS/ComponentHandler.h
+++ b/LambdaEngine/Include/ECS/ComponentHandler.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "Containers/TArray.h"
+#include "ECS/Component.h"
 #include "ECS/Entity.h"
 
 #include <functional>
-#include <typeindex>
 
 namespace LambdaEngine
 {
@@ -34,7 +34,7 @@ namespace LambdaEngine
     class ComponentHandler
     {
     public:
-        ComponentHandler(ECSCore* pECS, std::type_index tid_handler);
+        ComponentHandler(std::type_index tid_handler);
         // Deregisters component handler and deletes components
         virtual ~ComponentHandler();
 
@@ -54,7 +54,6 @@ namespace LambdaEngine
         void RegisterComponent(Entity entity, std::type_index componentType);
 
     protected:
-        ECSCore* m_pECS;
         TArray<std::type_index> m_HandledTypes;
 
     private:

--- a/LambdaEngine/Include/ECS/ECSCore.h
+++ b/LambdaEngine/Include/ECS/ECSCore.h
@@ -1,17 +1,14 @@
 #pragma once
 
 #include "ECS/ComponentHandler.h"
-#include "ECS/EntityPublisher.h"
 #include "ECS/ECSBooter.h"
+#include "ECS/EntityPublisher.h"
 #include "ECS/EntityRegistry.h"
 #include "ECS/JobScheduler.h"
 #include "ECS/System.h"
-
 #include "Utilities/IDGenerator.h"
 
 #include <typeindex>
-
-#define TID(type) std::type_index(typeid(type))
 
 namespace LambdaEngine
 {

--- a/LambdaEngine/Include/ECS/EntitySubscriber.h
+++ b/LambdaEngine/Include/ECS/EntitySubscriber.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "Containers/TArray.h"
+#include "ECS/Component.h"
 #include "ECS/Entity.h"
 
 #include <functional>
-#include <typeindex>
 
 namespace LambdaEngine
 {

--- a/LambdaEngine/Include/Game/Camera.h
+++ b/LambdaEngine/Include/Game/Camera.h
@@ -28,8 +28,8 @@ namespace LambdaEngine
 		glm::vec3 Direction = glm::vec3(1.0f, 0.0f, 0.0f);
 		float FOVDegrees	= 45.0f;
 		float Width			= 1280.0f;
-		float Height		= 720.0f; 
-		float NearPlane		= 0.0001f; 
+		float Height		= 720.0f;
+		float NearPlane		= 0.0001f;
 		float FarPlane		= 50.0f;
 	};
 

--- a/LambdaEngine/Include/Game/ECS/Physics/Transform.h
+++ b/LambdaEngine/Include/Game/ECS/Physics/Transform.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "Containers/IDVector.h"
+#include "ECS/ComponentHandler.h"
+#include "ECS/EntitySubscriber.h"
+#include "Math/Math.h"
+
+namespace LambdaEngine
+{
+	const glm::vec3 g_DefaultForward = glm::vec3(0.0f, 0.0f, 1.0f);
+	//The up vector is inverted because of vulkans inverted y-axis
+	const glm::vec3 g_DefaultUp = glm::vec3(0.0f, -1.0f, 0.0f);
+
+	struct Position
+	{
+		glm::vec3 Position;
+	};
+
+	struct Scale
+	{
+		glm::vec3 Scale;
+	};
+
+	struct Rotation
+	{
+		glm::quat Quaternion;
+	};
+
+	const std::type_index g_TIDPosition = TID(Position);
+	const std::type_index g_TIDScale    = TID(Scale);
+	const std::type_index g_TIDRotation = TID(Rotation);
+
+	// Transform is a convenience wrapper
+	struct Transform
+	{
+		glm::vec3& Position;
+		glm::vec3& Scale;
+		glm::quat& RotationQuaternion;
+	};
+
+	class TransformComponents : public IComponentGroup
+	{
+	public:
+		TArray<ComponentAccess> ToVector() const override final
+		{
+			return {m_Position, m_Scale, m_Rotation};
+		}
+
+	public:
+		ComponentAccess m_Position    = {R, g_TIDPosition};
+		ComponentAccess m_Scale       = {R, g_TIDScale};
+		ComponentAccess m_Rotation    = {R, g_TIDRotation};
+	};
+
+	struct WorldMatrix
+	{
+		glm::mat4 WorldMatrix;
+		// Flags whether or not the potential belonging Transform component has been written to since the last access
+		bool Dirty;
+	};
+
+	const std::type_index g_TIDWorldMatrix = TID(WorldMatrix);
+
+	class TransformHandler : public ComponentHandler
+	{
+	public:
+		TransformHandler();
+		~TransformHandler() = default;
+
+		virtual bool InitHandler() override;
+
+		void CreatePosition(Entity entity, const glm::vec3& position = {0.0f, 0.0f, 0.0f});
+		void CreateScale(Entity entity, const glm::vec3& scale = {1.0f, 1.0f, 1.0f});
+		void CreateRotation(Entity entity);
+
+		void CreateTransform(Entity entity, const glm::vec3& position = {0.0f, 0.0f, 0.0f}, const glm::vec3& scale = {1.0f, 1.0f, 1.0f});
+		// Requires that the entity has a transform component
+		void CreateWorldMatrix(Entity entity, const Transform& transform);
+
+	public:
+		// Required components: Position, Rotation and Scale
+		Transform GetTransform(Entity entity);
+		// Required components: Position, Rotation, Scale and World Matrix
+		WorldMatrix& GetWorldMatrix(Entity entity);
+		glm::vec3& GetPosition(Entity entity)   { return m_Positions.IndexID(entity).Position; }
+		glm::vec3& GetScale(Entity entity)      { return m_Scales.IndexID(entity).Scale; }
+		glm::quat& GetRotation(Entity entity)   { return m_Rotations.IndexID(entity).Quaternion; }
+
+	public:
+		// Transform calculation functions
+		static glm::vec3 GetUp(const glm::quat& rotationQuat)				{ return glm::normalize(glm::rotate(rotationQuat, g_DefaultUp)); }
+		static glm::vec3 GetForward(const glm::quat& rotationQuat)			{ return glm::normalize(glm::rotate(rotationQuat, g_DefaultForward)); }
+		static glm::quat GetRotationQuaternion(const glm::vec3& forward)	{ return glm::rotation(forward, g_DefaultForward); }
+
+		static float GetPitch(const glm::vec3& forward);
+		static float GetYaw(const glm::vec3& forward)		{ return glm::orientedAngle(g_DefaultForward, forward, g_DefaultUp); }
+		static float GetRoll(const glm::quat& rotationQuat)	{ return glm::orientedAngle(g_DefaultUp, GetUp(rotationQuat), GetForward(rotationQuat)); }
+
+		// Assumes the forward is normalized
+		static void SetForward(glm::quat& rotationQuat, const glm::vec3& forward) { rotationQuat = glm::rotation(GetForward(rotationQuat), forward); }
+
+		static void Roll(glm::quat& rotationQuat, float angle) { rotationQuat = glm::rotate(rotationQuat, angle, GetForward(rotationQuat)); };
+
+		// Rotate V around P using a given axis and angle
+		static void RotateAroundPoint(const glm::vec3& P, glm::vec3& V, const glm::vec3& axis, float angle);
+
+	private:
+		IDDVector<Position>     m_Positions;
+		IDDVector<Scale>        m_Scales;
+		IDDVector<Rotation>     m_Rotations;
+		IDDVector<WorldMatrix>  m_WorldMatrices;
+	};
+}

--- a/LambdaEngine/Include/Game/ECS/Rendering/Camera.h
+++ b/LambdaEngine/Include/Game/ECS/Rendering/Camera.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "Containers/IDVector.h"
+#include "ECS/ComponentHandler.h"
+#include "Math/Math.h"
+
+namespace LambdaEngine
+{
+	struct ViewProjectionMatrices
+	{
+		glm::mat4 Projection		= glm::mat4(1.0f);
+		glm::mat4 View				= glm::mat4(1.0f);
+		glm::mat4 PrevProjection	= glm::mat4(1.0f);
+		glm::mat4 PrevView			= glm::mat4(1.0f);
+	};
+
+	struct CameraProperties
+	{
+		glm::vec2 Jitter = glm::vec2(0.0f);
+	};
+
+	const std::type_index g_TIDViewProjectionMatrices = TID(ViewProjectionMatrices);
+	const std::type_index g_TIDCameraProperties = TID(ViewProjectionMatrices);
+
+	// Details how to create view and projection matrices
+	struct ViewProjectionDesc
+	{
+		glm::vec3 Position;
+		glm::vec3 Direction;
+		float FOVDegrees;
+		float Width;
+		float Height;
+		float NearPlane;
+		float FarPlane;
+	};
+
+	class LAMBDA_API CameraHandler : public ComponentHandler
+	{
+	public:
+		CameraHandler();
+		~CameraHandler() = default;
+
+		bool InitHandler() override final { return true; }
+
+		ViewProjectionMatrices& GetViewProjectionMatrices(Entity entity) { return m_VPMatrices.IndexID(entity); }
+
+		void CreateViewProjectionMatrices(Entity entity, const ViewProjectionDesc& matricesDesc);
+		void CreateCameraProperties(Entity entity, const glm::vec2& jitter);
+
+	private:
+		IDDVector<ViewProjectionMatrices> m_VPMatrices;
+		IDDVector<CameraProperties> m_CameraProperties;
+	};
+}

--- a/LambdaEngine/Include/Math/Math.h
+++ b/LambdaEngine/Include/Math/Math.h
@@ -9,10 +9,12 @@
 #define GLM_FORCE_SSE2
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/hash.hpp>
 #include <glm/gtx/norm.hpp>
+#include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/spline.hpp>
 #include <glm/gtx/string_cast.hpp>
-#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/vector_angle.hpp>
 
 #include "MathUtilities.h"

--- a/LambdaEngine/Source/ECS/ComponentHandler.cpp
+++ b/LambdaEngine/Source/ECS/ComponentHandler.cpp
@@ -4,14 +4,13 @@
 
 namespace LambdaEngine
 {
-    ComponentHandler::ComponentHandler(ECSCore* pECS, std::type_index tid_handler)
-        :m_pECS(pECS),
-        m_TID(tid_handler)
+    ComponentHandler::ComponentHandler(std::type_index tid_handler)
+        :m_TID(tid_handler)
     {}
 
     ComponentHandler::~ComponentHandler()
     {
-        m_pECS->GetEntityPublisher()->DeregisterComponentHandler(this);
+        ECSCore::GetInstance()->GetEntityPublisher()->DeregisterComponentHandler(this);
     }
 
     void ComponentHandler::RegisterHandler(const ComponentHandlerRegistration& handlerRegistration)
@@ -23,7 +22,7 @@ namespace LambdaEngine
             m_HandledTypes.PushBack(componentRegistration.TID);
         }
 
-        m_pECS->EnqueueComponentHandlerRegistration(handlerRegistration);
+        ECSCore::GetInstance()->EnqueueComponentHandlerRegistration(handlerRegistration);
     }
 
     const TArray<std::type_index>& ComponentHandler::GetHandledTypes() const
@@ -38,6 +37,6 @@ namespace LambdaEngine
 
     void ComponentHandler::RegisterComponent(Entity entity, std::type_index componentType)
     {
-        m_pECS->ComponentAdded(entity, componentType);
+        ECSCore::GetInstance()->ComponentAdded(entity, componentType);
     }
 }

--- a/LambdaEngine/Source/Game/ECS/Physics/Transform.cpp
+++ b/LambdaEngine/Source/Game/ECS/Physics/Transform.cpp
@@ -39,8 +39,6 @@ namespace LambdaEngine
 
     void TransformHandler::CreateRotation(Entity entity)
     {
-        Rotation rotation = {};
-
         m_Rotations.PushBack({ glm::identity<glm::quat>() }, entity);
         RegisterComponent(entity, g_TIDRotation);
     }

--- a/LambdaEngine/Source/Game/ECS/Physics/Transform.cpp
+++ b/LambdaEngine/Source/Game/ECS/Physics/Transform.cpp
@@ -1,0 +1,110 @@
+#include "Game/ECS/Physics/Transform.h"
+
+#include "Log/Log.h"
+
+#include <cmath>
+
+namespace LambdaEngine
+{
+    TransformHandler::TransformHandler()
+        :ComponentHandler(TID(TransformHandler))
+    {
+        ComponentHandlerRegistration handlerReg = {};
+        handlerReg.ComponentRegistrations = {
+            {g_TIDPosition,     &m_Positions},
+            {g_TIDScale,        &m_Scales},
+            {g_TIDRotation,     &m_Rotations},
+            {g_TIDWorldMatrix,  &m_WorldMatrices}
+        };
+
+        RegisterHandler(handlerReg);
+    }
+
+    bool TransformHandler::InitHandler()
+    {
+        return true;
+    }
+
+    void TransformHandler::CreatePosition(Entity entity, const glm::vec3& position)
+    {
+        m_Positions.PushBack({position}, entity);
+        RegisterComponent(entity, g_TIDPosition);
+    }
+
+    void TransformHandler::CreateScale(Entity entity, const glm::vec3& scale)
+    {
+        m_Scales.PushBack({scale}, entity);
+        RegisterComponent(entity, g_TIDScale);
+    }
+
+    void TransformHandler::CreateRotation(Entity entity)
+    {
+        Rotation rotation = {};
+
+        m_Rotations.PushBack({ glm::identity<glm::quat>() }, entity);
+        RegisterComponent(entity, g_TIDRotation);
+    }
+
+    void TransformHandler::CreateTransform(Entity entity, const glm::vec3& position, const glm::vec3& scale)
+    {
+        CreatePosition(entity, position);
+        CreateScale(entity, scale);
+        CreateRotation(entity);
+    }
+
+    void TransformHandler::CreateWorldMatrix(Entity entity, const Transform& transform)
+    {
+        WorldMatrix worldMatrix = {
+            .WorldMatrix =
+                glm::scale(glm::mat4(), glm::vec3(transform.Scale)) *
+                glm::toMat4(transform.RotationQuaternion) *
+                glm::translate(glm::mat4(), transform.Position),
+            .Dirty = false
+        };
+
+        m_WorldMatrices.PushBack(worldMatrix, entity);
+        RegisterComponent(entity, g_TIDWorldMatrix);
+    }
+
+    Transform TransformHandler::GetTransform(Entity entity)
+    {
+        return {
+            m_Positions.IndexID(entity).Position,
+            m_Scales.IndexID(entity).Scale,
+            m_Rotations.IndexID(entity).Quaternion
+        };
+    }
+
+    WorldMatrix& TransformHandler::GetWorldMatrix(Entity entity)
+    {
+        WorldMatrix& worldMatrix = m_WorldMatrices.IndexID(entity);
+
+        if (worldMatrix.Dirty)
+        {
+            const Transform transform = GetTransform(entity);
+
+            worldMatrix = {
+                .WorldMatrix =
+                    glm::scale(glm::mat4(), glm::vec3(transform.Scale)) *
+                    glm::toMat4(transform.RotationQuaternion) *
+                    glm::translate(glm::mat4(), transform.Position),
+                .Dirty = false
+            };
+        }
+
+        return worldMatrix;
+    }
+
+    float TransformHandler::GetPitch(const glm::vec3& forward)
+    {
+        glm::vec3 right = glm::normalize(glm::cross(forward, g_DefaultForward));
+        return glm::orientedAngle(g_DefaultForward, forward, right);
+    }
+
+    void TransformHandler::RotateAroundPoint(const glm::vec3& P, glm::vec3& V, const glm::vec3& axis, float angle)
+    {
+        V = V - P;
+        V = glm::rotate(glm::angleAxis(angle, axis), V);
+        V = V + P;
+    }
+}

--- a/LambdaEngine/Source/Game/ECS/Rendering/Camera.cpp
+++ b/LambdaEngine/Source/Game/ECS/Rendering/Camera.cpp
@@ -1,0 +1,36 @@
+#include "Game/ECS/Rendering/Camera.h"
+
+#include "Game/ECS/Physics/Transform.h"
+
+namespace LambdaEngine
+{
+	CameraHandler::CameraHandler()
+		:ComponentHandler(TID(CameraHandler))
+	{
+		ComponentHandlerRegistration handlerReg = {};
+		handlerReg.ComponentRegistrations = {
+			{g_TIDViewProjectionMatrices, &m_VPMatrices},
+			{g_TIDCameraProperties, &m_CameraProperties}
+		};
+
+		RegisterHandler(handlerReg);
+	}
+
+	void CameraHandler::CreateViewProjectionMatrices(Entity entity, const ViewProjectionDesc& matricesDesc)
+	{
+		ViewProjectionMatrices VPMatrices = {
+			.Projection = glm::perspective(glm::radians(matricesDesc.FOVDegrees), matricesDesc.Width / matricesDesc.Height, matricesDesc.NearPlane, matricesDesc.FarPlane),
+			.View = glm::lookAt(matricesDesc.Position, matricesDesc.Position + matricesDesc.Direction, g_DefaultUp),
+			.PrevProjection = VPMatrices.Projection,
+			.PrevView = VPMatrices.View
+		};
+
+		m_VPMatrices.PushBack(VPMatrices, entity);
+	}
+
+	void CameraHandler::CreateCameraProperties(Entity entity, const glm::vec2& jitter)
+	{
+		m_CameraProperties.PushBack({ jitter }, entity);
+		RegisterComponent(entity, g_TIDCameraProperties);
+	}
+}


### PR DESCRIPTION
The first step to integrate the camera into ECS.

Introduces components:
- `Position`, `Rotation` and `Scale` (all three together form the component group `Transform`)
- `ViewProjectionMatrices` and `CameraProperties`

To do:
- System for moving the camera
- Remove current camera implementation
- Create `CameraData` for rendering each frame