### PR TITLE
Profiler - Peak and average device memory

### DIFF
--- a/LambdaEngine/Include/Debug/CPUProfiler.h
+++ b/LambdaEngine/Include/Debug/CPUProfiler.h
@@ -81,7 +81,9 @@ namespace LambdaEngine
 
 		void EndSession();
 
-		void Render(Timestamp delta);
+		void Tick(Timestamp delta);
+
+		void Render();
 
 
 		static bool g_RunProfilingSample;
@@ -94,5 +96,6 @@ namespace LambdaEngine
 		float64 m_TimeSinceUpdate = 0.0f;
 		CPUStatistics m_CPUStat = {};
 		float32 m_UpdateFrequency = 1.0f;
+		Timestamp m_Timestamp = 0;
 	};
 }

--- a/LambdaEngine/Include/Debug/GPUProfiler.h
+++ b/LambdaEngine/Include/Debug/GPUProfiler.h
@@ -46,7 +46,8 @@ namespace LambdaEngine
 		GPUProfiler operator=(GPUProfiler& other) = delete;
 
 		void Init(TimeUnit timeUnit);
-		void Render(LambdaEngine::Timestamp delta);
+		void Tick(LambdaEngine::Timestamp delta);
+		void Render();
 		void Release();
 
 		// Create timestamps per command list
@@ -66,6 +67,9 @@ namespace LambdaEngine
 		void EndGraphicsPipelineStat(CommandList* pCommandList);
 		void GetGraphicsPipelineStat();
 		void ResetGraphicsPipelineStat(CommandList* pCommandList);
+
+		uint64 GetAverageDeviceMemory();
+		uint64 GetPeakDeviceMemory();
 
 	public:
 		static GPUProfiler* Get();
@@ -97,9 +101,10 @@ namespace LambdaEngine
 		THashTable<CommandList*, bool> m_ShouldGetTimestamps;
 
 		// Memory usage
-		uint32 m_MaxVram = 0;
-		uint32 m_CurrentVram = 0;
 		TArray<GraphicsDeviceMemoryStatistics> m_MemoryStats;
+		uint64 m_AverageDeviceMemory = 0;
+		uint64 m_AverageCount = 0;
+		uint64 m_PeakDeviceMemory = 0;
 
 		// Pipeline statistics
 		QueryHeap* m_pPipelineStatHeap = nullptr;

--- a/LambdaEngine/Include/Debug/Profiler.h
+++ b/LambdaEngine/Include/Debug/Profiler.h
@@ -21,10 +21,12 @@ namespace LambdaEngine
 		static CPUProfiler* GetCPUProfiler();
 		static GPUProfiler* GetGPUProfiler();
 
-		static void Render(Timestamp delta);
+		static void Tick(Timestamp delta);
+		static void Render();
 
 	private:
 		static GPUProfiler* s_pGPUProfiler;
 		static CPUProfiler* s_pCPUProfiler;
+		static Timestamp s_Timestamp;
 	};
 }

