### PR TITLE
Refactor component groups

### DIFF
--- a/LambdaEngine/Include/ECS/Component.h
+++ b/LambdaEngine/Include/ECS/Component.h
@@ -40,10 +40,30 @@ namespace LambdaEngine
 		RW  = 2		// Read & Write
 	};
 
+	template <typename Comp>
+	class GroupedComponent
+	{
+	public:
+		ComponentPermissions Permissions = NDA; // The default permissions for any component type in a component group
+	};
+
 	struct ComponentAccess
 	{
+		template <typename Comp>
+		ComponentAccess(GroupedComponent<Comp> groupedComponent)
+			:
+			Permissions(groupedComponent.Permissions),
+			pTID(Comp::Type())
+		{}
+
+		ComponentAccess(ComponentPermissions permissions, const ComponentType* pType)
+			:
+			Permissions(permissions),
+			pTID(pType)
+		{}
+
 		ComponentPermissions Permissions;
-		const ComponentType* TID;
+		const ComponentType* pTID;
 	};
 
 	class IComponentGroup

--- a/LambdaEngine/Include/Game/ECS/Components/Physics/Transform.h
+++ b/LambdaEngine/Include/Game/ECS/Components/Physics/Transform.h
@@ -52,9 +52,9 @@ namespace LambdaEngine
 			return { Position, Scale, Rotation };
 		}
 
-		ComponentAccess Position    = {R, PositionComponent::Type()};
-		ComponentAccess Scale       = {R, ScaleComponent::Type()};
-		ComponentAccess Rotation    = {R, RotationComponent::Type()};
+		GroupedComponent<PositionComponent>	Position;
+		GroupedComponent<ScaleComponent>	Scale;
+		GroupedComponent<RotationComponent>	Rotation;
 	};
 
 	// Transform calculation functions

--- a/LambdaEngine/Source/ECS/EntityPublisher.cpp
+++ b/LambdaEngine/Source/ECS/EntityPublisher.cpp
@@ -33,7 +33,7 @@ namespace LambdaEngine
 
             newSub.ComponentTypes.Reserve(componentRegs.GetSize());
             for (const ComponentAccess& componentReg : componentRegs)
-                newSub.ComponentTypes.PushBack(componentReg.TID);
+                newSub.ComponentTypes.PushBack(componentReg.pTID);
 
             EliminateDuplicateTIDs(newSub.ComponentTypes);
             newSub.ComponentTypes.ShrinkToFit();

--- a/LambdaEngine/Source/ECS/EntitySubscriber.cpp
+++ b/LambdaEngine/Source/ECS/EntitySubscriber.cpp
@@ -47,7 +47,7 @@ namespace LambdaEngine
         {
             for (const ComponentAccess& includedComponent : includedTypes)
             {
-                ASSERT_MSG(pExcludedComponent != includedComponent.TID, "The same component type was both included and excluded in an entity subscription");
+                ASSERT_MSG(pExcludedComponent != includedComponent.pTID, "The same component type was both included and excluded in an entity subscription");
             }
         }
     #endif // LAMBDA_DEVELOPMENT

--- a/LambdaEngine/Source/ECS/JobScheduler.cpp
+++ b/LambdaEngine/Source/ECS/JobScheduler.cpp
@@ -148,7 +148,7 @@ namespace LambdaEngine
         // i.e. prevent data races
         for (const ComponentAccess& componentReg : job.Components)
         {
-            auto processingComponentItr = m_ProcessingComponents.find(componentReg.TID);
+            auto processingComponentItr = m_ProcessingComponents.find(componentReg.pTID);
             if (processingComponentItr != m_ProcessingComponents.end() && (componentReg.Permissions == RW || processingComponentItr->second == 0))
             {
                 return false;
@@ -172,10 +172,10 @@ namespace LambdaEngine
         {
             uint32 isReadOnly = componentReg.Permissions == R;
 
-            auto processingComponentItr = m_ProcessingComponents.find(componentReg.TID);
+            auto processingComponentItr = m_ProcessingComponents.find(componentReg.pTID);
             if (processingComponentItr == m_ProcessingComponents.end())
             {
-                m_ProcessingComponents.insert({componentReg.TID, isReadOnly});
+                m_ProcessingComponents.insert({componentReg.pTID, isReadOnly});
             }
             else
             {
@@ -188,7 +188,7 @@ namespace LambdaEngine
     {
         for (const ComponentAccess& componentReg : job.Components)
         {
-            auto processingComponentItr = m_ProcessingComponents.find(componentReg.TID);
+            auto processingComponentItr = m_ProcessingComponents.find(componentReg.pTID);
             if (processingComponentItr->second <= 1u)
             {
                 // The job was the only one reading or writing to the component type

--- a/LambdaEngine/Source/ECS/RegularWorker.cpp
+++ b/LambdaEngine/Source/ECS/RegularWorker.cpp
@@ -50,10 +50,10 @@ namespace LambdaEngine
 				continue;
 			}
 
-			auto uniqueRegsItr = uniqueRegs.find(componentUpdateReg.TID);
+			auto uniqueRegsItr = uniqueRegs.find(componentUpdateReg.pTID);
 			if (uniqueRegsItr == uniqueRegs.end() || componentUpdateReg.Permissions > uniqueRegsItr->second)
 			{
-				uniqueRegs.insert(uniqueRegsItr, {componentUpdateReg.TID, componentUpdateReg.Permissions});
+				uniqueRegs.insert(uniqueRegsItr, {componentUpdateReg.pTID, componentUpdateReg.Permissions});
 			}
 		}
 	}

--- a/LambdaEngine/Source/Game/ECS/Systems/Audio/AudioSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Audio/AudioSystem.cpp
@@ -15,7 +15,6 @@ namespace LambdaEngine
 		{
 			TransformComponents transformComponents;
 			transformComponents.Position.Permissions	= R;
-			transformComponents.Scale.Permissions		= NDA;
 			transformComponents.Rotation.Permissions	= R;
 
 			SystemRegistration systemReg = {};


### PR DESCRIPTION
The access permissions of each component type in a componeng group should default to `NDA` (No Data Access). That way, when using a component group, you only have to enter the permissions of the component types you actually access.