### PR TITLE
Fixed small bugs in some containers

### DIFF
--- a/LambdaEngine/Include/Containers/TArray.h
+++ b/LambdaEngine/Include/Containers/TArray.h
@@ -20,10 +20,10 @@ namespace LambdaEngine
 		typedef uint32 SizeType;
 
 		/*
-		* IteratorBase
+		* TIterator
 		*/
 		template<typename TIteratorType>
-		class IteratorBase
+		class TIterator
 		{
 			friend class TArray;
 
@@ -34,9 +34,9 @@ namespace LambdaEngine
 			using pointer			= TIteratorType*;
 			using reference			= TIteratorType&;
 
-			~IteratorBase() = default;
+			~TIterator() = default;
 
-			FORCEINLINE IteratorBase(TIteratorType* ptr = nullptr)
+			FORCEINLINE TIterator(TIteratorType* ptr = nullptr)
 				: m_Ptr(ptr)
 			{
 			}
@@ -51,110 +51,115 @@ namespace LambdaEngine
 				return *m_Ptr;
 			}
 
-			FORCEINLINE IteratorBase operator++()
+			FORCEINLINE TIterator operator++()
 			{
 				m_Ptr++;
 				return *this;
 			}
 
-			FORCEINLINE IteratorBase operator++(int32)
+			FORCEINLINE TIterator operator++(int32)
 			{
-				IteratorBase Temp = *this;
+				TIterator Temp = *this;
 				m_Ptr++;
 				return Temp;
 			}
 
-			FORCEINLINE IteratorBase operator--()
+			FORCEINLINE TIterator operator--()
 			{
 				m_Ptr--;
 				return *this;
 			}
 
-			FORCEINLINE IteratorBase operator--(int32)
+			FORCEINLINE TIterator operator--(int32)
 			{
-				IteratorBase Temp = *this;
+				TIterator Temp = *this;
 				m_Ptr--;
 				return Temp;
 			}
 
-			FORCEINLINE IteratorBase operator+(int32 offset) const
+			FORCEINLINE TIterator operator+(int32 offset) const
 			{
-				IteratorBase Temp = *this;
+				TIterator Temp = *this;
 				return Temp += offset;
 			}
 
-			FORCEINLINE IteratorBase operator-(int32 offset) const
+			FORCEINLINE TIterator operator-(int32 offset) const
 			{
-				IteratorBase Temp = *this;
+				TIterator Temp = *this;
 				return Temp -= offset;
 			}
 
-			FORCEINLINE difference_type operator-(IteratorBase other) const
+			FORCEINLINE difference_type operator-(TIterator other) const
 			{
 				return static_cast<difference_type>(m_Ptr - other.m_Ptr);
 			}
 
-			FORCEINLINE IteratorBase& operator+=(int32 offset)
+			FORCEINLINE TIterator& operator+=(int32 offset)
 			{
 				m_Ptr += offset;
 				return *this;
 			}
 
-			FORCEINLINE IteratorBase& operator-=(int32 offset)
+			FORCEINLINE TIterator& operator-=(int32 offset)
 			{
 				m_Ptr -= offset;
 				return *this;
 			}
 
-			FORCEINLINE bool operator==(const IteratorBase& other) const
+			FORCEINLINE bool operator==(const TIterator& other) const
 			{
 				return (m_Ptr == other.m_Ptr);
 			}
 
-			FORCEINLINE bool operator!=(const IteratorBase& other) const
+			FORCEINLINE bool operator!=(const TIterator& other) const
 			{
 				return (m_Ptr != other.m_Ptr);
 			}
 
-			FORCEINLINE bool operator<(const IteratorBase& other) const
+			FORCEINLINE bool operator<(const TIterator& other) const
 			{
 				return m_Ptr < other.m_Ptr;
 			}
 
-			FORCEINLINE bool operator<=(const IteratorBase& other) const
+			FORCEINLINE bool operator<=(const TIterator& other) const
 			{
 				return m_Ptr <= other.m_Ptr;
 			}
 
-			FORCEINLINE bool operator>(const IteratorBase& other) const
+			FORCEINLINE bool operator>(const TIterator& other) const
 			{
 				return m_Ptr > other.m_Ptr;
 			}
 
