### PR TITLE
Fix crash when deleting entities

### DIFF
--- a/LambdaEngine/Include/ECS/ComponentStorage.h
+++ b/LambdaEngine/Include/ECS/ComponentStorage.h
@@ -125,7 +125,7 @@ namespace LambdaEngine
 	inline Comp& ComponentStorage::GetComponent(Entity entity)
 	{
 		ComponentArray<Comp>* pCompArray = GetComponentArray<Comp>();
-		VALIDATE_MSG(pCompArray, "Trying to fetch a component which was not registered!");
+		VALIDATE_MSG(pCompArray, "Trying to fetch an unregistered component type!");
 
 		return pCompArray->GetData(entity);
 	}
@@ -134,7 +134,7 @@ namespace LambdaEngine
 	inline const Comp& ComponentStorage::GetComponent(Entity entity) const
 	{
 		const ComponentArray<Comp>* pCompArray = GetComponentArray<Comp>();
-		VALIDATE_MSG(pCompArray, "Trying to fetch a component which was not registered!");
+		VALIDATE_MSG(pCompArray, "Trying to fetch an unregistered component type!");
 
 		return pCompArray->GetData(entity);
 	}

--- a/LambdaEngine/Source/ECS/ECSCore.cpp
+++ b/LambdaEngine/Source/ECS/ECSCore.cpp
@@ -181,11 +181,16 @@ namespace LambdaEngine
 	void ECSCore::PerformEntityDeletions()
 	{
 		const EntityRegistryPage& registryPage = m_EntityRegistry.GetTopRegistryPage();
+		/*	The component types to delete of each entity. It is a copy of the entity's set of component types in
+			the entity registry. Copying the set is necessary as the set is popped each time it is iterated. */
+		TArray<const ComponentType*> componentTypes;
 
 		for (Entity entity : m_EntitiesToDelete)
 		{
 			// Delete every component belonging to the entity
-			const std::unordered_set<const ComponentType*>& componentTypes = registryPage.IndexID(entity);
+			const std::unordered_set<const ComponentType*>& componentTypesSet = registryPage.IndexID(entity);
+			componentTypes.Assign(componentTypesSet.begin(), componentTypesSet.end());
+
 			for (const ComponentType* pComponentType : componentTypes)
 				DeleteComponent(entity, pComponentType);
 
@@ -199,6 +204,7 @@ namespace LambdaEngine
 
 	bool ECSCore::DeleteComponent(Entity entity, const ComponentType* pComponentType)
 	{
+		m_EntityRegistry.DeregisterComponentType(entity, pComponentType);
 		m_EntityPublisher.UnpublishComponent(entity, pComponentType);
 		return m_ComponentStorage.DeleteComponent(entity, pComponentType);
 	}

--- a/LambdaEngine/Source/ECS/EntityPublisher.cpp
+++ b/LambdaEngine/Source/ECS/EntityPublisher.cpp
@@ -183,12 +183,13 @@ namespace LambdaEngine
             // Use indices stored in the component type -> component storage mapping to get the component subscription
             EntitySubscription& sysSub = m_SubscriptionStorage.IndexID(subBucketItr->second.SystemID)[subBucketItr->second.SubIdx];
 
-            // Check if this component was excluded, and therefore preventing an entity to being pushed to a subscriber
-            if (!sysSub.pSubscriber->HasElement(entity) && m_pEntityRegistry->EntityHasAllowedTypes(entity, sysSub.ComponentTypes, sysSub.ExcludedComponentTypes))
+            if (!sysSub.pSubscriber->HasElement(entity))
             {
-                sysSub.pSubscriber->PushBack(entity);
-                subBucketItr++;
-                continue;
+                // Check if this component was excluded, and therefore preventing an entity to being pushed to a subscriber
+                if (m_pEntityRegistry->EntityHasAllowedTypes(entity, sysSub.ComponentTypes, sysSub.ExcludedComponentTypes))
+                {
+                    sysSub.pSubscriber->PushBack(entity);
+                }
             }
             else
             {

--- a/LambdaEngine/Source/Physics/PhysicsSystem.cpp
+++ b/LambdaEngine/Source/Physics/PhysicsSystem.cpp
@@ -274,13 +274,11 @@ namespace LambdaEngine
 
 	void PhysicsSystem::StaticCollisionDestructor(StaticCollisionComponent& collisionComponent)
 	{
-		m_pScene->removeActor(*collisionComponent.pActor);
 		PX_RELEASE(collisionComponent.pActor);
 	}
 
 	void PhysicsSystem::CharacterColliderDestructor(CharacterColliderComponent& characterColliderComponent)
 	{
-		m_pScene->removeActor(*characterColliderComponent.pController->getActor());
 		PX_RELEASE(characterColliderComponent.pController);
 		SAFEDELETE(characterColliderComponent.Filters.mFilterData);
 	}

--- a/Sandbox/Source/States/SandboxState.cpp
+++ b/Sandbox/Source/States/SandboxState.cpp
@@ -157,7 +157,7 @@ void SandboxState::Init()
 		pECS->AddComponent<RotationComponent>(entity, { true, glm::identity<glm::quat>() });
 		pECS->AddComponent<AnimationComponent>(entity, robotAnimationComp);
 		pECS->AddComponent<MeshComponent>(entity, robotMeshComp);
-		
+
 		position = glm::vec3(0.0f, 1.25f, 0.0f);
 		robotAnimationComp.IsLooping	= true;
 		robotAnimationComp.NumLoops		= 10;


### PR DESCRIPTION
It was due to two things: a bad if-statement (should be nested) and not deregistering component types from the entity registry when deleting them.