### PR TITLE
Entity deserialization

### DIFF
--- a/LambdaEngine/Include/ECS/Component.h
+++ b/LambdaEngine/Include/ECS/Component.h
@@ -63,5 +63,12 @@ namespace LambdaEngine
 		 * Does not write to the buffer if said size is greater than the provided bufferSize.
 		*/
 		std::function<uint32(const Comp& component, uint8* pBuffer, uint32 bufferSize)> Serialize;
+		/**
+		 * Deserialize the buffer into the referenced component. Does not add or register the component.
+		 * The passed component could be referencing an already existing component. One should be aware of this to
+		 * to avoid allocating memory for members of the component without deleting previous allocations.
+		 * \return Success or failure.
+		*/
+		std::function<bool(Comp& component, uint32 serializationSize, const uint8* pBuffer)> Deserialize;
 	};
 }

--- a/LambdaEngine/Include/ECS/ComponentStorage.h
+++ b/LambdaEngine/Include/ECS/ComponentStorage.h
@@ -34,11 +34,8 @@ namespace LambdaEngine
 
 		bool DeleteComponent(Entity entity, const ComponentType* pComponentType);
 
-		void SerializeComponent(Entity entity, uint8* pBuffer, uint32 bufferSize);
-
-		template <typename Comp>
-		uint32 SerializeComponent(const Comp& component, uint8* pBuffer, uint32 bufferSize) const;
 		uint32 SerializeComponent(Entity entity, const ComponentType* pComponentType, uint8* pBuffer, uint32 bufferSize) const;
+		bool DeserializeComponent(Entity entity, const ComponentType* pComponentType, uint32 componentDataSize, const uint8* pBuffer, bool& entityHadComponent);
 
 		template<typename Comp>
 		bool HasType() const;
@@ -56,8 +53,11 @@ namespace LambdaEngine
 		template<typename Comp>
 		const ComponentArray<Comp>* GetComponentArray() const;
 
+		const ComponentType* GetComponentType(uint32 componentTypeHash) const;
+
 	private:
 		std::unordered_map<const ComponentType*, uint32> m_CompTypeToArrayMap;
+		std::unordered_map<ComponentTypeHash, const ComponentType*> m_TypeHashToCompTypeMap;
 
 		TArray<IComponentArray*> m_ComponentArrays;
 		// All component types with dirty flags. Used for resetting dirty flags at the end of each frame.
@@ -73,6 +73,8 @@ namespace LambdaEngine
 		m_CompTypeToArrayMap[pComponentType] = m_ComponentArrays.GetSize();
 		ComponentArray<Comp>* pCompArray = DBG_NEW ComponentArray<Comp>();
 		m_ComponentArrays.PushBack(pCompArray);
+
+		m_TypeHashToCompTypeMap[pComponentType->GetHash()] = pComponentType;
 
 		if constexpr (Comp::HasDirtyFlag())
 		{
@@ -112,13 +114,6 @@ namespace LambdaEngine
 
 		// Add the new component.
 		pCompArray->Remove(entity);
-	}
-
-	template <typename Comp>
-	inline uint32 ComponentStorage::SerializeComponent(const Comp& component, uint8* pBuffer, uint32 bufferSize) const
-	{
-		const ComponentArray<Comp>* pComponentArray = GetComponentArray<Comp>();
-		return pComponentArray->SerializeComponent(component, pBuffer, bufferSize);
 	}
 
 	template<typename Comp>

--- a/LambdaEngine/Include/ECS/ComponentType.h
+++ b/LambdaEngine/Include/ECS/ComponentType.h
@@ -11,7 +11,7 @@ namespace LambdaEngine
 		constexpr ComponentType::ComponentType(const ConstString& className) :
 			m_ClassName(className)
 		{
-			
+
 		}
 
 		constexpr uint32 ComponentType::GetHash() const
@@ -32,6 +32,24 @@ namespace LambdaEngine
 	private:
 		const ConstString m_ClassName;
 	};
