### PR TITLE
Unpublish component before deleting it

### DIFF
--- a/LambdaEngine/Include/ECS/EntityPublisher.h
+++ b/LambdaEngine/Include/ECS/EntityPublisher.h
@@ -25,7 +25,7 @@ namespace LambdaEngine
         // Optional: Called after an entity was added due to the subscription
         std::function<void(Entity)> OnEntityAdded;
         // Optional: Called before an entity was removed
-        std::function<void(Entity)> OnEntityRemoved;
+        std::function<void(Entity)> OnEntityRemoval;
     };
 
     // Indices for subscription storage

--- a/LambdaEngine/Include/ECS/EntitySubscriber.h
+++ b/LambdaEngine/Include/ECS/EntitySubscriber.h
@@ -13,17 +13,17 @@ namespace LambdaEngine
 	class EntitySubscriptionRegistration
 	{
 	public:
-		EntitySubscriptionRegistration(TArray<ComponentAccess> componentAccesses, const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded = nullptr, std::function<void(Entity)>onEntityRemoved = nullptr);
-		EntitySubscriptionRegistration(const TArray<ComponentAccess>& componentAccesses, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded = nullptr, std::function<void(Entity)>onEntityRemoved = nullptr);
-		EntitySubscriptionRegistration(const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded = nullptr, std::function<void(Entity)>onEntityRemoved = nullptr);
+		EntitySubscriptionRegistration(TArray<ComponentAccess> componentAccesses, const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded = nullptr, std::function<void(Entity)>onEntityRemoval = nullptr);
+		EntitySubscriptionRegistration(const TArray<ComponentAccess>& componentAccesses, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded = nullptr, std::function<void(Entity)>onEntityRemoval = nullptr);
+		EntitySubscriptionRegistration(const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded = nullptr, std::function<void(Entity)>onEntityRemoval = nullptr);
 
 	public:
 		TArray<ComponentAccess> ComponentAccesses;
 		IDVector* pSubscriber;
-		// Optional: Called after an entity was added due to the subscription
+		// Optional: Called after an entity is added due to the subscription
 		std::function<void(Entity)> OnEntityAdded;
-		// Optional: Called before an entity was removed
-		std::function<void(Entity)> OnEntityRemoved;
+		// Optional: Called before an entity is removed
+		std::function<void(Entity)> OnEntityRemoval;
 	};
 
 	// EntitySubscriberRegistration is a complete set of data required to register a component subscriber

--- a/LambdaEngine/Source/ECS/ECSCore.cpp
+++ b/LambdaEngine/Source/ECS/ECSCore.cpp
@@ -145,12 +145,7 @@ namespace LambdaEngine
 
 	bool ECSCore::DeleteComponent(Entity entity, std::type_index componentType)
 	{
-		if (m_ComponentStorage.DeleteComponent(entity, componentType))
-		{
-			m_EntityPublisher.UnpublishComponent(entity, componentType);
-			return true;
-		}
-
-		return false;
+		m_EntityPublisher.UnpublishComponent(entity, componentType);
+		return m_ComponentStorage.DeleteComponent(entity, componentType);
 	}
 }

--- a/LambdaEngine/Source/ECS/EntityPublisher.cpp
+++ b/LambdaEngine/Source/ECS/EntityPublisher.cpp
@@ -28,7 +28,7 @@ namespace LambdaEngine
 
             newSub.pSubscriber = subReq.pSubscriber;
             newSub.OnEntityAdded = subReq.OnEntityAdded;
-            newSub.OnEntityRemoved = subReq.OnEntityRemoved;
+            newSub.OnEntityRemoval = subReq.OnEntityRemoval;
 
             newSub.ComponentTypes.Reserve(componentRegs.GetSize());
             for (const ComponentAccess& componentReg : componentRegs)
@@ -167,10 +167,8 @@ namespace LambdaEngine
                 continue;
             }
 
-            if (sysSub.OnEntityRemoved)
-            {
-                sysSub.OnEntityRemoved(entityID);
-            }
+            if (sysSub.OnEntityRemoval)
+                sysSub.OnEntityRemoval(entityID);
 
             sysSub.pSubscriber->Pop(entityID);
 

--- a/LambdaEngine/Source/ECS/EntitySubscriber.cpp
+++ b/LambdaEngine/Source/ECS/EntitySubscriber.cpp
@@ -4,10 +4,10 @@
 
 namespace LambdaEngine
 {
-    EntitySubscriptionRegistration::EntitySubscriptionRegistration(TArray<ComponentAccess> componentAccesses, const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded, std::function<void(Entity)>onEntityRemoved)
+    EntitySubscriptionRegistration::EntitySubscriptionRegistration(TArray<ComponentAccess> componentAccesses, const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded, std::function<void(Entity)>onEntityRemoval)
         :pSubscriber(pSubscriber),
         OnEntityAdded(onEntityAdded),
-        OnEntityRemoved(onEntityRemoved)
+        OnEntityRemoval(onEntityRemoval)
     {
         // Add the component accesses in the component groups to the component accesses vector
         for (const IComponentGroup* pComponentGroup : componentGroups)
@@ -19,12 +19,12 @@ namespace LambdaEngine
         ComponentAccesses = componentAccesses;
     }
 
-    EntitySubscriptionRegistration::EntitySubscriptionRegistration(const TArray<ComponentAccess>& componentAccesses, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded, std::function<void(Entity)>onEntityRemoved)
-        :EntitySubscriptionRegistration(componentAccesses, {}, pSubscriber, onEntityAdded, onEntityRemoved)
+    EntitySubscriptionRegistration::EntitySubscriptionRegistration(const TArray<ComponentAccess>& componentAccesses, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded, std::function<void(Entity)>onEntityRemoval)
+        :EntitySubscriptionRegistration(componentAccesses, {}, pSubscriber, onEntityAdded, onEntityRemoval)
     {}
 
-    EntitySubscriptionRegistration::EntitySubscriptionRegistration(const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded, std::function<void(Entity)>onEntityRemoved)
-        :EntitySubscriptionRegistration({}, componentGroups, pSubscriber, onEntityAdded, onEntityRemoved)
+    EntitySubscriptionRegistration::EntitySubscriptionRegistration(const TArray<IComponentGroup*>& componentGroups, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded, std::function<void(Entity)>onEntityRemoval)
+        :EntitySubscriptionRegistration({}, componentGroups, pSubscriber, onEntityAdded, onEntityRemoval)
     {}
 
     EntitySubscriber::~EntitySubscriber()


### PR DESCRIPTION
Currently `onEntityRemoved` is called after a component has been deleted. Now it is called before the entity is deleted.