### PR TITLE
Fix entities not being excluded properly

### DIFF
--- a/LambdaEngine/Include/ECS/EntityPublisher.h
+++ b/LambdaEngine/Include/ECS/EntityPublisher.h
@@ -48,9 +48,9 @@ namespace LambdaEngine
         void UnsubscribeFromEntities(uint32 subscriptionID);
 
         // Notifies subscribers that a component has been added
-        void PublishComponent(Entity entityID, const ComponentType* pComponentType);
+        void PublishComponent(Entity entity, const ComponentType* pComponentType);
         // Notifies subscribers that a component has been deleted
-        void UnpublishComponent(Entity entityID, const ComponentType* pComponentType);
+        void UnpublishComponent(Entity entity, const ComponentType* pComponentType);
 
     private:
         static void EliminateDuplicateTIDs(TArray<const ComponentType*>& TIDs);

--- a/LambdaEngine/Include/ECS/EntityRegistry.h
+++ b/LambdaEngine/Include/ECS/EntityRegistry.h
@@ -25,8 +25,12 @@ namespace LambdaEngine
         void RegisterComponentType(Entity entity, const ComponentType* pComponentType);
         void DeregisterComponentType(Entity entity, const ComponentType* pComponentType);
 
-        // Queries whether or not the entity has all the specified types
-        bool EntityHasAllowedTypes(Entity entity, const TArray<const ComponentType*>& queryTypes, const TArray<const ComponentType*>& excludedComponentsTypes = {}) const;
+        // EntityHasAllTypes returns true if the entity has all of the allowed types and none of the disallowed types
+        bool EntityHasAllowedTypes(Entity entity, const TArray<const ComponentType*>& allowedTypes, const TArray<const ComponentType*>& disallowedTypes) const;
+        // EntityHasAllTypes returns true if the entity has all of the specified types
+        bool EntityHasAllTypes(Entity entity, const TArray<const ComponentType*>& types) const;
+        // EntityHasAnyOfTypes returns true if the entity has at least one of the specified types
+        bool EntityHasAnyOfTypes(Entity entity, const TArray<const ComponentType*>& types) const;
 
         Entity CreateEntity();
         void DeregisterEntity(Entity entity);

--- a/LambdaEngine/Source/ECS/EntityRegistry.cpp
+++ b/LambdaEngine/Source/ECS/EntityRegistry.cpp
@@ -44,33 +44,50 @@ namespace LambdaEngine
 		}
 	}
 
-	bool EntityRegistry::EntityHasAllowedTypes(Entity entity, const TArray<const ComponentType*>& queryTypes, const TArray<const ComponentType*>& excludedComponentsTypes) const
+	bool EntityRegistry::EntityHasAllowedTypes(Entity entity, const TArray<const ComponentType*>& allowedTypes, const TArray<const ComponentType*>& disallowedTypes) const
 	{
 		std::scoped_lock<SpinLock> lock(m_Lock);
 
 		const EntityRegistryPage& topPage = m_EntityPages.top();
 		const std::unordered_set<const ComponentType*>& entityTypes = topPage.IndexID(entity);
 
-		// Entity with excluded components are not allowed
-		for (const ComponentType* pExcludedType : excludedComponentsTypes)
+		const bool hasDisallowedType = std::any_of(disallowedTypes.Begin(), disallowedTypes.End(), [entityTypes](const ComponentType* pType) {
+			return entityTypes.contains(pType);
+		});
+
+		if (hasDisallowedType)
 		{
-			auto got = entityTypes.find(pExcludedType);
-			if (got != entityTypes.end())
-			{
-				return false;
-			}
+			return false;
 		}
 
-		for (const ComponentType* pComponentType : queryTypes)
-		{
-			auto got = entityTypes.find(pComponentType);
-			if (got == entityTypes.end())
-			{
-				return false;
-			}
-		}
+		return std::none_of(allowedTypes.Begin(), allowedTypes.End(), [entityTypes](const ComponentType* pType) {
+			return !entityTypes.contains(pType);
+		});
+	}
 
