### PR TITLE
Fixed crash with Point Light Component

### DIFF
--- a/LambdaEngine/Source/Game/ECS/Systems/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/RenderSystem.cpp
@@ -453,8 +453,11 @@ namespace LambdaEngine
 		uint32 currentIndex = m_EntityToPointLight[entity];
 
 		m_PointLights[currentIndex] = m_PointLights[lastIndex];
+		
 		m_EntityToPointLight[lastEntity] = currentIndex;
+		m_PointLightToEntity[currentIndex] = lastEntity;
 
+		m_PointLightToEntity.erase(lastIndex);
 		m_EntityToPointLight.erase(entity);
 		m_PointLights.PopBack();
 


### PR DESCRIPTION
Fixed crash which occurred when removing entities with Point Light Components.