### PR TITLE
Added a new header for operators new and delete

### DIFF
--- a/LambdaEngine/Include/LambdaEngine.h
+++ b/LambdaEngine/Include/LambdaEngine.h
@@ -4,4 +4,6 @@
 
 #include "Assert/Assert.h"
 
+// Should always be included in this order since the New.h depends on Malloc.h in SharedLib for now
 #include "Memory/API/Malloc.h"
+#include "Memory/API/New.h"

--- a/LambdaEngine/Include/Memory/API/Malloc.h
+++ b/LambdaEngine/Include/Memory/API/Malloc.h
@@ -2,17 +2,10 @@
 #include "Types.h"
 #include "Defines.h"
 
-#include <new>
-
-#ifdef LAMBDA_DEBUG
-	#define DBG_NEW	new(__FILE__, __LINE__)
-#else
-	#define DBG_NEW	new
-#endif
-
 /*
 * Delete and Release
 */
+
 #define DELETE_OBJECT(object)	delete(object); (object) = nullptr
 #define SAFEDELETE(object)		if ((object))	{ DELETE_OBJECT(object); }
 
@@ -22,17 +15,22 @@
 #define RELEASE(object)			(object)->Release(); (object) = nullptr
 #define SAFERELEASE(object)		if ((object))	{ RELEASE(object); }
 
-/*
-* Custom memory handler
-*/
 namespace LambdaEngine
 {
+	/*
+	* FMemoryDebugFlags
+	*/
+
 	enum FMemoryDebugFlags : uint16
 	{
 		MEMORY_DEBUG_FLAGS_NONE				= 0,
 		MEMORY_DEBUG_FLAGS_OVERFLOW_PROTECT	= FLAG(1),
 		MEMORY_DEBUG_FLAGS_LEAK_CHECK		= FLAG(2),
 	};
+
+	/*
+	* Malloc
+	*/
 
 	class LAMBDA_API Malloc
 	{
@@ -61,78 +59,3 @@ namespace LambdaEngine
 		static uint16 s_DebugFlags;
 	};
 }
-
-#ifdef LAMBDA_VISUAL_STUDIO
-	#pragma warning(push)
-	#pragma warning(disable : 4595) // Disable "non-member operator new or delete functions may not be declared inline" warning
-#endif
-
-/*
-* Custom Debug new and delete
-*/
-inline void* operator new(size_t sizeInBytes, const char* pFileName, int32 lineNumber)
-{
-	return LambdaEngine::Malloc::AllocateDbg(sizeInBytes, pFileName, lineNumber);
-}
-
-inline void* operator new[](size_t sizeInBytes, const char* pFileName, int32 lineNumber)
-{
-	return LambdaEngine::Malloc::AllocateDbg(sizeInBytes, pFileName, lineNumber);
-}
-
-inline void operator delete(void* pPtr, const char*, int32) noexcept
-{
-	LambdaEngine::Malloc::Free(pPtr);
-}
-
-inline void operator delete[](void* pPtr, const char*, int32) noexcept
-{
-	LambdaEngine::Malloc::Free(pPtr);
-}
-
-/*
-* Custom new and delete
-*/
-inline void* operator new(size_t sizeInBytes)
-{
-	return LambdaEngine::Malloc::Allocate(sizeInBytes);
-}
-
-inline void* operator new[](size_t sizeInBytes)
-{
-	return LambdaEngine::Malloc::Allocate(sizeInBytes);
-}
-
-inline void* operator new(size_t sizeInBytes, const std::nothrow_t&) noexcept
-{
-	return LambdaEngine::Malloc::Allocate(sizeInBytes);
-}
-
-inline void* operator new[](size_t sizeInBytes, const std::nothrow_t&) noexcept
-{
-	return LambdaEngine::Malloc::Allocate(sizeInBytes);
-}
-
-inline void operator delete(void* pPtr) noexcept
-{
-	LambdaEngine::Malloc::Free(pPtr);
-}
-
-inline void operator delete[](void* pPtr) noexcept
-{
-	LambdaEngine::Malloc::Free(pPtr);
-}
-
-inline void operator delete(void* pPtr, size_t) noexcept
-{
-	LambdaEngine::Malloc::Free(pPtr);
-}
-
-inline void operator delete[](void* pPtr, size_t) noexcept
-{
-	LambdaEngine::Malloc::Free(pPtr);
-}
-
-#ifdef LAMBDA_VISUAL_STUDIO
-	#pragma warning(pop)
-#endif