-			FORCEINLINE bool operator>=(const IteratorBase& other) const
+			FORCEINLINE bool operator>=(const TIterator& other) const
 			{
 				return m_Ptr >= other.m_Ptr;
+			}
+
+			FORCEINLINE operator TIterator<const TIteratorType>() const
+			{
+				return TIterator<const TIteratorType>(m_Ptr);
 			}
 
 		protected:
 			TIteratorType* m_Ptr;
 		};
 
-		typedef IteratorBase<T>			Iterator;
-		typedef IteratorBase<const T>	ConstIterator;
+		typedef TIterator<T>		Iterator;
+		typedef TIterator<const T>	ConstIterator;
 
 		/*
 		* Reverse Iterator: Stores for example End(), but will reference End() - 1
 		*/
 		template<typename TIteratorType>
-		class ReverseIteratorBase
+		class TReverseIterator
 		{
 			friend class TArray;
 
 		public:
-			~ReverseIteratorBase() = default;
+			~TReverseIterator() = default;
 
-			FORCEINLINE ReverseIteratorBase(TIteratorType* ptr = nullptr)
+			FORCEINLINE TReverseIterator(TIteratorType* ptr = nullptr)
 				: m_Ptr(ptr)
 			{
 			}
@@ -169,72 +174,77 @@ namespace LambdaEngine
 				return *(m_Ptr - 1);
 			}
 
-			FORCEINLINE ReverseIteratorBase operator++()
+			FORCEINLINE TReverseIterator operator++()
 			{
 				m_Ptr--;
 				return *this;
 			}
 
-			FORCEINLINE ReverseIteratorBase operator++(int32)
+			FORCEINLINE TReverseIterator operator++(int32)
 			{
-				ReverseIteratorBase Temp = *this;
+				TReverseIterator Temp = *this;
 				m_Ptr--;
 				return Temp;
 			}
 
-			FORCEINLINE ReverseIteratorBase operator--()
+			FORCEINLINE TReverseIterator operator--()
 			{
 				m_Ptr++;
 				return *this;
 			}
 
-			FORCEINLINE ReverseIteratorBase operator--(int32)
+			FORCEINLINE TReverseIterator operator--(int32)
 			{
-				ReverseIteratorBase Temp = *this;
+				TReverseIterator Temp = *this;
 				m_Ptr++;
 				return Temp;
 			}
 
-			FORCEINLINE ReverseIteratorBase operator+(int32 offset) const
+			FORCEINLINE TReverseIterator operator+(int32 offset) const
 			{
-				ReverseIteratorBase Temp = *this;
+				TReverseIterator Temp = *this;
 				return Temp += offset;
 			}
 
-			FORCEINLINE ReverseIteratorBase operator-(int32 offset) const
+			FORCEINLINE TReverseIterator operator-(int32 offset) const
 			{
-				ReverseIteratorBase Temp = *this;
+				TReverseIterator Temp = *this;
 				return Temp -= offset;
 			}
 
-			FORCEINLINE ReverseIteratorBase& operator+=(int32 offset)
+			FORCEINLINE TReverseIterator& operator+=(int32 offset)
 			{
 				m_Ptr -= offset;
 				return *this;
 			}
 
-			FORCEINLINE ReverseIteratorBase& operator-=(int32 offset)
+			FORCEINLINE TReverseIterator& operator-=(int32 offset)
 			{
 				m_Ptr += offset;
 				return *this;
 			}
 
-			FORCEINLINE bool operator==(const ReverseIteratorBase& other) const
+			FORCEINLINE bool operator==(const TReverseIterator& other) const
 			{
 				return (m_Ptr == other.m_Ptr);
 			}
 
-			FORCEINLINE bool operator!=(const ReverseIteratorBase& other) const
+			FORCEINLINE bool operator!=(const TReverseIterator& other) const
 			{
 				return (m_Ptr != other.m_Ptr);
+			}
+
+			FORCEINLINE operator TReverseIterator<const TIteratorType>() const
+			{
+				return TReverseIterator<const TIteratorType>(m_Ptr);
 			}
 
 		protected:
 			TIteratorType* m_Ptr;
 		};
 
