### PR TITLE
Profiler VK_NOT_READY warning 

### DIFF
--- a/LambdaEngine/Include/Debug/GPUProfiler.h
+++ b/LambdaEngine/Include/Debug/GPUProfiler.h
@@ -75,7 +75,6 @@ namespace LambdaEngine
 		static GPUProfiler* Get();
 
 	private:
-		void SaveResults();
 		std::string GetTimeUnitName() const;
 
 	private:
@@ -87,7 +86,6 @@ namespace LambdaEngine
 		uint32_t m_NextIndex			= 0;
 		uint32_t m_TimestampValidBits	= 0;
 		float m_TimestampPeriod			= 0.0f;
-		uint64_t m_StartTimestamp		= 0;
 
 		THashTable<String, Timestamp>	m_Results;
 		TArray<PlotResult>				m_PlotResults;

--- a/LambdaEngine/Include/Rendering/Core/API/QueryHeap.h
+++ b/LambdaEngine/Include/Rendering/Core/API/QueryHeap.h
@@ -12,6 +12,12 @@ namespace LambdaEngine
 		uint32		PipelineStatisticsFlags = 0;
 	};
 
+	struct QueryHeapAvailabilityResult
+	{
+		uint64 Result		= 0;
+		uint64 Availability	= 0;
+	};
+
 	class QueryHeap : public DeviceChild
 	{
 	public:
@@ -24,6 +30,16 @@ namespace LambdaEngine
 		*	 pData		- Array of type uint64 that the results will be written to, must have size of queryCount
 		*/
 		virtual bool GetResults(uint32 firstQuery, uint32 queryCount, uint64 dataSize, uint64* pData) const = 0;
+
+		/*
+		* Get the results from the query heap. The dataSize should be twice as large as the amount of queries.
+		* This is because the availability is also collected with this function, and it is laid out in memory as follows:
+		* [[result0,availability0], [result1,availability1]] where each variable is an uint64
+		*	 firstQuery	- Index to the first query in the heap starting at zero
+		*	 queryCount	- Number of queries to get results from
+		*	 pData		- Array of type QueryHeapAvailabilityResult that the results will be written to, must have size of queryCount
+		*/
+		virtual bool GetResultsAvailable(uint32 firstQuery, uint32 queryCount, uint64 dataSize, QueryHeapAvailabilityResult* pData) const = 0;
 
 		/*
 		* Returns the API-specific handle to the underlaying QueryHeap-resource

--- a/LambdaEngine/Include/Rendering/Core/Vulkan/QueryHeapVK.h
+++ b/LambdaEngine/Include/Rendering/Core/Vulkan/QueryHeapVK.h
@@ -30,6 +30,8 @@ namespace LambdaEngine
 		// QueryHeap interface
 		virtual bool GetResults(uint32 firstQuery, uint32 queryCount, uint64 dataSize, uint64* pData) const override final;
 
+		virtual bool GetResultsAvailable(uint32 firstQuery, uint32 queryCount, uint64 dataSize, QueryHeapAvailabilityResult* pData) const override final;
+
 		FORCEINLINE virtual uint64 GetHandle() const override final
 		{
 			return reinterpret_cast<uint64>(m_QueryPool);

--- a/LambdaEngine/Source/Debug/GPUProfiler.cpp
+++ b/LambdaEngine/Source/Debug/GPUProfiler.cpp
@@ -128,7 +128,7 @@ namespace LambdaEngine
 					m_TimeSinceUpdate = 0.0f;
 					float average = 0.0f;
 
-					for (uint32_t i = 0; i < m_PlotDataSize; i++)
+					for (uint32 i = 0; i < m_PlotDataSize; i++)
 					{
 						average += stage.Results[i];
 					}
@@ -159,7 +159,7 @@ namespace LambdaEngine
 					"Fragment shader invocations        "
 				};
 
-				for (uint32_t i = 0; i < m_GraphicsStats.GetSize(); i++) {
+				for (uint32 i = 0; i < m_GraphicsStats.GetSize(); i++) {
 					std::string caption = statNames[i] + ": %d";
 					ImGui::BulletText(caption.c_str(), m_GraphicsStats[i]);
 				}
@@ -197,7 +197,7 @@ namespace LambdaEngine
 #endif
 	}
 
-	void GPUProfiler::CreateTimestamps(uint32_t listCount)
+	void GPUProfiler::CreateTimestamps(uint32 listCount)
 	{
 #ifdef LAMBDA_DEBUG
 		// Need two timestamps per list
@@ -250,7 +250,7 @@ namespace LambdaEngine
 				PlotResult plotResult = {};
 				plotResult.Name = name;
 				plotResult.Results.Resize(m_PlotDataSize);
-					for (uint32_t i = 0; i < m_PlotDataSize; i++)
+					for (uint32 i = 0; i < m_PlotDataSize; i++)
 						plotResult.Results[i] = 0.0f;
 
 				m_PlotResults.PushBack(plotResult);
@@ -289,9 +289,9 @@ namespace LambdaEngine
 			return;
 		}
 
-		uint32_t timestampCount = 2;
+		uint32 timestampCount = 2;
 		TArray<QueryHeapAvailabilityResult> results(timestampCount);
-		bool res = m_pTimestampHeap->GetResultsAvailable((uint32_t)m_Timestamps[pCommandList].Start, timestampCount, timestampCount * sizeof(QueryHeapAvailabilityResult), results.GetData());
+		bool res = m_pTimestampHeap->GetResultsAvailable((uint32)m_Timestamps[pCommandList].Start, timestampCount, timestampCount * sizeof(QueryHeapAvailabilityResult), results.GetData());
 
 		if (res)
 		{
@@ -305,8 +305,8 @@ namespace LambdaEngine
 				}
 			}
 
-			uint64_t start = glm::bitfieldExtract<uint64_t>(results[0].Result, 0, m_TimestampValidBits);
-			uint64_t end = glm::bitfieldExtract<uint64_t>(results[1].Result, 0, m_TimestampValidBits);
+			uint64 start = glm::bitfieldExtract<uint64>(results[0].Result, 0, m_TimestampValidBits);
+			uint64 end = glm::bitfieldExtract<uint64>(results[1].Result, 0, m_TimestampValidBits);
 
 			if (m_StartTimestamp == 0)
 				m_StartTimestamp = start;
@@ -314,7 +314,7 @@ namespace LambdaEngine
 			const String& name = m_Timestamps[pCommandList].Name;
 			m_Results[name].Start = start;
 			m_Results[name].End = end;
-			float duration = ((end - start) * m_TimestampPeriod) / (uint64_t)m_TimeUnit;
+			float duration = ((end - start) * m_TimestampPeriod) / (uint64)m_TimeUnit;
 			m_Results[name].Duration = duration;
 
 			if (duration > m_CurrentMaxDuration[name])
@@ -340,7 +340,7 @@ namespace LambdaEngine
 	void GPUProfiler::ResetTimestamp(CommandList* pCommandList)
 	{
 #ifdef LAMBDA_DEBUG
-		pCommandList->ResetQuery(m_pTimestampHeap, (uint32_t)m_Timestamps[pCommandList].Start, 2);
+		pCommandList->ResetQuery(m_pTimestampHeap, (uint32)m_Timestamps[pCommandList].Start, 2);
 #endif
 	}
 
@@ -411,10 +411,10 @@ namespace LambdaEngine
 		file << "{\"otherData\": {}, \"displayTimeUnit\": \"ms\", \"traceEvents\": [";
 		file.flush();
 
-		uint32_t j = 0;
+		uint32 j = 0;
 		for (auto& res : m_Results)
 		{
-			//for (uint32_t i = 0; i < res.second.size(); i++, j++)
+			//for (uint32 i = 0; i < res.second.size(); i++, j++)
 			//{
 				if (j > 0) file << ",";
 
@@ -427,7 +427,7 @@ namespace LambdaEngine
 				file << "\"ph\": \"X\",";
 				file << "\"pid\": " << 1 << ",";
 				file << "\"tid\": " << 0 << ",";
-				file << "\"ts\": " << (((res.second.Start - m_StartTimestamp) * m_TimestampPeriod) / (uint64_t)m_TimeUnit) << ",";
+				file << "\"ts\": " << (((res.second.Start - m_StartTimestamp) * m_TimestampPeriod) / (uint64)m_TimeUnit) << ",";
 				file << "\"dur\": " << res.second.Duration;
 				file << "}";
 				j++;

--- a/LambdaEngine/Source/Debug/GPUProfiler.cpp
+++ b/LambdaEngine/Source/Debug/GPUProfiler.cpp
@@ -182,7 +182,6 @@ namespace LambdaEngine
 		m_NextIndex				= 0;
 		m_TimestampValidBits	= 0;
 		m_TimestampPeriod		= 0.0f;
-		m_StartTimestamp		= 0;
 
 		m_Results.clear();
 		m_PlotResults.Clear();
@@ -308,9 +307,6 @@ namespace LambdaEngine
 			uint64 start = glm::bitfieldExtract<uint64>(results[0].Result, 0, m_TimestampValidBits);
 			uint64 end = glm::bitfieldExtract<uint64>(results[1].Result, 0, m_TimestampValidBits);
 
-			if (m_StartTimestamp == 0)
-				m_StartTimestamp = start;
-
 			const String& name = m_Timestamps[pCommandList].Name;
 			m_Results[name].Start = start;
 			m_Results[name].End = end;
@@ -393,51 +389,6 @@ namespace LambdaEngine
 	{
 		static GPUProfiler instance;
 		return &instance;
-	}
-
-	void GPUProfiler::SaveResults()
-	{
-		/*
-			GPU Timestamps are not optimal to represent in a serial fashion that
-			chrome://tracing does.
-			This feature is therefore possible unnecessary
-		*/
-
-#ifdef LAMBDA_DEBUG
-		const char* filePath = "GPUResults.txt";
-
-		std::ofstream file;
-		file.open(filePath);
-		file << "{\"otherData\": {}, \"displayTimeUnit\": \"ms\", \"traceEvents\": [";
-		file.flush();
-
-		uint32 j = 0;
-		for (auto& res : m_Results)
-		{
-			//for (uint32 i = 0; i < res.second.size(); i++, j++)
-			//{
-				if (j > 0) file << ",";
-
-				std::string name = "Render Graph Graphics Command List";
-				std::replace(name.begin(), name.end(), '"', '\'');
-
-				file << "{";
-				file << "\"name\": \"" << name << " " << j << "\",";
-				file << "\"cat\": \"function\",";
-				file << "\"ph\": \"X\",";
-				file << "\"pid\": " << 1 << ",";
-				file << "\"tid\": " << 0 << ",";
-				file << "\"ts\": " << (((res.second.Start - m_StartTimestamp) * m_TimestampPeriod) / (uint64)m_TimeUnit) << ",";
-				file << "\"dur\": " << res.second.Duration;
-				file << "}";
-				j++;
-			//}
-		}
-
-		file << "]" << std::endl << "}";
-		file.flush();
-		file.close();
-#endif
 	}
 
 	std::string GPUProfiler::GetTimeUnitName() const

