### PR TITLE
Use default config path upon missing config file for state

### DIFF
--- a/LambdaEngine/Source/Engine/EngineConfig.cpp
+++ b/LambdaEngine/Source/Engine/EngineConfig.cpp
@@ -26,10 +26,17 @@ namespace LambdaEngine
 		FILE* pFile = fopen(s_FilePath.c_str(), "r");
 		if (!pFile)
 		{
-			// TODO: We should probably create a default so that the user does not need to have a config file to even run the application
-			LOG_WARNING("Engine config could not be opened: %s", s_FilePath.c_str());
-			DEBUGBREAK();
-			return false;
+			// The state does not have its own config file, try the default config path
+			s_FilePath = "engine_config_" + String(pDefaultPathPostfix) + ".json";
+
+			pFile = fopen(s_FilePath.c_str(), "r");
+			if (!pFile)
+			{
+				// TODO: We should probably create a default so that the user does not need to have a config file to even run the application
+				LOG_WARNING("Engine config could not be opened: %s", s_FilePath.c_str());
+				DEBUGBREAK();
+				return false;
+			}
 		}
 
 		char readBuffer[2048];


### PR DESCRIPTION
In the recent 'merge projects' branch which was merged to master, each state could have its own config file. Since they don't need to have one though, there needs to be a default config path to use. This fixes benchmarks crashing in master.