-		typedef ReverseIteratorBase<T>			ReverseIterator;
-		typedef ReverseIteratorBase<const T>	ReverseConstIterator;
+		typedef TReverseIterator<T>			ReverseIterator;
+		typedef TReverseIterator<const T>	ReverseConstIterator;
 
 		/*
 		* TArray API

--- a/LambdaEngine/Include/Containers/TSharedPtr.h
+++ b/LambdaEngine/Include/Containers/TSharedPtr.h
@@ -11,6 +11,12 @@ namespace LambdaEngine
 	public:
 		typedef uint32 RefType;
 
+		inline PtrControlBlock()
+			: m_WeakReferences(0)
+			, m_StrongReferences(0)
+		{
+		}
+
 		FORCEINLINE RefType AddWeakRef() noexcept
 		{
 			return m_WeakReferences++;

--- a/LambdaEngine/Include/Containers/TSharedPtr.h
+++ b/LambdaEngine/Include/Containers/TSharedPtr.h
@@ -47,13 +47,34 @@ namespace LambdaEngine
 	};
 
 	/*
-	* Base class for TWeak- and TSharedPtr
+	* Deleter functors
 	*/
 	template<typename T>
+	struct TDeleter
+	{
+		void operator()(T* pPtr)
+		{
+			delete pPtr;
+		}
+	};
+
+	template<typename T>
+	struct TDeleter<T[]>
+	{
+		void operator()(T* pPtr)
+		{
+			delete[] pPtr;
+		}
+	};
+
+	/*
+	* Base class for TWeak- and TSharedPtr
+	*/
+	template<typename T, typename TDeleter>
 	class TPtrBase
 	{
 	public:
-		template<typename TOther>
+		template<typename TOther, typename TOtherDeleter>
 		friend class TPtrBase;
 
 		FORCEINLINE T* Get() const noexcept
@@ -81,22 +102,6 @@ namespace LambdaEngine
 			return GetAddressOf();
 		}
 
-		FORCEINLINE T* operator->() const noexcept
-		{
-			return Get();
-		}
-
-		FORCEINLINE T& operator*() const noexcept
-		{
-			return (*m_pPtr);
-		}
-
-		FORCEINLINE T& operator[](uint32 Index) const noexcept
-		{
-			VALIDATE(m_pPtr != nullptr);
-			return m_pPtr[Index];
-		}
-
 		FORCEINLINE bool operator==(T* pPtr) const noexcept
 		{
 			return (m_pPtr == pPtr);
@@ -116,7 +121,9 @@ namespace LambdaEngine
 		FORCEINLINE TPtrBase() noexcept
 			: m_pPtr(nullptr)
 			, m_pCounter(nullptr)
+			, m_Deleter()
 		{
+			static_assert(std::is_invocable<TDeleter, T*>(), "TDeleter must be a callable");
 		}
 
 		FORCEINLINE void InternalAddStrongRef() noexcept
@@ -155,7 +162,7 @@ namespace LambdaEngine
 						delete m_pCounter;
 					}
 
-					delete m_pPtr;
+					m_Deleter(m_pPtr);
 				}
 			}
 
@@ -203,8 +210,8 @@ namespace LambdaEngine
 			other.m_pCounter = nullptr;
 		}
 
-		template<typename TOther>
-		FORCEINLINE void InternalMove(TPtrBase<TOther>&& other) noexcept
+		template<typename TOther, typename TOtherDeleter>
+		FORCEINLINE void InternalMove(TPtrBase<TOther, TOtherDeleter>&& other) noexcept
 		{
 			static_assert(std::is_convertible<TOther*, T*>());
 
@@ -239,8 +246,8 @@ namespace LambdaEngine
 			InternalAddStrongRef();
 		}
 
-		template<typename TOther>
-		FORCEINLINE void InternalConstructStrong(const TPtrBase<TOther>& other)
+		template<typename TOther, typename TOtherDeleter>
+		FORCEINLINE void InternalConstructStrong(const TPtrBase<TOther, TOtherDeleter>& other)
 		{
 			static_assert(std::is_convertible<TOther*, T*>());
 
@@ -273,8 +280,8 @@ namespace LambdaEngine
 			InternalAddWeakRef();
 		}
 
