### PR TITLE
Removed validation info for VK_NOT_READY for queryHeap

### DIFF
--- a/LambdaEngine/Source/Rendering/Core/Vulkan/GraphicsDeviceVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/GraphicsDeviceVK.cpp
@@ -1748,8 +1748,13 @@ namespace LambdaEngine
 
 		if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
 		{
-			LOG_MESSAGE("[Validation Layer]: %s", pCallbackData->pMessage);
-			PlatformConsole::Print("\n");
+			// MessageID 0x8928392f corresponds to the vKGetQueryPoolResults with VK_NOT_READY result, which is handled
+			// as the best practice info message says.
+			if (pCallbackData->messageIdNumber != 0x8928392F)
+			{
+				LOG_MESSAGE("[Validation Layer]: %s", pCallbackData->pMessage);
+				PlatformConsole::Print("\n");
+			}
 		}
 		else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT)
 		{


### PR DESCRIPTION
Validation layer info spammed out the "Best Practice" message for VK_NOT_READY for the vkGetQueryPoolResults. This is printed even when it is handled correctly, which it is. Therefore it is ignored.