-		return true;
+	bool EntityRegistry::EntityHasAllTypes(Entity entity, const TArray<const ComponentType*>& types) const
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		const EntityRegistryPage& topPage = m_EntityPages.top();
+		const std::unordered_set<const ComponentType*>& entityTypes = topPage.IndexID(entity);
+
+		// Check that none of the entity types are missing
+		return std::none_of(types.Begin(), types.End(), [entityTypes](const ComponentType* pType) {
+			return !entityTypes.contains(pType);
+		});
+	}
+
+	bool EntityRegistry::EntityHasAnyOfTypes(Entity entity, const TArray<const ComponentType*>& types) const
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		const EntityRegistryPage& topPage = m_EntityPages.top();
+		const std::unordered_set<const ComponentType*>& entityTypes = topPage.IndexID(entity);
+
+		return std::any_of(types.Begin(), types.End(), [entityTypes](const ComponentType* pType) {
+			return entityTypes.contains(pType);
+		});
 	}
 
 	Entity EntityRegistry::CreateEntity()

--- a/LambdaEngine/Source/ECS/EntitySubscriber.cpp
+++ b/LambdaEngine/Source/ECS/EntitySubscriber.cpp
@@ -20,7 +20,7 @@ namespace LambdaEngine
     }
 
     EntitySubscriptionRegistration::EntitySubscriptionRegistration(const TArray<ComponentAccess>& componentAccesses, const TArray<IComponentGroup*>& componentGroups, const TArray<const ComponentType*>& excludedComponentTypes, IDVector* pSubscriber, std::function<void(Entity)>onEntityAdded, std::function<void(Entity)>onEntityRemoval)
-        :EntitySubscriptionRegistration(componentAccesses, {}, pSubscriber, onEntityAdded, onEntityRemoval)
+        :EntitySubscriptionRegistration(componentAccesses, componentGroups, pSubscriber, onEntityAdded, onEntityRemoval)
     {
         // Filter the component accesses present in excluded list
         TArray<ComponentAccess> componentAccessesFiltered;
@@ -34,7 +34,6 @@ namespace LambdaEngine
             {
                 componentAccessesFiltered.PushBack(component);
             }
-
         }
 
         ComponentAccesses = componentAccessesFiltered;

--- a/LambdaEngine/Source/Game/ECS/Systems/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/RenderSystem.cpp
@@ -475,7 +475,7 @@ namespace LambdaEngine
 		uint32 currentIndex = m_EntityToPointLight[entity];
 
 		m_PointLights[currentIndex] = m_PointLights[lastIndex];
-		
+
 		m_EntityToPointLight[lastEntity] = currentIndex;
 		m_PointLightToEntity[currentIndex] = lastEntity;
 
@@ -849,7 +849,7 @@ namespace LambdaEngine
 
 		m_PointLights[index].ColorIntensity = colorIntensity;
 		m_PointLights[index].Position = position;
-		
+
 		const glm::vec3 directions[6] =
 		{
 			{1.0f, 0.0f, 0.0f},

--- a/Sandbox/Source/States/SandboxState.cpp
+++ b/Sandbox/Source/States/SandboxState.cpp
@@ -104,7 +104,7 @@ void SandboxState::Init()
 		materialProperties.Roughness	= 1.0f;
 		materialProperties.Metallic		= 1.0f;
 
-		const uint32 robotMaterialGUID	= ResourceManager::LoadMaterialFromMemory(
+		const uint32 robotMaterialGUID = ResourceManager::LoadMaterialFromMemory(
 			"Robot Material",
 			robotAlbedoGUID,
 			robotNormalGUID,


### PR DESCRIPTION
Component exclusion in entity subscriptions was not functioning in the two cases:
- An entity matching a subscription has an excluded component added to it. The entity should be removed from the excluding subscriber.
- An excluded component is removed from an entity. The entity should be added to the excluding subscriber.