+
+	/*	ComponentTypeHash allows one to use an already hashed uint32 as a key in an unordered associative container.
+		This is used to for a <uint32, ComponentType> mapping, which is used when deserializing entities. When sending entity data over the internet,
+		only the hash of each component type is sent, not its name string. Hence the mapping is needed. */
+	class ComponentTypeHash
+	{
+	public:
+		ComponentTypeHash(uint32 hash) :
+			Hash(hash)
+		{}
+
+		bool operator==(const ComponentTypeHash& other) const
+		{
+			return Hash == other.Hash;
+		}
+
+		const uint32 Hash;
+	};
 }
 
 namespace std
@@ -39,9 +57,18 @@ namespace std
 	template<>
 	struct hash<const LambdaEngine::ComponentType*>
 	{
-		size_t operator()(const LambdaEngine::ComponentType* componentType) const
+		size_t operator()(const LambdaEngine::ComponentType* pComponentType) const
 		{
-			return componentType->GetHash();
+			return pComponentType->GetHash();
+		}
+	};
+
+	template<>
+	struct hash<LambdaEngine::ComponentTypeHash>
+	{
+		size_t operator()(const LambdaEngine::ComponentTypeHash& typeHash) const
+		{
+			return typeHash.Hash;
 		}
 	};
 }

--- a/LambdaEngine/Include/ECS/ECSCore.h
+++ b/LambdaEngine/Include/ECS/ECSCore.h
@@ -78,26 +78,27 @@ namespace LambdaEngine
 		void ReinstateTopRegistryPage();
 
 		/**
-		* Serializes the entity into the following format:
-		* Total Serialization Size			- 4 bytes (includes the size of the header)
-		* Entity ID							- 4 bytes
-		* Component Count					- 4 bytes
-		* [
-		*	Component Serialization Size	- 4 bytes (includes the size of the header)
-		* 	Component Type Hash				- 4 bytes
-		*	Component Data					- Component Serialization Size
-		* ]
-		*
-		* \return The required of the serialization.
-		* If said return value is greater than the provided bufferSize, the serialization failed.
-		* Providing a zero bufferSize and nullptr pBuffer is a slow but valid strategy for getting the required buffer size.
+		 * Serializes the entity into the following format:
+		 * Total Serialization Size			- 4 bytes (includes the size of the header)
+		 * Entity ID						- 4 bytes
+		 * Component Count					- 4 bytes
+		 * [
+		 *	Component Serialization Size	- 4 bytes (includes the size of the header)
+		 * 	Component Type Hash				- 4 bytes
+		 *	Component Data					- Component Serialization Size
+		 * ]
+		 *
+		 * @param componentsFilter The component types to serialize
+		 * \return The required of the serialization.
+		 * If said return value is greater than the provided bufferSize, the serialization failed.
+		 * Providing a zero bufferSize and nullptr pBuffer is a slow but valid strategy for getting the required buffer size.
 		*/
-		uint32 SerializeEntity(Entity entity, uint8* pBuffer, uint32 bufferSize) const;
-
-		// See the above documentation for the layout of a component serialization
-		template <typename Comp>
-		uint32 SerializeComponent(const Comp& component, uint8* pBuffer, uint32 bufferSize) const;
-		uint32 SerializeComponent(Entity entity, const ComponentType* pComponentType, uint8* pBuffer, uint32 bufferSize) const;
+		uint32 SerializeEntity(Entity entity, const TArray<const ComponentType*>& componentsFilter, uint8* pBuffer, uint32 bufferSize) const;
+		/**
+		 * DeserializeEntity uses the entity and component data to add new components and update existing ones.
+		 * \return Whether deserializing all components succeeded.
+		*/
+		bool DeserializeEntity(const uint8* pBuffer);
 
         Timestamp GetDeltaTime() const { return m_DeltaTime; }
 
