### PR TITLE
Use build action for Välfärden

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,163 +2,105 @@ name: Välfärden
 on: pull_request
 
 jobs:
-  Pre-Build:
-    runs-on: [self-hosted, Windows, X64]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Read LFS Cache
-        run: cp -r -Force ../../.git/lfs .git/
-
-      # Fetches changes and replaces LFS pointers with their actual contents
-      - name: Pull From LFS
-        run: git lfs pull
-
-      - name: Update LFS Cache
-        run: cp -r -Force .git/lfs ../../.git/
-
   Build-LambdaEngine-Debug:
     runs-on: [self-hosted, Windows, X64]
-    needs: Pre-Build
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild LambdaEngine/LambdaEngine.vcxproj -p:Configuration="Debug x64_StaticLib" -p:Platform=x64
+      - name: Build LambdaEngine Debug
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: LambdaEngine/LambdaEngine.vcxproj
+          build-configuration: Debug x64_StaticLib
 
   Build-LambdaEngine-Release:
     runs-on: [self-hosted, Windows, X64]
-    needs: Pre-Build
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild LambdaEngine/LambdaEngine.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build LambdaEngine Release
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: LambdaEngine/LambdaEngine.vcxproj
+          build-configuration: Release x64_StaticLib
 
   Build-CrazyCanvas-Debug:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Debug
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild CrazyCanvas/CrazyCanvas.vcxproj -p:Configuration="Debug x64_StaticLib" -p:Platform=x64
+      - name: Build CrazyCanvas Debug
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: CrazyCanvas/CrazyCanvas.vcxproj
+          build-configuration: Debug x64_StaticLib
 
   Build-CrazyCanvas-Release:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Release
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild CrazyCanvas/CrazyCanvas.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build CrazyCanvas Release
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: CrazyCanvas/CrazyCanvas.vcxproj
+          build-configuration: Release x64_StaticLib
 
   Build-Sandbox-Debug:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Debug
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild Sandbox/Sandbox.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build Sandbox Debug
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: Sandbox/Sandbox.vcxproj
+          build-configuration: Debug x64_StaticLib
 
   Build-Sandbox-Release:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Release
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild Sandbox/Sandbox.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build Sandbox Release
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: Sandbox/Sandbox.vcxproj
+          build-configuration: Release x64_StaticLib
 
   Build-Client-Debug:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Debug
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild Client/Client.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build Client Debug
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: Client/Client.vcxproj
+          build-configuration: Debug x64_StaticLib
 
   Build-Client-Release:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Release
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild Client/Client.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build Client Release
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: Client/Client.vcxproj
+          build-configuration: Release x64_StaticLib
 
   Build-Server-Debug:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Debug
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild Server/Server.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build Server Debug
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: Server/Server.vcxproj
+          build-configuration: Debug x64_StaticLib
 
   Build-Server-Release:
     runs-on: [self-hosted, Windows, X64]
-    needs: Build-LambdaEngine-Release
-
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
-      - name: Build
-        run: msbuild Server/Server.vcxproj -p:Configuration="Release x64_StaticLib" -p:Platform=x64
+      - name: Build Server Release
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: Server/Server.vcxproj
+          build-configuration: Release x64_StaticLib
 
   Lint:
     runs-on: [self-hosted, Windows, X64]
@@ -175,10 +117,9 @@ jobs:
         run: python .github/workflows/generate-lint-report.py -o cppcheck_report.txt -i Dependencies
 
       - name: Get file changes
-        id: get_file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read Lint Report
         run: python ./.github/workflows/read-lint-report.py --report ./cppcheck_report.txt

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,8 +5,15 @@ jobs:
   Build-LambdaEngine-Debug:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build LambdaEngine Debug
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: LambdaEngine/LambdaEngine.vcxproj
@@ -15,8 +22,15 @@ jobs:
   Build-LambdaEngine-Release:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build LambdaEngine Release
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: LambdaEngine/LambdaEngine.vcxproj
@@ -25,8 +39,15 @@ jobs:
   Build-CrazyCanvas-Debug:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build CrazyCanvas Debug
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: CrazyCanvas/CrazyCanvas.vcxproj
@@ -35,8 +56,15 @@ jobs:
   Build-CrazyCanvas-Release:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build CrazyCanvas Release
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: CrazyCanvas/CrazyCanvas.vcxproj
@@ -45,8 +73,15 @@ jobs:
   Build-Sandbox-Debug:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build Sandbox Debug
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: Sandbox/Sandbox.vcxproj
@@ -55,8 +90,15 @@ jobs:
   Build-Sandbox-Release:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build Sandbox Release
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: Sandbox/Sandbox.vcxproj
@@ -65,8 +107,15 @@ jobs:
   Build-Client-Debug:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build Client Debug
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: Client/Client.vcxproj
@@ -75,8 +124,15 @@ jobs:
   Build-Client-Release:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build Client Release
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: Client/Client.vcxproj
@@ -85,8 +141,15 @@ jobs:
   Build-Server-Debug:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build Server Debug
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: Server/Server.vcxproj
@@ -95,8 +158,15 @@ jobs:
   Build-Server-Release:
     runs-on: [self-hosted, Windows, X64]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Build Server Release