--- a/LambdaEngine/Include/Memory/API/New.h
+++ b/LambdaEngine/Include/Memory/API/New.h
@@ -1,0 +1,113 @@
+#pragma once
+#include <new>
+
+#ifdef LAMBDA_DEBUG
+	#define DBG_NEW	new(__FILE__, __LINE__)
+#else
+	#define DBG_NEW	new
+#endif
+
+/*
+* Custom Debug new and delete
+*/
+
+void* operator new  (size_t sizeInBytes, const char* pFileName, int32 lineNumber);
+void* operator new[](size_t sizeInBytes, const char* pFileName, int32 lineNumber);
+
+void operator delete  (void* pPtr, const char*, int32) noexcept;
+void operator delete[](void* pPtr, const char*, int32) noexcept;
+
+/*
+* Custom new and delete
+*/
+
+void* operator new  (size_t sizeInBytes);
+void* operator new[](size_t sizeInBytes);
+void* operator new  (size_t sizeInBytes, const std::nothrow_t&)	noexcept;
+void* operator new[](size_t sizeInBytes, const std::nothrow_t&)	noexcept;
+
+void operator delete  (void* pPtr)			noexcept;
+void operator delete[](void* pPtr)			noexcept;
+void operator delete  (void* pPtr, size_t)	noexcept;
+void operator delete[](void* pPtr, size_t)	noexcept;
+
+#ifdef LAMBDA_SHARED_LIB
+	#ifdef LAMBDA_VISUAL_STUDIO
+		#pragma warning(push)
+		#pragma warning(disable : 4595) // Disable "non-member operator new or delete functions may not be declared inline" warning
+	#endif
+
+#include "Malloc.h"
+
+/*
+* Custom Debug new and delete
+*/
+
+inline void* operator new(size_t sizeInBytes, const char* pFileName, int32 lineNumber)
+{
+	return LambdaEngine::Malloc::AllocateDbg(sizeInBytes, pFileName, lineNumber);
+}
+
+inline void* operator new[](size_t sizeInBytes, const char* pFileName, int32 lineNumber)
+{
+	return LambdaEngine::Malloc::AllocateDbg(sizeInBytes, pFileName, lineNumber);
+}
+
+inline void operator delete(void* pPtr, const char*, int32) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+inline void operator delete[](void* pPtr, const char*, int32) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+/*
+* Custom new and delete
+*/
+
+inline void* operator new(size_t sizeInBytes)
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+inline void* operator new[](size_t sizeInBytes)
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+inline void* operator new(size_t sizeInBytes, const std::nothrow_t&) noexcept
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+inline void* operator new[](size_t sizeInBytes, const std::nothrow_t&) noexcept
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+inline void operator delete(void* pPtr) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+inline void operator delete[](void* pPtr) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+inline void operator delete(void* pPtr, size_t) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+inline void operator delete[](void* pPtr, size_t) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+	#ifdef LAMBDA_VISUAL_STUDIO
+		#pragma warning(pop)
+	#endif
+#endif

--- a/LambdaEngine/PreCompiled.h
+++ b/LambdaEngine/PreCompiled.h
@@ -15,3 +15,7 @@
 // Core
 #include "Core/TSharedRef.h"
 #include "Core/RefCountedObject.h"
+
+// Memory
+#include "Memory/API/Malloc.h"
+#include "Memory/API/New.h"

--- a/LambdaEngine/Source/Memory/API/New.cpp
+++ b/LambdaEngine/Source/Memory/API/New.cpp
@@ -1,0 +1,72 @@
+#ifndef LAMBDA_SHARED_LIB
+#include "Memory/API/New.h"
+
+/*
+* Custom Debug new and delete
+*/
+
+void* operator new(size_t sizeInBytes, const char* pFileName, int32 lineNumber)
+{
+	return LambdaEngine::Malloc::AllocateDbg(sizeInBytes, pFileName, lineNumber);
+}
+
+void* operator new[](size_t sizeInBytes, const char* pFileName, int32 lineNumber)
+{
+	return LambdaEngine::Malloc::AllocateDbg(sizeInBytes, pFileName, lineNumber);
+}
+
+void operator delete(void* pPtr, const char*, int32) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+void operator delete[](void* pPtr, const char*, int32) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+/*
+* Custom new and delete
+*/
+
+void* operator new(size_t sizeInBytes)
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+void* operator new[](size_t sizeInBytes)
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+void* operator new(size_t sizeInBytes, const std::nothrow_t&) noexcept
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+void* operator new[](size_t sizeInBytes, const std::nothrow_t&) noexcept
+{
+	return LambdaEngine::Malloc::Allocate(sizeInBytes);
+}
+
+void operator delete(void* pPtr) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+void operator delete[](void* pPtr) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+void operator delete(void* pPtr, size_t) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+void operator delete[](void* pPtr, size_t) noexcept
+{
+	LambdaEngine::Malloc::Free(pPtr);
+}
+
+#endif


### PR DESCRIPTION
* Operators new and delete are preferred not to be defined in header files, and the compiler will complain when you try to do so. However, we have removed this warning because we did not care before. But now, when we are primarily building static, we can do it the proper way. We had it in because of SharedLib-builds since we cannot export the operator new and delete to the .dll (The compiler will generate an error if I remember correctly). For this reason, I have now defined the custom new and delete operators in a .cpp file when building for static libs. I also put all new operators in the new header file, "New.h" since malloc and new are different things, and it becomes clearer this way.