@@ -180,11 +181,5 @@ namespace LambdaEngine
 	{
 		std::scoped_lock<SpinLock> lock(m_LockRemoveComponent);
 		m_ComponentsToDelete.PushBack({entity, Comp::Type()});
-	}
-
-	template<typename Comp>
-	inline uint32 ECSCore::SerializeComponent(const Comp& component, uint8* pBuffer, uint32 bufferSize) const
-	{
-		return m_ComponentStorage.SerializeComponent<Comp>(component, pBuffer, bufferSize);
 	}
 }

--- a/LambdaEngine/Source/ECS/ComponentStorage.cpp
+++ b/LambdaEngine/Source/ECS/ComponentStorage.cpp
@@ -37,6 +37,12 @@ namespace LambdaEngine
 		return pComponentArray->SerializeComponent(entity, pBuffer, bufferSize);
 	}
 
+	bool ComponentStorage::DeserializeComponent(Entity entity, const ComponentType* pComponentType, uint32 componentDataSize, const uint8* pBuffer, bool& entityHadComponent)
+	{
+		IComponentArray* pComponentArray = GetComponentArray(pComponentType);
+		return pComponentArray->DeserializeComponent(entity, pBuffer, componentDataSize, entityHadComponent);
+	}
+
 	IComponentArray* ComponentStorage::GetComponentArray(const ComponentType* pComponentType)
 	{
 		auto arrayItr = m_CompTypeToArrayMap.find(pComponentType);
@@ -55,5 +61,11 @@ namespace LambdaEngine
 		{
 			pArray->ResetDirtyFlags();
 		}
+	}
+
+	const ComponentType* ComponentStorage::GetComponentType(uint32 componentTypeHash) const
+	{
+		auto componentTypeItr = m_TypeHashToCompTypeMap.find(componentTypeHash);
+		return componentTypeItr != m_TypeHashToCompTypeMap.end() ? componentTypeItr->second : nullptr;
 	}
 }

--- a/LambdaEngine/Source/ECS/ECSCore.cpp
+++ b/LambdaEngine/Source/ECS/ECSCore.cpp
@@ -97,11 +97,8 @@ namespace LambdaEngine
 		}
 	}
 
-	uint32 ECSCore::SerializeEntity(Entity entity, uint8* pBuffer, uint32 bufferSize) const
+	uint32 ECSCore::SerializeEntity(Entity entity, const TArray<const ComponentType*>& componentsFilter, uint8* pBuffer, uint32 bufferSize) const
 	{
-		const EntityRegistryPage& entityPage = m_EntityRegistry.GetTopRegistryPage();
-		const std::unordered_set<const ComponentType*>& componentTypes = entityPage.IndexID(entity);
-
 		/*	EntitySerializationHeader is written to the beginning of the buffer. This is done last, when the size of
 			the serialization is known. */
 		uint8* pHeaderPosition = pBuffer;
@@ -117,14 +114,23 @@ namespace LambdaEngine
 
 		// Serialize all components
 		uint32 requiredTotalSize = headerSize;
-		for (const ComponentType* pComponentType : componentTypes)
+		uint32 serializedComponentsCount = 0u;
+		for (const ComponentType* pComponentType : componentsFilter)
 		{
+			const IComponentArray* pComponentArray = m_ComponentStorage.GetComponentArray(pComponentType);
+			if (pComponentArray && !pComponentArray->HasComponent(entity))
+			{
+				LOG_WARNING("Attempted to serialize a component type which entity %d does not have: %s", entity, pComponentType->GetName());
+				continue;
+			}
+
 			const uint32 requiredComponentSize = m_ComponentStorage.SerializeComponent(entity, pComponentType, pBuffer, remainingSize);
 			requiredTotalSize += requiredComponentSize;
 			if (requiredComponentSize <= remainingSize)
 			{
 				pBuffer += requiredComponentSize;
 				remainingSize -= requiredComponentSize;
+				++serializedComponentsCount;
 			}
 		}
 
@@ -135,7 +141,7 @@ namespace LambdaEngine
 			{
 				.TotalSerializationSize	= requiredTotalSize,
 				.Entity					= entity,
-				.ComponentCount			= (uint32)componentTypes.size()
+				.ComponentCount			= serializedComponentsCount
 			};
 
 			memcpy(pHeaderPosition, &header, headerSize);
@@ -144,9 +150,42 @@ namespace LambdaEngine
 		return requiredTotalSize;
 	}
 
