### PR TITLE
Crash quick fix

### DIFF
--- a/Client/key_bindings.json
+++ b/Client/key_bindings.json
@@ -1,0 +1,14 @@
+{
+	"CAM_FORWARD": "W",
+	"CAM_BACKWARD": "S",
+	"CAM_LEFT": "A",
+	"CAM_RIGHT": "D",
+	"CAM_UP": "Q",
+	"CAM_DOWN": "E",
+	"CAM_ROT_UP": "UP",
+	"CAM_ROT_DOWN": "DOWN",
+	"CAM_ROT_LEFT": "LEFT",
+	"CAM_ROT_RIGHT": "RIGHT",
+	"CAM_SPEED_MODIFIER": "LEFT_SHIFT",
+	"TOGGLE_MOUSE": "C"
+}

--- a/LambdaEngine/Include/Engine/EngineConfig.h
+++ b/LambdaEngine/Include/Engine/EngineConfig.h
@@ -12,24 +12,24 @@ namespace LambdaEngine
 	public:
 		DECL_STATIC_CLASS(EngineConfig);
 
-        static bool             LoadFromFile();
-        static bool             WriteToFile();
+		static bool				LoadFromFile();
+		static bool				WriteToFile();
 
-        static bool             GetBoolProperty(const String& propertyName);
-        static float            GetFloatProperty(const String& propertyName);
-        static int              GetIntProperty(const String& propertyName);
-        static double           GetDoubleProperty(const String& propertyName);
-        static String           GetStringProperty(const String& propertyName);
-        static TArray<float>    GetFloatArrayProperty(const String& propertyName);
-        static TArray<int>      GetIntArrayProperty(const String& propertyName);
+		static bool				GetBoolProperty(const String& propertyName);
+		static float			GetFloatProperty(const String& propertyName);
+		static int				GetIntProperty(const String& propertyName);
+		static double			GetDoubleProperty(const String& propertyName);
+		static String			GetStringProperty(const String& propertyName);
+		static TArray<float>	GetFloatArrayProperty(const String& propertyName);
+		static TArray<int>		GetIntArrayProperty(const String& propertyName);
 
-        static bool             SetBoolProperty(const String& propertyName, bool value);
-        static bool             SetFloatProperty(const String& propertyName, float value);
-        static bool             SetIntProperty(const String& propertyName, int value);
-        static bool             SetDoubleProperty(const String& propertyName, double value);
-        static bool             SetStringProperty(const String& propertyName, const String& string);
-        static bool             SetFloatArrayProperty(const String& propertyName, const TArray<float>& arr);
-        static bool             SetIntArrayProperty(const String& propertyName, const TArray<int>& arr);
+		static bool				SetBoolProperty(const String& propertyName, bool value);
+		static bool				SetFloatProperty(const String& propertyName, float value);
+		static bool				SetIntProperty(const String& propertyName, int value);
+		static bool				SetDoubleProperty(const String& propertyName, double value);
+		static bool				SetStringProperty(const String& propertyName, const String& string);
+		static bool				SetFloatArrayProperty(const String& propertyName, const TArray<float>& arr);
+		static bool				SetIntArrayProperty(const String& propertyName, const TArray<int>& arr);
 
 	private:
 		static rapidjson::Document s_ConfigDocument;

