### PR TITLE
Stop storing ECSCore pointers

### DIFF
--- a/LambdaEngine/Include/ECS/EntitySubscriber.h
+++ b/LambdaEngine/Include/ECS/EntitySubscriber.h
@@ -27,7 +27,7 @@ namespace LambdaEngine
     class IComponentGroup
     {
     public:
-        virtual TArray<ComponentAccess> ToVector() const = 0;
+        virtual TArray<ComponentAccess> ToArray() const = 0;
     };
 
     // EntitySubscriptionRegistration contains all required information to request a single entity subscription
@@ -60,14 +60,13 @@ namespace LambdaEngine
     class EntitySubscriber
     {
     public:
-        EntitySubscriber(ECSCore* pECS);
+        EntitySubscriber() = default;
         ~EntitySubscriber();
 
         // subscribeToEntities enqueues entity subscriptions. initFn is called when all dependencies have been initialized.
         void SubscribeToEntities(const EntitySubscriberRegistration& subscriberRegistration, const std::function<bool()>& initFn);
 
     private:
-        ECSCore* m_pECS;
-        uint32 m_SubscriptionID;
+        uint32 m_SubscriptionID = UINT32_MAX;
     };
 }

--- a/LambdaEngine/Include/ECS/RegularWorker.h
+++ b/LambdaEngine/Include/ECS/RegularWorker.h
@@ -11,7 +11,7 @@ namespace LambdaEngine
     class RegularWorker
     {
     public:
-        RegularWorker(ECSCore* pECS);
+        RegularWorker() = default;
         ~RegularWorker();
 
         void ScheduleRegularWork(const Job& job, uint32 phase);
@@ -24,8 +24,7 @@ namespace LambdaEngine
         static void MapComponentAccesses(const TArray<ComponentAccess>& componentAccesses, THashTable<std::type_index, ComponentPermissions>& uniqueRegs);
 
     private:
-        ECSCore* m_pECS;
-        uint32 m_Phase;
-        uint32 m_JobID;
+        uint32 m_Phase = UINT32_MAX;
+        uint32 m_JobID = UINT32_MAX;
     };
 }

--- a/LambdaEngine/Include/ECS/System.h
+++ b/LambdaEngine/Include/ECS/System.h
@@ -7,7 +7,6 @@
 
 #include <functional>
 #include <typeindex>
-#include <vector>
 
 namespace LambdaEngine
 {
@@ -18,14 +17,13 @@ namespace LambdaEngine
     };
 
     class ComponentHandler;
-    class ECSCore;
 
     // A system processes components each frame in the tick function
     class System : private EntitySubscriber, private RegularWorker
     {
     public:
         // Registers the system in the system handler
-        System(ECSCore* pECS);
+        System() = default;
 
         // Deregisters system
         virtual ~System() = default;
@@ -43,7 +41,6 @@ namespace LambdaEngine
         ComponentHandler* GetComponentHandler(const std::type_index& handlerType);
 
     private:
-        ECSCore* m_pECS;
-        uint32 m_SystemID;
+        uint32 m_SystemID = UINT32_MAX;
     };
 }

