### PR TITLE
Quick fix

### DIFF
--- a/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
@@ -518,7 +518,7 @@ namespace LambdaEngine
 	void CommandListVK::PipelineBufferBarriers(FPipelineStageFlags srcStage, FPipelineStageFlags dstStage, const PipelineBufferBarrierDesc* pBufferBarriers, uint32 bufferBarrierCount)
 	{
 		VALIDATE(pBufferBarriers		!= nullptr);
-		VALIDATE(bufferBarrierCount	< MAX_BUFFER_BARRIERS);
+		VALIDATE(bufferBarrierCount	<= MAX_BUFFER_BARRIERS);
 
 		BufferVK* pVkBuffer = nullptr;
 		for (uint32 i = 0; i < bufferBarrierCount; i++)


### PR DESCRIPTION
The RenderGraph will now use the initialBarriers array instead of doing nothing.