-		template<typename TOther>
-		FORCEINLINE void InternalConstructWeak(const TPtrBase<TOther>& other)
+		template<typename TOther, typename TOtherDeleter>
+		FORCEINLINE void InternalConstructWeak(const TPtrBase<TOther, TOtherDeleter>& other)
 		{
 			static_assert(std::is_convertible<TOther*, T*>());
 
@@ -304,6 +311,7 @@ namespace LambdaEngine
 	protected:
 		T* m_pPtr;
 		PtrControlBlock* m_pCounter;
+		TDeleter m_Deleter;
 	};
 
 	/*
@@ -313,12 +321,12 @@ namespace LambdaEngine
 	class TWeakPtr;
 
 	/*
-	* TSharedPtr - RefCounted Pointer similar to std::shared_ptr
+	* TSharedPtr - RefCounted Pointer for scalar pointers
 	*/
 	template<typename T>
-	class TSharedPtr : public TPtrBase<T>
+	class TSharedPtr : public TPtrBase<T, TDeleter<T>>
 	{
-		using TBase = TPtrBase<T>;
+		using TBase = TPtrBase<T, TDeleter<T>>;
 
 	public:
 		FORCEINLINE TSharedPtr() noexcept
@@ -399,6 +407,16 @@ namespace LambdaEngine
 		FORCEINLINE bool IsUnique() const noexcept
 		{
 			return (TBase::GetStrongReferences() == 1);
+		}
+
+		FORCEINLINE T* operator->() const noexcept
+		{
+			return Get();
+		}
+
+		FORCEINLINE T& operator*() const noexcept
+		{
+			return (*m_pPtr);
 		}
 
 		FORCEINLINE TSharedPtr& operator=(const TSharedPtr& other) noexcept
@@ -490,12 +508,195 @@ namespace LambdaEngine
 	};
 
 	/*
-	* TWeakPtr - Weak Pointer similar to std::weak_ptr
+	* TSharedPtr - RefCounted Pointer for array pointers
 	*/
 	template<typename T>