--- a/LambdaEngine/Include/Game/ECS/Physics/Transform.h
+++ b/LambdaEngine/Include/Game/ECS/Physics/Transform.h
@@ -41,7 +41,7 @@ namespace LambdaEngine
 	class TransformComponents : public IComponentGroup
 	{
 	public:
-		TArray<ComponentAccess> ToVector() const override final
+		TArray<ComponentAccess> ToArray() const override final
 		{
 			return {m_Position, m_Scale, m_Rotation};
 		}

--- a/LambdaEngine/Source/ECS/EntitySubscriber.cpp
+++ b/LambdaEngine/Source/ECS/EntitySubscriber.cpp
@@ -12,7 +12,7 @@ namespace LambdaEngine
         // Add the component accesses in the component groups to the component accesses vector
         for (const IComponentGroup* pComponentGroup : componentGroups)
         {
-            const TArray<ComponentAccess> groupAccesses = pComponentGroup->ToVector();
+            const TArray<ComponentAccess> groupAccesses = pComponentGroup->ToArray();
             componentAccesses.Insert(componentAccesses.end(), groupAccesses.begin(), groupAccesses.end());
         }
 
@@ -27,18 +27,13 @@ namespace LambdaEngine
         :EntitySubscriptionRegistration({}, componentGroups, pSubscriber, onEntityAdded, onEntityRemoved)
     {}
 
-    EntitySubscriber::EntitySubscriber(ECSCore* pECS)
-        :m_pECS(pECS),
-        m_SubscriptionID(UINT32_MAX)
-    {}
-
     EntitySubscriber::~EntitySubscriber()
     {
-        m_pECS->GetEntityPublisher()->UnsubscribeFromComponents(m_SubscriptionID);
+        ECSCore::GetInstance()->GetEntityPublisher()->UnsubscribeFromComponents(m_SubscriptionID);
     }
 
     void EntitySubscriber::SubscribeToEntities(const EntitySubscriberRegistration& subscriberRegistration, const std::function<bool()>& initFn)
     {
-        m_pECS->EnqueueEntitySubscriptions(subscriberRegistration, initFn, &m_SubscriptionID);
+        ECSCore::GetInstance()->EnqueueEntitySubscriptions(subscriberRegistration, initFn, &m_SubscriptionID);
     }
 }

--- a/LambdaEngine/Source/ECS/RegularWorker.cpp
+++ b/LambdaEngine/Source/ECS/RegularWorker.cpp
@@ -5,21 +5,15 @@
 
 namespace LambdaEngine
 {
-    RegularWorker::RegularWorker(ECSCore* pECS)
-        :m_pECS(pECS),
-        m_Phase(UINT32_MAX),
-        m_JobID(UINT32_MAX)
-    {}
-
     RegularWorker::~RegularWorker()
     {
-        m_pECS->DescheduleRegularJob(m_Phase, m_JobID);
+        ECSCore::GetInstance()->DescheduleRegularJob(m_Phase, m_JobID);
     }
 
     void RegularWorker::ScheduleRegularWork(const Job& job, uint32 phase)
     {
         m_Phase = phase;
-        m_JobID = m_pECS->ScheduleRegularJob(job, phase);
+        m_JobID = ECSCore::GetInstance()->ScheduleRegularJob(job, phase);
     }
 
     TArray<ComponentAccess> RegularWorker::GetUniqueComponentAccesses(const EntitySubscriberRegistration& subscriberRegistration)

--- a/LambdaEngine/Source/ECS/System.cpp
+++ b/LambdaEngine/Source/ECS/System.cpp
@@ -5,18 +5,11 @@
 
 namespace LambdaEngine
 {
-    System::System(ECSCore* pECS)
-        :EntitySubscriber(pECS),
-        RegularWorker(pECS),
-        m_pECS(pECS),
-        m_SystemID(UINT32_MAX)
-    {}
-
     void System::EnqueueRegistration(const SystemRegistration& systemRegistration)
     {
         Job job = {
             .Function = [this] {
-                Tick(m_pECS->GetDeltaTime());
+                Tick(ECSCore::GetInstance()->GetDeltaTime());
             },
             .Components = GetUniqueComponentAccesses(systemRegistration.SubscriberRegistration)
         };
@@ -28,7 +21,7 @@ namespace LambdaEngine
                 return false;
             }
 
-            m_pECS->GetDeltaTime();
+            ECSCore::GetInstance()->GetDeltaTime();
 
             ScheduleRegularWork(job, phase);
             return true;
@@ -39,6 +32,6 @@ namespace LambdaEngine
 
     ComponentHandler* System::GetComponentHandler(const std::type_index& handlerType)
     {
-        return m_pECS->GetEntityPublisher()->GetComponentHandler(handlerType);
+        return ECSCore::GetInstance()->GetEntityPublisher()->GetComponentHandler(handlerType);
     }
 }


### PR DESCRIPTION
Since there is a static instance of `ECSCore`, there is no need to store pointers to it in classes.