### PR TITLE
Thread safe entity and component creations and removals

### DIFF
--- a/LambdaEngine/Include/ECS/ECSCore.h
+++ b/LambdaEngine/Include/ECS/ECSCore.h
@@ -33,19 +33,27 @@ namespace LambdaEngine
 		template<typename Comp>
 		Comp& AddComponent(Entity entity, const Comp& component);
 
-		// Fetch a reference to a component within a specific entity.
+		// Fetch a reference to a component for a specific entity.
 		template<typename Comp>
 		Comp& GetComponent(Entity entity);
 
-		// Fetch the whole array with the specific component type.
+		// Fetch a const reference to a component for a specific entity.
+		template<typename Comp>
+		const Comp& GetComponent(Entity entity) const;
+
+		// Fetch a pointer to an array containing all components of a specific type.
 		template<typename Comp>
 		ComponentArray<Comp>* GetComponentArray();
 
-		// Remove a component from a specific entity.
+		// Fetch a const pointer to an array containing all components of a specific type.
+		template<typename Comp>
+		const ComponentArray<Comp>* GetComponentArray() const;
+
+		// RemoveComponent enqueues the removal of a component, which is performed at the end of the current/next frame.
 		template<typename Comp>
 		void RemoveComponent(Entity entity);
 
-		// Remove a specific entity.
+		// RemoveEntity enqueues the removal of an entity, which is performed at the end of the current/next frame.
 		void RemoveEntity(Entity entity);
 
 		void ScheduleJobASAP(const Job& job);
@@ -88,6 +96,8 @@ namespace LambdaEngine
 
 		Timestamp m_DeltaTime;
 
+		SpinLock m_LockAddComponent, m_LockRemoveComponent, m_LockRemoveEntity;
+
 	private:
 		static ECSCore* s_pInstance;
 	};
@@ -95,19 +105,26 @@ namespace LambdaEngine
 	template<typename Comp>
 	inline Comp& ECSCore::AddComponent(Entity entity, const Comp& component)
 	{
+		std::scoped_lock<SpinLock> lock(m_LockAddComponent);
 		if (!m_ComponentStorage.HasType<Comp>())
 			m_ComponentStorage.RegisterComponentType<Comp>();
 
 		/*	Create component immediately, but hold off on registering and publishing it until the end of the frame.
 			This is to prevent concurrency issues. Publishing a component means pushing entity IDs to IDVectors,
 			and there is no guarentee that no one is simultaneously reading from these IDVectors. */
-		Comp& comp = m_ComponentStorage.AddComponent<Comp>(entity, component);
 		m_ComponentsToRegister.PushBack({entity, Comp::s_TID});
-		return comp;
+
+		return m_ComponentStorage.AddComponent<Comp>(entity, component);
 	}
 
 	template<typename Comp>
 	inline Comp& ECSCore::GetComponent(Entity entity)
+	{
+		return m_ComponentStorage.GetComponent<Comp>(entity);
+	}
+
+	template<typename Comp>
+	inline const Comp& ECSCore::GetComponent(Entity entity) const
 	{
 		return m_ComponentStorage.GetComponent<Comp>(entity);
 	}
@@ -119,8 +136,15 @@ namespace LambdaEngine
 	}
 
 	template<typename Comp>
+	inline const ComponentArray<Comp>* ECSCore::GetComponentArray() const
+	{
+		return m_ComponentStorage.GetComponentArray<Comp>();
+	}
+
+	template<typename Comp>
 	inline void ECSCore::RemoveComponent(Entity entity)
 	{
+		std::scoped_lock<SpinLock> lock(m_LockRemoveComponent);
 		m_ComponentsToDelete.PushBack({entity, Comp::s_TID});
 	}
 }

--- a/LambdaEngine/Include/ECS/JobScheduler.h
+++ b/LambdaEngine/Include/ECS/JobScheduler.h
@@ -10,8 +10,6 @@
 #include <mutex>
 #include <unordered_set>
 