-	class TWeakPtr : public TPtrBase<T>
+	class TSharedPtr<T[]> : public TPtrBase<T, TDeleter<T[]>>
 	{
-		using TBase = TPtrBase<T>;
+		using TBase = TPtrBase<T, TDeleter<T[]>>;
+
+	public:
+		FORCEINLINE TSharedPtr() noexcept
+			: TBase()
+		{
+		}
+
+		FORCEINLINE TSharedPtr(std::nullptr_t) noexcept
+			: TBase()
+		{
+		}
+
+		FORCEINLINE explicit TSharedPtr(T* pPtr) noexcept
+			: TBase()
+		{
+			TBase::InternalConstructStrong(pPtr);
+		}
+
+		FORCEINLINE TSharedPtr(const TSharedPtr& other) noexcept
+			: TBase()
+		{
+			TBase::InternalConstructStrong(other);
+		}
+
+		FORCEINLINE TSharedPtr(TSharedPtr&& other) noexcept
+			: TBase()
+		{
+			TBase::InternalMove(Move(other));
+		}
+
+		template<typename TOther>
+		FORCEINLINE TSharedPtr(const TSharedPtr<TOther>& other) noexcept
+			: TBase()
+		{
+			static_assert(std::is_convertible<TOther*, T*>());
+			TBase::template InternalConstructStrong<TOther>(other);
+		}
+
+		template<typename TOther>
+		FORCEINLINE TSharedPtr(TSharedPtr<TOther>&& other) noexcept
+			: TBase()
+		{
+			static_assert(std::is_convertible<TOther*, T*>());
+			TBase::template InternalMove<TOther>(Move(other));
+		}
+
+		template<typename TOther>
+		FORCEINLINE explicit TSharedPtr(const TWeakPtr<TOther>& other) noexcept
+			: TBase()
+		{
+			static_assert(std::is_convertible<TOther*, T*>());
+			TBase::template InternalConstructStrong<TOther>(other);
+		}
+
+		template<typename TOther>
+		FORCEINLINE TSharedPtr(TUniquePtr<TOther>&& other) noexcept
+			: TBase()
+		{
+			static_assert(std::is_convertible<TOther*, T*>());
+			TBase::template InternalConstructStrong<TOther>(other.Release());
+		}
+
+		FORCEINLINE ~TSharedPtr()
+		{
+			Reset();
+		}
+
+		FORCEINLINE void Reset() noexcept
+		{
+			TBase::InternalDestructStrong();
+		}
+
+		FORCEINLINE void Swap(TSharedPtr& other) noexcept
+		{
+			TBase::InternalSwap(other);
+		}
+
+		FORCEINLINE bool IsUnique() const noexcept
+		{
+			return (TBase::GetStrongReferences() == 1);
+		}
+
+		FORCEINLINE T& operator[](uint32 Index) const noexcept
+		{
+			VALIDATE(m_pPtr != nullptr);
+			return m_pPtr[Index];
+		}
+
+		FORCEINLINE TSharedPtr& operator=(const TSharedPtr& other) noexcept
+		{
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::InternalConstructStrong(other);
+			}
+
+			return *this;
+		}
+
+		FORCEINLINE TSharedPtr& operator=(TSharedPtr&& other) noexcept
+		{
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::InternalMove(Move(other));
+			}
+
+			return *this;
+		}
+
+		template<typename TOther>
+		FORCEINLINE TSharedPtr& operator=(const TSharedPtr<TOther>& other) noexcept
+		{
+			static_assert(std::is_convertible<TOther*, T*>());
+
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::template InternalConstructStrong<TOther>(other);
+			}
+
+			return *this;
+		}
+
+		template<typename TOther>
+		FORCEINLINE TSharedPtr& operator=(TSharedPtr<TOther>&& other) noexcept
+		{
+			static_assert(std::is_convertible<TOther*, T*>());
+
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::template InternalMove<TOther>(Move(other));
+			}
+
+			return *this;
+		}
+
+		FORCEINLINE TSharedPtr& operator=(T* pPtr) noexcept
+		{
+			if (this->m_pPtr != pPtr)
+			{
+				Reset();
+				TBase::InternalConstructStrong(pPtr);
+			}
+
+			return *this;
+		}
+
+		FORCEINLINE TSharedPtr& operator=(std::nullptr_t) noexcept
+		{
+			Reset();
+			return *this;
+		}
+
+		FORCEINLINE bool operator==(const TSharedPtr& other) const noexcept
+		{
+			return (TBase::m_pPtr == other.m_pPtr);
+		}
+
+		FORCEINLINE bool operator!=(const TSharedPtr& other) const noexcept
+		{
+			return (TBase::m_pPtr != other.m_pPtr);
+		}
+
+		FORCEINLINE bool operator==(TSharedPtr&& other) const noexcept
+		{
+			return (TBase::m_pPtr == other.m_pPtr);
+		}
+
+		FORCEINLINE bool operator!=(TSharedPtr&& other) const noexcept
+		{
+			return (TBase::m_pPtr != other.m_pPtr);
+		}
+	};
+
+	/*
+	* TWeakPtr - Weak Pointer similar for scalar types
+	*/
+	template<typename T>
+	class TWeakPtr : public TPtrBase<T, TDeleter<T>>
+	{
+		using TBase = TPtrBase<T, TDeleter<T>>;
 
 	public:
 		FORCEINLINE TWeakPtr() noexcept
@@ -569,6 +770,192 @@ namespace LambdaEngine
 		{
 			const TWeakPtr& This = *this;
 			return Move(TSharedPtr<T>(This));
+		}
+
+		FORCEINLINE T* operator->() const noexcept
+		{
+			return Get();
+		}
+
+		FORCEINLINE T& operator*() const noexcept
+		{
+			return (*m_pPtr);
+		}
+
+		FORCEINLINE TWeakPtr& operator=(const TWeakPtr& other) noexcept
+		{
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::InternalConstructWeak(other);
+			}
+
+			return *this;
+		}
+
+		FORCEINLINE TWeakPtr& operator=(TWeakPtr&& other) noexcept
+		{
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::InternalMove(Move(other));
+			}
+
+			return *this;
+		}
+
+		template<typename TOther>
+		FORCEINLINE TWeakPtr& operator=(const TWeakPtr<TOther>& other) noexcept
+		{
+			static_assert(std::is_convertible<TOther, T>(), "TWeakPtr: Trying to convert non-convertable types");
+
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::template InternalConstructWeak<TOther>(other);
+			}
+
+			return *this;
+		}
+
+		template<typename TOther>
+		FORCEINLINE TWeakPtr& operator=(TWeakPtr<TOther>&& other) noexcept
+		{
+			static_assert(std::is_convertible<TOther, T>(), "TWeakPtr: Trying to convert non-convertable types");
+
+			if (this != std::addressof(other))
+			{
+				Reset();
+				TBase::InternalMove(Move(other));
+			}
+
+			return *this;
+		}
+
+		FORCEINLINE TWeakPtr& operator=(T* pPtr) noexcept
+		{
+			if (TBase::m_pPtr != pPtr)
+			{
+				Reset();
+				TBase::InternalConstructWeak(pPtr);
+			}
+
+			return *this;
+		}
+
+		FORCEINLINE TWeakPtr& operator=(std::nullptr_t) noexcept
+		{
+			Reset();
+			return *this;
+		}
+
+		FORCEINLINE bool operator==(const TWeakPtr& other) const noexcept
+		{
+			return (TBase::m_pPtr == other.m_pPtr);
+		}
+
+		FORCEINLINE bool operator!=(const TWeakPtr& other) const noexcept
+		{
+			return (TBase::m_pPtr != other.m_pPtr);
+		}
+
+		FORCEINLINE bool operator==(TWeakPtr&& other) const noexcept
+		{
+			return (TBase::m_pPtr == other.m_pPtr);
+		}
+
+		FORCEINLINE bool operator!=(TWeakPtr&& other) const noexcept
+		{
+			return (TBase::m_pPtr != other.m_pPtr);
+		}
+	};
+
+	/*
+	* TWeakPtr - Weak Pointer for array types
+	*/
+	template<typename T>
+	class TWeakPtr<T[]> : public TPtrBase<T, TDeleter<T[]>>
+	{
+		using TBase = TPtrBase<T, TDeleter<T[]>>;
+
+	public:
+		FORCEINLINE TWeakPtr() noexcept
+			: TBase()
+		{
+		}
+
+		FORCEINLINE TWeakPtr(const TSharedPtr<T>& pPtr) noexcept
+			: TBase()
+		{
+			TBase::InternalConstructWeak(pPtr);
+		}
+
+		template<typename TOther>
+		FORCEINLINE TWeakPtr(const TSharedPtr<TOther>& pPtr) noexcept
+			: TBase()
+		{
+			static_assert(std::is_convertible<TOther, T>(), "TWeakPtr: Trying to convert non-convertable types");
+			TBase::template InternalConstructWeak<TOther>(pPtr);
+		}
+
+		FORCEINLINE TWeakPtr(const TWeakPtr& other) noexcept
+			: TBase()
+		{
+			TBase::InternalConstructWeak(other);
+		}
+
+		FORCEINLINE TWeakPtr(TWeakPtr&& other) noexcept
+			: TBase()
+		{
+			TBase::InternalMove(Move(other));
+		}
+
+		template<typename TOther>
+		FORCEINLINE TWeakPtr(const TWeakPtr<TOther>& other) noexcept
+			: TBase()
+		{
+			static_assert(std::is_convertible<TOther, T>(), "TWeakPtr: Trying to convert non-convertable types");
+			TBase::template InternalConstructWeak<TOther>(other);
+		}
+
+		template<typename TOther>
+		FORCEINLINE TWeakPtr(TWeakPtr<TOther>&& other) noexcept
+			: TBase()
+		{
+			static_assert(std::is_convertible<TOther, T>(), "TWeakPtr: Trying to convert non-convertable types");
+			TBase::template InternalMove<TOther>(Move(other));
+		}
+
+		FORCEINLINE ~TWeakPtr()
+		{
+			Reset();
+		}
+
+		FORCEINLINE void Reset() noexcept
+		{
+			TBase::InternalDestructWeak();
+		}
+
+		FORCEINLINE void Swap(TWeakPtr& other) noexcept
+		{
+			TBase::InternalSwap(other);
+		}
+
+		FORCEINLINE bool IsExpired() const noexcept
+		{
+			return (TBase::GetStrongReferences() < 1);
+		}
+
+		FORCEINLINE TSharedPtr<T[]> MakeShared() noexcept
+		{
+			const TWeakPtr& This = *this;
+			return Move(TSharedPtr<T[]>(This));
+		}
+
+		FORCEINLINE T& operator[](uint32 Index) const noexcept
+		{
+			VALIDATE(m_pPtr != nullptr);
+			return m_pPtr[Index];
 		}
 
 		FORCEINLINE TWeakPtr& operator=(const TWeakPtr& other) noexcept
@@ -663,9 +1050,21 @@ namespace LambdaEngine
 	* Creates a new object together with a SharedPtr
 	*/
 	template<typename T, typename... TArgs>
-	TSharedPtr<T> MakeShared(TArgs&&... args) noexcept
+	std::enable_if_t<std::is_pointer_v<T>, TSharedPtr<T>> MakeShared(TArgs&&... args) noexcept
 	{
 		T* pRefCountedPtr = DBG_NEW T(Forward<TArgs>(args)...);
+		return Move(TSharedPtr<T>(pRefCountedPtr));
+	}
+
+	/*
+	* Creates a new object together with a SharedPtr
+	*/
+	template<typename T>
+	std::enable_if_t<std::is_unbounded_array_v<T>, TSharedPtr<T>> MakeShared(uint32 size) noexcept
+	{
+		using TType = TRemoveExtent<T>;
+
+		TType* pRefCountedPtr = DBG_NEW TType[size];
 		return Move(TSharedPtr<T>(pRefCountedPtr));
 	}
 }