-        uses: IbexOmega/lambda-build-action@v1.0
+        uses: IbexOmega/lambda-build-action@v1.0.1
         with:
           branch: ${{ github.ref }}
           project-path: Server/Server.vcxproj

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build LambdaEngine Debug
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: LambdaEngine/LambdaEngine.vcxproj
@@ -30,7 +30,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build LambdaEngine Release
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: LambdaEngine/LambdaEngine.vcxproj
@@ -47,7 +47,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build CrazyCanvas Debug
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: CrazyCanvas/CrazyCanvas.vcxproj
@@ -64,7 +64,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build CrazyCanvas Release
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: CrazyCanvas/CrazyCanvas.vcxproj
@@ -81,7 +81,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build Sandbox Debug
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: Sandbox/Sandbox.vcxproj
@@ -98,7 +98,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build Sandbox Release
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: Sandbox/Sandbox.vcxproj
@@ -115,7 +115,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build Client Debug
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: Client/Client.vcxproj
@@ -132,7 +132,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build Client Release
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: Client/Client.vcxproj
@@ -149,7 +149,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build Server Debug
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: Server/Server.vcxproj
@@ -166,7 +166,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build Server Release
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           branch: ${{ github.ref }}
           project-path: Server/Server.vcxproj

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -5,37 +5,15 @@ on:
         - master
 
 jobs:
-  Pre-Build:
-    runs-on: [self-hosted, Windows, X64]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Read LFS Cache
-        run: cp -r -Force ../../.git/lfs .git/
-
-      # Fetches changes and replaces LFS pointers with their actual contents
-      - name: Pull From LFS
-        run: git lfs pull
-
-      - name: Update LFS Cache
-        run: cp -r -Force .git/lfs ../../.git/
-
   benchmark:
-    runs-on: [self-hosted, Windows, X64]
-    needs: Pre-Build
-
+    runs-on: [self-hosted, benchmarker, Windows, X64]
     steps:
-      - name: Execute Premake
-        run: .\premake5.exe vs2019
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
-
       - name: Build CrazyCanvas Production
-        run: msbuild CrazyCanvas/CrazyCanvas.vcxproj -p:Configuration="Production x64_StaticLib" -p:Platform=x64
+        uses: IbexOmega/lambda-build-action@v1.0
+        with:
+          branch: ${{ github.ref }}
+          project-path: CrazyCanvas/CrazyCanvas.vcxproj
+          build-configuration: Production x64_StaticLib
 
       - name: Benchmark
         run: python .github/workflows/benchmark.py --bin .\Build\bin\Production-windows-x86_64-x64_StaticLib\CrazyCanvas\CrazyCanvas.exe

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Build CrazyCanvas Production
-        uses: IbexOmega/lambda-build-action@v1.0.1
+        uses: IbexOmega/lambda-build-action@v1.0.2
         with:
           project-path: CrazyCanvas/CrazyCanvas.vcxproj
           build-configuration: Production x64_StaticLib

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -8,10 +8,16 @@ jobs:
   benchmark:
     runs-on: [self-hosted, benchmarker, Windows, X64]
     steps:
-      - name: Build CrazyCanvas Production
-        uses: IbexOmega/lambda-build-action@v1.0
+      - uses: actions/checkout@v2
         with:
-          branch: ${{ github.ref }}
+          submodules: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.1
+
+      - name: Build CrazyCanvas Production
+        uses: IbexOmega/lambda-build-action@v1.0.1
+        with:
           project-path: CrazyCanvas/CrazyCanvas.vcxproj
           build-configuration: Production x64_StaticLib
 


### PR DESCRIPTION
Build action is in https://github.com/IbexOmega/lambda-build-action/tree/v1.0

The same steps for building a project will be used, the only difference is that building a project will be performed in a single job. Previously, we'd have one pre-build job and one actual job. The problem with that is that between the pre-build and build jobs, the github action runner could start building a different branch, with the current branch's code.