--- a/LambdaEngine/Include/Rendering/Core/API/GraphicsDevice.h
+++ b/LambdaEngine/Include/Rendering/Core/API/GraphicsDevice.h
@@ -91,9 +91,10 @@ namespace LambdaEngine
 	*/
 	struct GraphicsDeviceMemoryStatistics
 	{
-		uint64 TotalBytesReserved = 0;
-		uint64 TotalBytesAllocated = 0;
-		std::string MemoryTypeName = "";
+		uint64 TotalBytesReserved	= 0;
+		uint64 TotalBytesAllocated	= 0;
+		std::string MemoryTypeName	= "";
+		EMemoryType MemoryType		= EMemoryType::MEMORY_TYPE_NONE;
 	};
 
 	/*

--- a/LambdaEngine/Source/Debug/CPUProfiler.cpp
+++ b/LambdaEngine/Source/Debug/CPUProfiler.cpp
@@ -129,17 +129,21 @@ namespace LambdaEngine
 		m_File.close();
 	}
 
-	void CPUProfiler::Render(Timestamp delta)
+	void CPUProfiler::Tick(Timestamp delta)
 	{
 		m_TimeSinceUpdate += delta.AsSeconds();
+		m_Timestamp = delta;
+	}
 
+	void CPUProfiler::Render()
+	{
 		if (m_TimeSinceUpdate > 1 / m_UpdateFrequency)
 		{
 			CommonApplication::Get()->GetPlatformApplication()->QueryCPUStatistics(&m_CPUStat);
 			m_TimeSinceUpdate = 0.f;
 		}
-		ImGui::BulletText("FPS: %f", 1.0f / delta.AsSeconds());
-		ImGui::BulletText("Frametime (ms): %f", delta.AsMilliSeconds());
+		ImGui::BulletText("FPS: %f", 1.0f / m_Timestamp.AsSeconds());
+		ImGui::BulletText("Frametime (ms): %f", m_Timestamp.AsMilliSeconds());
 		// Spacing
 		ImGui::Dummy(ImVec2(0.0f, 20.0f));
 

--- a/LambdaEngine/Source/Debug/GPUProfiler.cpp
+++ b/LambdaEngine/Source/Debug/GPUProfiler.cpp
@@ -6,6 +6,7 @@
 #include "Rendering/RenderAPI.h"
 #include "Rendering/Core/API/GraphicsDevice.h"
 #include "Rendering/Core/API/CommandQueue.h"
+#include "Rendering/Core/API/GraphicsTypes.h"
 
 #include <glm/glm.hpp>
 #include <imgui.h>
@@ -42,20 +43,44 @@ namespace LambdaEngine
 		m_MemoryStats.Resize(statCount);
 	}
 
-	void GPUProfiler::Render(LambdaEngine::Timestamp delta)
+	void GPUProfiler::Tick(LambdaEngine::Timestamp delta)
+	{
+		// Update timings
+		m_TimeSinceUpdate += delta.AsSeconds();
+
+		// Get memory statistics
+		if (m_TimeSinceUpdate > 1 / m_UpdateFreq)
+		{
+			uint32 statCount = m_MemoryStats.GetSize();
+			RenderAPI::GetDevice()->QueryDeviceMemoryStatistics(&statCount, m_MemoryStats);
+
+			// Update average and peak GPU memory
+			uint64 memoryUsage = 0;
+			for (auto& stats : m_MemoryStats)
+			{
+				if (stats.MemoryType == EMemoryType::MEMORY_TYPE_GPU)
+				{
+					memoryUsage += stats.TotalBytesAllocated;
+				}
+			}
+
+			if (memoryUsage > m_PeakDeviceMemory)
+				m_PeakDeviceMemory = memoryUsage;
+
+			// Calculate moving average
+			m_AverageDeviceMemory = (memoryUsage + m_AverageCount * m_AverageDeviceMemory) / (m_AverageCount + 1);
+			m_AverageCount++;
+		}
+	}
+
+	void GPUProfiler::Render()
 	{
 		if (ImGui::CollapsingHeader("GPU Statistics", ImGuiTreeNodeFlags_DefaultOpen))
 		{
 			ImGui::Indent(10.0f);
 			// Profiler (Which has the instance of GPUProfiler) begins the ImGui window
-			m_TimeSinceUpdate += delta.AsMilliSeconds();
 
 			// Memory display
-			if (m_TimeSinceUpdate > 1 / m_UpdateFreq)
-			{
-				uint32 statCount = m_MemoryStats.GetSize();
-				RenderAPI::GetDevice()->QueryDeviceMemoryStatistics(&statCount, m_MemoryStats);
-			}
 			static const char* items[] = { "B", "KB", "MB", "GB" };
 			static int itemSelected = 2;
 			static float byteDivider = 1;
@@ -74,12 +99,22 @@ namespace LambdaEngine
 				ImGui::ProgressBar(percentage, ImVec2(-1.0f, 0.0f), buf);
 			}
 
+			ImGui::Text("Average Device Memory Usage: %.3f", m_AverageDeviceMemory / byteDivider);
+			ImGui::Text("Peak Device Memory Usage: %.3f", m_PeakDeviceMemory / byteDivider);
+
+			if(ImGui::Button("Reset Memory Counts"))
+			{
+				m_PeakDeviceMemory		= 0;
+				m_AverageCount			= 0;
+				m_AverageDeviceMemory	= 0;
+			}
+
 #ifdef LAMBDA_DEBUG
 			// Timestamp display
-			if (m_TimestampCount != 0 && ImGui::CollapsingHeader("Timestamps") && m_TimeSinceUpdate > 1 / m_UpdateFreq)
+			if (m_TimestampCount != 0 && ImGui::CollapsingHeader("Timestamps"))
 			{
 				ImGui::Indent(10.0f);
-				ImGui::SliderFloat("Update frequency", &m_UpdateFreq, 1.0f, 144.0f);
+				ImGui::SliderFloat("Update frequency", &m_UpdateFreq, 0.10f, 60.0f);
 
 				// Enable/disable graph update
 				ImGui::Checkbox("Update graphs", &m_EnableGraph);
@@ -325,6 +360,16 @@ namespace LambdaEngine
 #ifdef LAMBDA_DEBUG
 		pCommandList->ResetQuery(m_pPipelineStatHeap, 0, 6);
 #endif
+	}
+
+	uint64 GPUProfiler::GetAverageDeviceMemory()
+	{
+		return m_AverageDeviceMemory;
+	}
+
+	uint64 GPUProfiler::GetPeakDeviceMemory()
+	{
+		return m_PeakDeviceMemory;
 	}
 
 	GPUProfiler* GPUProfiler::Get()

--- a/LambdaEngine/Source/Debug/Profiler.cpp
+++ b/LambdaEngine/Source/Debug/Profiler.cpp
@@ -7,9 +7,9 @@
 
 namespace LambdaEngine
 {
-	GPUProfiler* Profiler::s_pGPUProfiler = nullptr;
-	CPUProfiler* Profiler::s_pCPUProfiler = nullptr;
-
+	GPUProfiler* Profiler::s_pGPUProfiler 	= nullptr;
+	CPUProfiler* Profiler::s_pCPUProfiler 	= nullptr;
+	Timestamp Profiler::s_Timestamp			= 0;
 
 	Profiler::Profiler()
 	{
@@ -29,12 +29,18 @@ namespace LambdaEngine
 		return s_pGPUProfiler;
 	}
 
-	void Profiler::Render(Timestamp delta)
+	void Profiler::Tick(Timestamp delta)
+	{
+		s_Timestamp = delta;
+		GetGPUProfiler()->Tick(delta);
+	}
+
+	void Profiler::Render()
 	{
 		ImGui::Begin("Profiling data");
 
-		GetCPUProfiler()->Render(delta);
-		GetGPUProfiler()->Render(delta);
+		GetCPUProfiler()->Render(s_Timestamp);
+		GetGPUProfiler()->Render();
 
 		ImGui::End();
 	}

--- a/LambdaEngine/Source/Debug/Profiler.cpp
+++ b/LambdaEngine/Source/Debug/Profiler.cpp
@@ -32,6 +32,7 @@ namespace LambdaEngine
 	void Profiler::Tick(Timestamp delta)
 	{
 		s_Timestamp = delta;
+		GetCPUProfiler()->Tick(delta);
 		GetGPUProfiler()->Tick(delta);
 	}
 
@@ -39,7 +40,7 @@ namespace LambdaEngine
 	{
 		ImGui::Begin("Profiling data");
 
-		GetCPUProfiler()->Render(s_Timestamp);
+		GetCPUProfiler()->Render();
 		GetGPUProfiler()->Render();
 
 		ImGui::End();

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/GraphicsDeviceVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/GraphicsDeviceVK.cpp
@@ -457,11 +457,20 @@ namespace LambdaEngine
 						{
 							VkMemoryPropertyFlags propFlag = memProp2.memoryProperties.memoryTypes[typeIdx].propertyFlags;
 							if ((propFlag & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) && (propFlag & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) && (propFlag & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
-								pMemoryStat[i].MemoryTypeName = "Special Memory"; // Memory that is directly mappable on the GPU
+							{
+								pMemoryStat[i].MemoryType		= EMemoryType::MEMORY_TYPE_GPU;
+								pMemoryStat[i].MemoryTypeName 	= "Special Memory"; // Memory that is directly mappable on the GPU
+							}
 							else if ((propFlag & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) && (propFlag & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT))
-								pMemoryStat[i].MemoryTypeName = "Shared GPU Memory"; // Memory that is mappable on the CPU
+							{
+								pMemoryStat[i].MemoryType		= EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
+								pMemoryStat[i].MemoryTypeName 	= "Shared GPU Memory"; // Memory that is mappable on the CPU
+							}
 							else if (propFlag & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
-								pMemoryStat[i].MemoryTypeName = "Dedicated GPU Memory"; // Non-mappable memory on the GPU (VRAM)
+							{
+								pMemoryStat[i].MemoryType		= EMemoryType::MEMORY_TYPE_GPU;
+								pMemoryStat[i].MemoryTypeName 	= "Dedicated GPU Memory"; // Non-mappable memory on the GPU (VRAM)
+							}
 							else
 								pMemoryStat[i].MemoryTypeName = "Memory heap does not match known memory types";
 						}

--- a/Sandbox/Source/Sandbox.cpp
+++ b/Sandbox/Source/Sandbox.cpp
@@ -200,6 +200,7 @@ void Sandbox::Tick(LambdaEngine::Timestamp delta)
 	using namespace LambdaEngine;
 
 	m_pRenderGraphEditor->Update();
+	Profiler::Tick(delta);
 	Render(delta);
 }
 
@@ -227,7 +228,7 @@ void Sandbox::Render(LambdaEngine::Timestamp delta)
 
 			if (m_DebuggingWindow)
 			{
-				Profiler::Render(delta);
+				Profiler::Render();
 			}
 
 			if (m_ShowTextureDebuggingWindow)

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -3,3 +3,13 @@ Pos=60,60
 Size=400,400
 Collapsed=0
 
+[Window][Console]
+Pos=0,0
+Size=32,32
+Collapsed=0
+
+[Window][Profiling data]
+Pos=137,126
+Size=730,642
+Collapsed=0
+

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -5,11 +5,11 @@ Collapsed=0
 
 [Window][Console]
 Pos=0,0
-Size=32,32
+Size=1920,70
 Collapsed=0
 
 [Window][Profiling data]
-Pos=137,126
+Pos=158,121
 Size=730,642
 Collapsed=0
 


### PR DESCRIPTION
Additions:
* GPUProfiler now saves and calculates the average and peak memory on the GPU. This includes both the "normal" accessed DEVICE_MEMORY, but also the "special" memory that is mappable from the GPU.
* Getters for the peak and average device memory

Changes:
* Changed profilers to also have a Tick() function to update their timestamps instead of having it in the Render() functions which does not match the code standard.
* Moved update code for the data in profilers to Tick() instead of having it in Render()