--- a/LambdaEngine/Include/Containers/TUniquePtr.h
+++ b/LambdaEngine/Include/Containers/TUniquePtr.h
@@ -4,7 +4,7 @@
 namespace LambdaEngine
 {
 	/*
-	* TUniquePtr - SmartPointer similar to std::unique_ptr
+	* TUniquePtr - SmartPointer for scalar types
 	*/
 	template<typename T>
 	class TUniquePtr
@@ -164,7 +164,7 @@ namespace LambdaEngine
 	};
 
 	/*
-	* TUniquePtr - Array specialization
+	* TUniquePtr - SmartPointer for array types
 	*/
 	template<typename T>
 	class TUniquePtr<T[]>
@@ -323,9 +323,21 @@ namespace LambdaEngine
 	* Creates a new object together with a UniquePtr
 	*/
 	template<typename T, typename... TArgs>
-	TUniquePtr<T> MakeUnique(TArgs&&... args) noexcept
+	std::enable_if_t<std::is_pointer_v<T>, TUniquePtr<T>> MakeUnique(TArgs&&... args) noexcept
 	{
-		T* UniquePtr = DBG_NEW T(Forward<TArgs>(args)...);
-		return Move(TUniquePtr<T>(UniquePtr));
+		T* pUniquePtr = DBG_NEW T(Forward<TArgs>(args)...);
+		return Move(TUniquePtr<T>(pUniquePtr));
+	}
+
+	/*
+	* Creates a new object together with a SharedPtr
+	*/
+	template<typename T>
+	std::enable_if_t<std::is_unbounded_array_v<T>, TUniquePtr<T>> MakeUnique(uint32 size) noexcept
+	{
+		using TType = TRemoveExtent<T>;
+
+		TType* pUniquePtr = DBG_NEW TType[size];
+		return Move(TUniquePtr<T>(pUniquePtr));
 	}
 }