-	uint32 ECSCore::SerializeComponent(Entity entity, const ComponentType* pComponentType, uint8* pBuffer, uint32 bufferSize) const
+	bool ECSCore::DeserializeEntity(const uint8* pBuffer)
 	{
-		return m_ComponentStorage.SerializeComponent(entity, pComponentType, pBuffer, bufferSize);
+		constexpr const uint32 entityHeaderSize = sizeof(EntitySerializationHeader);
+		EntitySerializationHeader entityHeader;
+		memcpy(&entityHeader, pBuffer, entityHeaderSize);
+		pBuffer += entityHeaderSize;
+
+		// Deserialize each component. If the entity already has the component, update its data. Otherwise, create it.
+		const uint32 componentCount = entityHeader.ComponentCount;
+		bool success = true;
+		for (uint32 componentIdx = 0u; componentIdx < componentCount; ++componentIdx)
+		{
+			constexpr const uint32 componentHeaderSize = sizeof(ComponentSerializationHeader);
+			ComponentSerializationHeader componentHeader;
+			memcpy(&componentHeader, pBuffer, componentHeaderSize);
+			pBuffer += componentHeaderSize;
+
+			const ComponentType* pComponentType = m_ComponentStorage.GetComponentType(componentHeader.TypeHash);
+			if (!pComponentType)
+			{
+				LOG_WARNING("Attempted to deserialize an unregistered component type, hash: %d", componentHeader.TypeHash);
+				success = false;
+				continue;
+			}
+
+			bool entityHadComponent = false;
+			const uint32 componentDataSize = componentHeader.TotalSerializationSize - componentHeaderSize;
+			success = m_ComponentStorage.DeserializeComponent(entityHeader.Entity, pComponentType, componentDataSize, pBuffer, entityHadComponent) && success;
+
+			if (!entityHadComponent)
+			{
+				m_ComponentsToRegister.PushBack({entityHeader.Entity, pComponentType});
+			}
+		}
+
+		return success;
 	}
 
 	void ECSCore::PerformComponentRegistrations()

--- a/LambdaEngine/Source/ECS/ECSCore.cpp
+++ b/LambdaEngine/Source/ECS/ECSCore.cpp
@@ -157,6 +157,8 @@ namespace LambdaEngine
 		memcpy(&entityHeader, pBuffer, entityHeaderSize);
 		pBuffer += entityHeaderSize;
 
+		ASSERT_MSG(m_EntityRegistry.GetTopRegistryPage().HasElement(entityHeader.Entity), "Attempted to deserialize unknown entity: %d", entityHeader.Entity);
+
 		// Deserialize each component. If the entity already has the component, update its data. Otherwise, create it.
 		const uint32 componentCount = entityHeader.ComponentCount;
 		bool success = true;

--- a/Sandbox/Source/States/SandboxState.cpp
+++ b/Sandbox/Source/States/SandboxState.cpp
@@ -157,7 +157,7 @@ void SandboxState::Init()
 		pECS->AddComponent<RotationComponent>(entity, { true, glm::identity<glm::quat>() });
 		pECS->AddComponent<AnimationComponent>(entity, robotAnimationComp);
 		pECS->AddComponent<MeshComponent>(entity, robotMeshComp);
-		
+
 		position = glm::vec3(0.0f, 1.25f, 0.0f);
 		robotAnimationComp.IsLooping	= true;
 		robotAnimationComp.NumLoops		= 10;


### PR DESCRIPTION
Adds `ECSCore::DeserializeEntity`, which accepts a serialized entity. For each component in the serialization, the existence of the component is checked. If the component already exists, the current instance is updated. Otherwise, the component is created, registered and published.