--- a/LambdaEngine/Source/Engine/EngineConfig.cpp
+++ b/LambdaEngine/Source/Engine/EngineConfig.cpp
@@ -10,19 +10,21 @@
 
 namespace LambdaEngine
 {
-    rapidjson::Document EngineConfig::s_ConfigDocument = {};
-    using namespace rapidjson;
+	rapidjson::Document EngineConfig::s_ConfigDocument = {};
+	using namespace rapidjson;
 
 	bool EngineConfig::LoadFromFile()
 	{
 		const char* pEngineConfigPath = "engine_config.json";
 
-        FILE* pFile = fopen(pEngineConfigPath, "r");
-        if (!pFile)
-        {
-            LOG_WARNING("Engine config could not be opened: %s", pEngineConfigPath);
-            return false;
-        }
+		FILE* pFile = fopen(pEngineConfigPath, "r");
+		if (!pFile)
+		{
+			// TODO: We should probably create a default so that the user does not need to have a config file to even run the application
+			LOG_WARNING("Engine config could not be opened: %s", pEngineConfigPath);
+			DEBUGBREAK();
+			return false;
+		}
 
 		char readBuffer[2048];
 		FileReadStream inputStream(pFile, readBuffer, sizeof(readBuffer));
@@ -34,171 +36,171 @@ namespace LambdaEngine
 		return true;
 	}
 
-    bool EngineConfig::WriteToFile()
-    {
-        const char* pEngineConfigPath = "engine_config.json";
+	bool EngineConfig::WriteToFile()
+	{
+		const char* pEngineConfigPath = "engine_config.json";
 
-        FILE* pFile = fopen(pEngineConfigPath, "w");
-        if (!pFile)
-        {
-            LOG_WARNING("Engine config could not be opened: %s", pEngineConfigPath);
-            return false;
-        }
+		FILE* pFile = fopen(pEngineConfigPath, "w");
+		if (!pFile)
+		{
+			LOG_WARNING("Engine config could not be opened: %s", pEngineConfigPath);
+			return false;
+		}
 
-        char writeBuffer[2048];
-        FileWriteStream outputStream(pFile, writeBuffer, sizeof(writeBuffer));
+		char writeBuffer[2048];
+		FileWriteStream outputStream(pFile, writeBuffer, sizeof(writeBuffer));
 
-        PrettyWriter<FileWriteStream> writer(outputStream);
-        s_ConfigDocument.Accept(writer);
+		PrettyWriter<FileWriteStream> writer(outputStream);
+		s_ConfigDocument.Accept(writer);
 
-        fclose(pFile);
+		fclose(pFile);
 
-        return true;
-    }
+		return true;
+	}
 
-    bool EngineConfig::GetBoolProperty(const String& propertyName)
-    {
-        return s_ConfigDocument[propertyName.c_str()].GetBool();
-    }
+	bool EngineConfig::GetBoolProperty(const String& propertyName)
+	{
+		return s_ConfigDocument[propertyName.c_str()].GetBool();
+	}
 
-    float EngineConfig::GetFloatProperty(const String& propertyName)
-    {
-        return s_ConfigDocument[propertyName.c_str()].GetFloat();
-    }
+	float EngineConfig::GetFloatProperty(const String& propertyName)
+	{
+		return s_ConfigDocument[propertyName.c_str()].GetFloat();
+	}
 
-    int EngineConfig::GetIntProperty(const String& propertyName)
-    {
-        return s_ConfigDocument[propertyName.c_str()].GetInt();
-    }
+	int EngineConfig::GetIntProperty(const String& propertyName)
+	{
+		return s_ConfigDocument[propertyName.c_str()].GetInt();
+	}
 
-    double EngineConfig::GetDoubleProperty(const String& propertyName)
-    {
-        return s_ConfigDocument[propertyName.c_str()].GetDouble();
-    }
+	double EngineConfig::GetDoubleProperty(const String& propertyName)
+	{
+		return s_ConfigDocument[propertyName.c_str()].GetDouble();
+	}
 
-    String EngineConfig::GetStringProperty(const String& propertyName)
-    {
-        return s_ConfigDocument[propertyName.c_str()].GetString();
-    }
+	String EngineConfig::GetStringProperty(const String& propertyName)
+	{
+		return s_ConfigDocument[propertyName.c_str()].GetString();
+	}
 
-    TArray<float> EngineConfig::GetFloatArrayProperty(const String& propertyName)
-    {
-        const Value& arr = s_ConfigDocument[propertyName.c_str()];
-        TArray<float> tArr;
-        for (auto& itr : arr.GetArray())
-            tArr.PushBack(itr.GetFloat());
+	TArray<float> EngineConfig::GetFloatArrayProperty(const String& propertyName)
+	{
+		const Value& arr = s_ConfigDocument[propertyName.c_str()];
+		TArray<float> tArr;
+		for (auto& itr : arr.GetArray())
+			tArr.PushBack(itr.GetFloat());
 
-        return tArr;
-    }
+		return tArr;
+	}
 
-    TArray<int> EngineConfig::GetIntArrayProperty(const String& propertyName)
-    {
-        const Value& arr = s_ConfigDocument[propertyName.c_str()];
-        TArray<int> tArr;
-        for (auto& itr : arr.GetArray())
-            tArr.PushBack(itr.GetInt());
+	TArray<int> EngineConfig::GetIntArrayProperty(const String& propertyName)
+	{
+		const Value& arr = s_ConfigDocument[propertyName.c_str()];
+		TArray<int> tArr;
+		for (auto& itr : arr.GetArray())
+			tArr.PushBack(itr.GetInt());
 
-        return tArr;
-    }
+		return tArr;
+	}
 
-    bool EngineConfig::SetBoolProperty(const String& propertyName, const bool value)
-    {
-        if (s_ConfigDocument.HasMember(propertyName.c_str()))
-        {
-            s_ConfigDocument[propertyName.c_str()].SetBool(value);
+	bool EngineConfig::SetBoolProperty(const String& propertyName, const bool value)
+	{
+		if (s_ConfigDocument.HasMember(propertyName.c_str()))
+		{
+			s_ConfigDocument[propertyName.c_str()].SetBool(value);
 
-            return true;
-        }
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    bool EngineConfig::SetFloatProperty(const String& propertyName, const float value)
-    {
-        if (s_ConfigDocument.HasMember(propertyName.c_str()))
-        {
-            s_ConfigDocument[propertyName.c_str()].SetFloat(value);
+	bool EngineConfig::SetFloatProperty(const String& propertyName, const float value)
+	{
+		if (s_ConfigDocument.HasMember(propertyName.c_str()))
+		{
+			s_ConfigDocument[propertyName.c_str()].SetFloat(value);
 
-            return true;
-        }
-        return false;
-    }
+			return true;
+		}
+		return false;
+	}
 
-    bool EngineConfig::SetIntProperty(const String& propertyName, const int value)
-    {
-        if (s_ConfigDocument.HasMember(propertyName.c_str()))
-        {
-            s_ConfigDocument[propertyName.c_str()].SetFloat(value);
+	bool EngineConfig::SetIntProperty(const String& propertyName, const int value)
+	{
+		if (s_ConfigDocument.HasMember(propertyName.c_str()))
+		{
+			s_ConfigDocument[propertyName.c_str()].SetFloat(value);
 
-            return true;
-        }
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    bool EngineConfig::SetDoubleProperty(const String& propertyName, const double value)
-    {
-        if (s_ConfigDocument.HasMember(propertyName.c_str()))
-        {
-            s_ConfigDocument[propertyName.c_str()].SetDouble(value);
+	bool EngineConfig::SetDoubleProperty(const String& propertyName, const double value)
+	{
+		if (s_ConfigDocument.HasMember(propertyName.c_str()))
+		{
+			s_ConfigDocument[propertyName.c_str()].SetDouble(value);
 
-            return true;
-        }
-        return false;
-    }
+			return true;
+		}
+		return false;
+	}
 
-    bool EngineConfig::SetStringProperty(const String& propertyName, const String& string)
-    {
-        if (s_ConfigDocument.HasMember(propertyName.c_str()))
-        {
-            s_ConfigDocument[propertyName.c_str()].SetString(string.c_str(), static_cast<SizeType>(strlen(string.c_str())), s_ConfigDocument.GetAllocator());
+	bool EngineConfig::SetStringProperty(const String& propertyName, const String& string)
+	{
+		if (s_ConfigDocument.HasMember(propertyName.c_str()))
+		{
+			s_ConfigDocument[propertyName.c_str()].SetString(string.c_str(), static_cast<SizeType>(strlen(string.c_str())), s_ConfigDocument.GetAllocator());
 
-            return true;
-        }
-        return false;
-    }
+			return true;
+		}
+		return false;
+	}
 
-    bool EngineConfig::SetFloatArrayProperty(const String& propertyName, const TArray<float>& arr)
-    {
-        if (s_ConfigDocument.HasMember(propertyName.c_str()))
-        {
-            Document::AllocatorType& allocator = s_ConfigDocument.GetAllocator();
+	bool EngineConfig::SetFloatArrayProperty(const String& propertyName, const TArray<float>& arr)
+	{
+		if (s_ConfigDocument.HasMember(propertyName.c_str()))
+		{
+			Document::AllocatorType& allocator = s_ConfigDocument.GetAllocator();
 
-            auto& newArr = s_ConfigDocument[propertyName.c_str()].SetArray();
-            newArr.Reserve(arr.GetSize(), allocator);
+			auto& newArr = s_ConfigDocument[propertyName.c_str()].SetArray();
+			newArr.Reserve(arr.GetSize(), allocator);
 
-            for (auto& itr : arr)
-                newArr.PushBack(Value().SetFloat(itr), allocator);
+			for (auto& itr : arr)
+				newArr.PushBack(Value().SetFloat(itr), allocator);
 
-            StringBuffer strBuf;
-            PrettyWriter<StringBuffer> writer(strBuf);
-            s_ConfigDocument.Accept(writer);
+			StringBuffer strBuf;
+			PrettyWriter<StringBuffer> writer(strBuf);
+			s_ConfigDocument.Accept(writer);
 
-            return true;
-        }
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    bool EngineConfig::SetIntArrayProperty(const String& propertyName, const TArray<int>& arr)
-    {
-        if (s_ConfigDocument.HasMember(propertyName.c_str()))
-        {
-            Document::AllocatorType& allocator = s_ConfigDocument.GetAllocator();
+	bool EngineConfig::SetIntArrayProperty(const String& propertyName, const TArray<int>& arr)
+	{
+		if (s_ConfigDocument.HasMember(propertyName.c_str()))
+		{
+			Document::AllocatorType& allocator = s_ConfigDocument.GetAllocator();
 
-            auto& newArr = s_ConfigDocument[propertyName.c_str()].SetArray();
-            newArr.Reserve(arr.GetSize(), allocator);
+			auto& newArr = s_ConfigDocument[propertyName.c_str()].SetArray();
+			newArr.Reserve(arr.GetSize(), allocator);
 
-            for (auto& itr : arr)
-                newArr.PushBack(Value().SetInt(itr), allocator);
+			for (auto& itr : arr)
+				newArr.PushBack(Value().SetInt(itr), allocator);
 
-            StringBuffer strBuf;
-            PrettyWriter<StringBuffer> writer(strBuf);
-            s_ConfigDocument.Accept(writer);
+			StringBuffer strBuf;
+			PrettyWriter<StringBuffer> writer(strBuf);
+			s_ConfigDocument.Accept(writer);
 
-            return true;
-        }
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 }

--- a/LambdaEngine/Source/Input/API/InputActionSystem.cpp
+++ b/LambdaEngine/Source/Input/API/InputActionSystem.cpp
@@ -20,7 +20,9 @@ namespace LambdaEngine
 		FILE* pFile = fopen(pKeyBindingsConfigPath, "r");
 		if (!pFile)
 		{
-			LOG_WARNING("Config file could not be opened: %s", pKeyBindingsConfigPath);
+			// TODO: We should probably create a default so that the user does not need to have a config file to even run the application
+			LOG_ERROR("Config file could not be opened: %s", pKeyBindingsConfigPath);
+			DEBUGBREAK();
 			return false;
 		}
 

--- a/Sandbox/key_bindings.json
+++ b/Sandbox/key_bindings.json
@@ -1,0 +1,14 @@
+{
+	"CAM_FORWARD": "W",
+	"CAM_BACKWARD": "S",
+	"CAM_LEFT": "A",
+	"CAM_RIGHT": "D",
+	"CAM_UP": "Q",
+	"CAM_DOWN": "E",
+	"CAM_ROT_UP": "UP",
+	"CAM_ROT_DOWN": "DOWN",
+	"CAM_ROT_LEFT": "LEFT",
+	"CAM_ROT_RIGHT": "RIGHT",
+	"CAM_SPEED_MODIFIER": "LEFT_SHIFT",
+	"TOGGLE_MOUSE": "C"
+}

--- a/Server/key_bindings.json
+++ b/Server/key_bindings.json
@@ -1,0 +1,14 @@
+{
+	"CAM_FORWARD": "W",
+	"CAM_BACKWARD": "S",
+	"CAM_LEFT": "A",
+	"CAM_RIGHT": "D",
+	"CAM_UP": "Q",
+	"CAM_DOWN": "E",
+	"CAM_ROT_UP": "UP",
+	"CAM_ROT_DOWN": "DOWN",
+	"CAM_ROT_LEFT": "LEFT",
+	"CAM_ROT_RIGHT": "RIGHT",
+	"CAM_SPEED_MODIFIER": "LEFT_SHIFT",
+	"TOGGLE_MOUSE": "C"
+}


### PR DESCRIPTION
* Added key_binding files to Sandbox, server, and client. The missing file caused the application to exit that later caused a crash.

**The problem**: Some static instances (NetworkSystem) were deleted and their destructors were called. The job system is called from the destructor and UINT_MAX is sent in as _phase_ in the job scheduler. This is probably something that we need to fix somehow. As I see it there are a couple of solutions
1. Do not use global instances of systems. (Maybe have a standard for how we deal with singleton systems)
2. Make sure that the application can handle values for phases that are not valid (Enable the user to handle this error)
There are certainly more but these are probably the easiest solutions.

Something else that needs to be discussed is if we really should be this dependent on a couple of config files for the final product. Maybe we should create a default setting if the config does not exist and let the application continue to run, and not exit in initialize.
 