--- a/LambdaEngine/Include/Containers/TUniquePtr.h
+++ b/LambdaEngine/Include/Containers/TUniquePtr.h
@@ -323,7 +323,7 @@ namespace LambdaEngine
 	* Creates a new object together with a UniquePtr
 	*/
 	template<typename T, typename... TArgs>
-	std::enable_if_t<std::is_pointer_v<T>, TUniquePtr<T>> MakeUnique(TArgs&&... args) noexcept
+	std::enable_if_t<!std::is_array_v<T>, TUniquePtr<T>> MakeUnique(TArgs&&... args) noexcept
 	{
 		T* pUniquePtr = DBG_NEW T(Forward<TArgs>(args)...);
 		return Move(TUniquePtr<T>(pUniquePtr));
@@ -333,7 +333,7 @@ namespace LambdaEngine
 	* Creates a new object together with a SharedPtr
 	*/
 	template<typename T>
-	std::enable_if_t<std::is_unbounded_array_v<T>, TUniquePtr<T>> MakeUnique(uint32 size) noexcept
+	std::enable_if_t<std::is_array_v<T>, TUniquePtr<T>> MakeUnique(uint32 size) noexcept
 	{
 		using TType = TRemoveExtent<T>;
 

--- a/LambdaEngine/Include/Containers/TUtilities.h
+++ b/LambdaEngine/Include/Containers/TUtilities.h
@@ -65,6 +65,28 @@ namespace LambdaEngine
 	template<typename T>
 	using TRemovePointer = typename _TRemovePointer<T>::TType;
 
+	// Removes array type
+	template<typename T>
+	struct _TRemoveExtent
+	{
+		using TType = T;
+	};
+
+	template<typename T>
+	struct _TRemoveExtent<T[]>
+	{
+		using TType = T;
+	};
+
+	template<typename T, size_t SIZE>
+	struct _TRemoveExtent<T[SIZE]>
+	{
+		using TType = T;
+	};
+
+	template<typename T>
+	using TRemoveExtent = typename _TRemoveExtent<T>::TType;
+
 	// Move an object by converting it into a rvalue
 	template<typename T>
 	constexpr TRemoveReference<T>&& Move(T&& Object) noexcept

--- a/Sandbox/Source/Sandbox.cpp
+++ b/Sandbox/Source/Sandbox.cpp
@@ -50,6 +50,8 @@
 #include <argh/argh.h>
 #include <imgui.h>
 
+#include "Containers/TSharedPtr.h"
+
 constexpr const float DEFAULT_DIR_LIGHT_R			= 1.0f;
 constexpr const float DEFAULT_DIR_LIGHT_G			= 1.0f;
 constexpr const float DEFAULT_DIR_LIGHT_B			= 1.0f;
@@ -71,6 +73,9 @@ Sandbox::Sandbox()
 	: Game()
 {
 	using namespace LambdaEngine;
+
+	TSharedPtr<int32[]> ptr0 = MakeShared<int32[]>(50);
+	TUniquePtr<int32[]> ptr1 = MakeUnique<int32[]>(50);
 
 	m_RenderGraphWindow = EngineConfig::GetBoolProperty("ShowRenderGraph");
 	m_ShowDemoWindow = EngineConfig::GetBoolProperty("ShowDemo");

--- a/Sandbox/Source/Sandbox.cpp
+++ b/Sandbox/Source/Sandbox.cpp
@@ -74,9 +74,6 @@ Sandbox::Sandbox()
 {
 	using namespace LambdaEngine;
 
-	TSharedPtr<int32[]> ptr0 = MakeShared<int32[]>(50);
-	TUniquePtr<int32[]> ptr1 = MakeUnique<int32[]>(50);
-
 	m_RenderGraphWindow = EngineConfig::GetBoolProperty("ShowRenderGraph");
 	m_ShowDemoWindow = EngineConfig::GetBoolProperty("ShowDemo");
 	m_DebuggingWindow = EngineConfig::GetBoolProperty("Debugging");


### PR DESCRIPTION
Fixed a couple of bugs in the custom containers, these include
* Added array type specialization of TSharedPtr and TWeakPtr
* Added MakeShared for array types

Also:
* TArray::TIterator and TArray::TReverseIterator is now convertable to TArray::ConstIterator and TArray::ConstReverseIterator
* Changed name from IteratorBase to TIterator
* Changed name from ReverseIteratorBase to TReverseIterator 