--- a/LambdaEngine/Source/Debug/GPUProfiler.cpp
+++ b/LambdaEngine/Source/Debug/GPUProfiler.cpp
@@ -14,9 +14,6 @@
 #include <fstream>
 #include <sstream>
 
-// TODO: Remove
-#define LAMBDA_DEBUG
-
 namespace LambdaEngine
 {
 	GPUProfiler::GPUProfiler() : m_TimeUnit(TimeUnit::MILLI), m_PlotDataSize(100), m_UpdateFreq(1.0f)

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/QueryHeapVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/QueryHeapVK.cpp
@@ -65,4 +65,21 @@ namespace LambdaEngine
 			return true;
 		}
 	}
+
+	bool QueryHeapVK::GetResultsAvailable(uint32 firstQuery, uint32 queryCount, uint64 dataSize, QueryHeapAvailabilityResult* pData) const
+	{
+		VkResult result = vkGetQueryPoolResults(m_pDevice->Device, m_QueryPool, firstQuery, queryCount, dataSize, reinterpret_cast<void*>(pData), sizeof(QueryHeapAvailabilityResult), VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WITH_AVAILABILITY_BIT);
+
+		// QueryPoolResults return a VK_NOT_READY if some requested queries were not available for collection.
+		// The available uint64 will be non-zero if the result is finished.
+		if (result != VK_SUCCESS && result != VK_NOT_READY)
+		{
+			LOG_VULKAN_ERROR(result, "[QueryHeapVK]: Failed to retrive query results");
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
 }


### PR DESCRIPTION
Changes:
* Made it ok to try to get a timestamp which has not yet finished.

Notes:
* No _warning_ will be printed when trying to get a timestamp which has not finished, however the validation layer will still print out general information about it when it happens. This is not a bug and and the only way to suppress it is to suppress all, or filtered, _information_ (not _warnings_) that the validation layer debug logger prints.