-#define CURRENT_PHASE UINT32_MAX
-
 namespace LambdaEngine
 {
     class JobScheduler
@@ -22,12 +20,13 @@ namespace LambdaEngine
 
         void Tick();
 
-        void ScheduleJob(const Job& job, uint32_t phase = CURRENT_PHASE);
-        void ScheduleJobs(const TArray<Job>& jobs, uint32_t phase = CURRENT_PHASE);
+        void ScheduleJob(const Job& job, uint32_t phase);
+        void ScheduleJobASAP(const Job& job);
+        void ScheduleJobs(const TArray<Job>& jobs, uint32_t phase);
 
         /*  scheduleRegularJob schedules a job that is performed each frame, until it is explicitly deregistered using the job ID.
             Returns the job ID. */
-        uint32 ScheduleRegularJob(const Job& job, uint32_t phase = CURRENT_PHASE);
+        uint32 ScheduleRegularJob(const Job& job, uint32_t phase);
         void DescheduleRegularJob(uint32 phase, uint32 jobID);
 
         // Schedules an advance to the next phase

--- a/LambdaEngine/Source/ECS/ECSCore.cpp
+++ b/LambdaEngine/Source/ECS/ECSCore.cpp
@@ -24,12 +24,13 @@ namespace LambdaEngine
 
 	void ECSCore::RemoveEntity(Entity entity)
 	{
+		std::scoped_lock<SpinLock> lock(m_LockRemoveEntity);
 		m_EntitiesToDelete.PushBack(entity);
 	}
 
 	void ECSCore::ScheduleJobASAP(const Job& job)
 	{
-		m_JobScheduler.ScheduleJob(job, CURRENT_PHASE);
+		m_JobScheduler.ScheduleJobASAP(job);
 	}
 
 	void ECSCore::ScheduleJobPostFrame(const Job& job)

--- a/LambdaEngine/Source/ECS/JobScheduler.cpp
+++ b/LambdaEngine/Source/ECS/JobScheduler.cpp
@@ -51,7 +51,8 @@ namespace LambdaEngine
                 {
                     SetPhase(m_CurrentPhase + 1u);
                 }
-            } else
+            }
+            else
             {
                 m_ScheduleTimeoutCvar.wait(uLock);
             }
@@ -60,19 +61,26 @@ namespace LambdaEngine
 
     void JobScheduler::ScheduleJob(const Job& job, uint32_t phase)
     {
-        m_Lock.lock();
-        phase = phase == CURRENT_PHASE ? m_CurrentPhase : phase;
+        std::scoped_lock<std::mutex> lock(m_Lock);
         m_Jobs[phase].EmplaceBack(job);
         m_JobIndices[phase].PushBack(m_Jobs[phase].GetSize() - 1u);
 
         m_ScheduleTimeoutCvar.notify_all();
-        m_Lock.unlock();
+    }
+
+    void JobScheduler::ScheduleJobASAP(const Job& job)
+    {
+        std::scoped_lock<std::mutex> lock(m_Lock);
+        uint32 phase = m_CurrentPhase >= m_Jobs.size() ? 0u : m_CurrentPhase;
+        m_Jobs[phase].EmplaceBack(job);
+        m_JobIndices[phase].PushBack(m_Jobs[phase].GetSize() - 1u);
+
+        m_ScheduleTimeoutCvar.notify_all();
     }
 
     void JobScheduler::ScheduleJobs(const TArray<Job>& jobs, uint32_t phase)
     {
-        m_Lock.lock();
-        phase = phase == CURRENT_PHASE ? m_CurrentPhase : phase;
+        std::scoped_lock<std::mutex> lock(m_Lock);
 
         // Push jobs
         uint32 oldJobsCount = m_Jobs[phase].GetSize();
@@ -86,27 +94,22 @@ namespace LambdaEngine
         std::iota(&jobIndices[oldIndicesCount - 1u], &jobIndices.GetBack(), oldJobsCount);
 
         m_ScheduleTimeoutCvar.notify_all();
-
-        m_Lock.unlock();
     }
 
     uint32 JobScheduler::ScheduleRegularJob(const Job& job, uint32_t phase)
     {
-        m_Lock.lock();
+        std::scoped_lock<std::mutex> lock(m_Lock);
 
         uint32 jobID = m_RegularJobIDGenerator.GenID();
         m_RegularJobs[phase].PushBack(job, jobID);
-
-        m_Lock.unlock();
 
         return jobID;
     }
 
     void JobScheduler::DescheduleRegularJob(uint32 phase, uint32 jobID)
     {
-        m_Lock.lock();
+        std::scoped_lock<std::mutex> lock(m_Lock);
         m_RegularJobs[phase].Pop(jobID);
-        m_Lock.unlock();
     }
 
     const Job* JobScheduler::FindExecutableJob()


### PR DESCRIPTION
Also:
- Fixed a crash where calling `ECSCore::ScheduleJobASAP` would lead to an out-of-range exception in `JobScheduler`
- Added `const` versions of `ECSCore::GetComponent` and `ECSCore::GetComponentArray`