### PR TITLE
Mesh painting remove paint

### DIFF
--- a/Assets/Shaders/MeshPainting/Unwrap.frag
+++ b/Assets/Shaders/MeshPainting/Unwrap.frag
@@ -48,6 +48,7 @@ void main()
 
 	if(brushMask.a > 0.01f && length(worldPosition-projectedPosition) <= BRUSH_SIZE && valid > 0.5f)
 	{
+		// Paint mode 1 is normal paint. Paint mode 0 is remove paint (See enum in PaintMaskRenderer.h for enum)
 		if (in_PaintMode == 1)
 			out_UnwrappedTexture = vec4(1.f, 1.f, 1.f, 1.f);
 		else

--- a/Assets/Shaders/MeshPainting/Unwrap.frag
+++ b/Assets/Shaders/MeshPainting/Unwrap.frag
@@ -5,10 +5,11 @@
 
 #include "../Defines.glsl"
 
-layout(location = 0) in vec3	in_WorldPosition;
-layout(location = 1) in vec3	in_Normal;
-layout(location = 2) in vec3	in_TargetPosition;
-layout(location = 3) in vec3	in_TargetDirection;
+layout(location = 0) in vec3		in_WorldPosition;
+layout(location = 1) in vec3		in_Normal;
+layout(location = 2) in vec3		in_TargetPosition;
+layout(location = 3) in vec3		in_TargetDirection;
+layout(location = 4) flat in uint	in_PaintMode;
 
 layout(binding = 0, set = TEXTURE_SET_INDEX) uniform sampler2D u_BrushMaskTexture;
 
@@ -46,7 +47,12 @@ void main()
 	vec4 brushMask = texture(u_BrushMaskTexture, maskUV).rgba;
 
 	if(brushMask.a > 0.01f && length(worldPosition-projectedPosition) <= BRUSH_SIZE && valid > 0.5f)
-		out_UnwrappedTexture = vec4(1.f, 1.f, 1.f, 1.f);
+	{
+		if (in_PaintMode == 1)
+			out_UnwrappedTexture = vec4(1.f, 1.f, 1.f, 1.f);
+		else
+			out_UnwrappedTexture = vec4(0.f, 0.f, 0.f, 1.f);
+	}
 	else
 		discard;
 		// out_UnwrappedTexture = vec4(0.f, 0.f, 0.f, 1.f);

--- a/Assets/Shaders/MeshPainting/Unwrap.vert
+++ b/Assets/Shaders/MeshPainting/Unwrap.vert
@@ -58,9 +58,9 @@ void main()
 
 	out_PaintMode					= u_UnwrapData.val.PaintMode;
 
-    // This is not removed because of debug purposes.
-    //out_TargetDirection             = -normalize(vec3(-perFrameBuffer.View[0][2], -perFrameBuffer.View[1][2], -perFrameBuffer.View[2][2]));
-    //out_TargetPosition              = perFrameBuffer.CameraPosition.xyz;  
+	// This is not removed because of debug purposes.
+	//out_TargetDirection             = -normalize(vec3(-perFrameBuffer.View[0][2], -perFrameBuffer.View[1][2], -perFrameBuffer.View[2][2]));
+	//out_TargetPosition              = perFrameBuffer.CameraPosition.xyz;  
 
 	vec2 texCoord = vec2(vertex.TexCoord.x, vertex.TexCoord.y);
 	texCoord.y = 1.f - texCoord.y;

--- a/Assets/Shaders/MeshPainting/Unwrap.vert
+++ b/Assets/Shaders/MeshPainting/Unwrap.vert
@@ -5,10 +5,13 @@
 
 #include "../Defines.glsl"
 
+#define UNWRAP_DRAW_SET_INDEX 3
+
 struct SUnwrapData
 {
 	vec4 TargetPosition;
 	vec4 TargetDirection;
+	uint PaintMode; // True when painting, false when removing paint
 };
 
 layout(push_constant) uniform TransformBuffer
@@ -21,13 +24,15 @@ layout(binding = 0, set = BUFFER_SET_INDEX) uniform PerFrameBuffer				{ SPerFram
 layout(binding = 0, set = DRAW_SET_INDEX) restrict readonly buffer Vertices		{ SVertex val[]; }			b_Vertices;
 layout(binding = 1, set = DRAW_SET_INDEX) restrict readonly buffer Instances	{ SInstance val[]; }		b_Instances;
 
-layout(binding = 0, set = 3) uniform UnwrapData									{ SUnwrapData val; }		u_UnwrapData;
+layout(binding = 0, set = UNWRAP_DRAW_SET_INDEX) uniform UnwrapData				{ SUnwrapData val; }		u_UnwrapData;
 
 layout(location = 0) out vec3 out_WorldPosition;
 layout(location = 1) out vec3 out_Normal;
 
 layout(location = 2) out vec3 out_TargetPosition;
 layout(location = 3) out vec3 out_TargetDirection;
+
+layout(location = 4) out uint out_PaintMode;
 
 /*
 	Three parameters are needed to make this work. These are:
@@ -50,6 +55,8 @@ void main()
 
 	out_TargetDirection				= u_UnwrapData.val.TargetDirection.xyz;
 	out_TargetPosition				= u_UnwrapData.val.TargetPosition.xyz;
+
+	out_PaintMode					= u_UnwrapData.val.PaintMode;
 
     // This is not removed because of debug purposes.
     //out_TargetDirection             = -normalize(vec3(-perFrameBuffer.View[0][2], -perFrameBuffer.View[1][2], -perFrameBuffer.View[2][2]));

--- a/Assets/Shaders/MeshPainting/Unwrap.vert
+++ b/Assets/Shaders/MeshPainting/Unwrap.vert
@@ -11,7 +11,7 @@ struct SUnwrapData
 {
 	vec4 TargetPosition;
 	vec4 TargetDirection;
-	uint PaintMode; // True when painting, false when removing paint
+	uint PaintMode;
 };
 
 layout(push_constant) uniform TransformBuffer

--- a/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
+++ b/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
@@ -23,6 +23,12 @@ namespace LambdaEngine
 	class Buffer;
 	class Window;
 
+	enum class EPaintMode
+	{
+		REMOVE = 0,
+		PAINT
+	};
+
 	class PaintMaskRenderer : public ICustomRenderer
 	{
 	public:
@@ -62,7 +68,7 @@ namespace LambdaEngine
 		*	direction - vec3 of the direction the hit position had during collision
 		*	paintingEnabled - true to paint on target, false to remove paint on target
 		*/
-		static void AddHitPoint(const glm::vec3& position, const glm::vec3& direction, uint32 paintMode);
+		static void AddHitPoint(const glm::vec3& position, const glm::vec3& direction, EPaintMode paintMode);
 
 	private:
 		bool CreateCopyCommandList();
@@ -88,7 +94,7 @@ namespace LambdaEngine
 		{
 			glm::vec4	TargetPosition;
 			glm::vec4	TargetDirection;
-			uint32		PaintMode = 1; // TODO: Change to an enum for clearer use
+			EPaintMode	PaintMode = EPaintMode::PAINT;
 		};
 
 	private:

--- a/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
+++ b/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
@@ -25,8 +25,8 @@ namespace LambdaEngine
 
 	enum class EPaintMode
 	{
-		REMOVE = 0,
-		PAINT
+		REMOVE	= 0,
+		PAINT	= 1
 	};
 
 	class PaintMaskRenderer : public ICustomRenderer

--- a/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
+++ b/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
@@ -66,7 +66,7 @@ namespace LambdaEngine
 		* Note: Currently only one hitpoint will be handled at each frame
 		*	position - vec3 of the hit point position
 		*	direction - vec3 of the direction the hit position had during collision
-		*	paintingEnabled - true to paint on target, false to remove paint on target
+		*	paintMode - painting mode to be used for the target
 		*/
 		static void AddHitPoint(const glm::vec3& position, const glm::vec3& direction, EPaintMode paintMode);
 
@@ -123,7 +123,7 @@ namespace LambdaEngine
 		TArray<TSharedRef<Buffer>>	m_UnwrapDataCopyBuffers;
 		TSharedRef<Buffer>			m_UnwrapDataBuffer = nullptr;
 
-		const DrawArg*												m_pDrawArgs;
+		const DrawArg*												m_pDrawArgs = nullptr;
 		TArray<TArray<TSharedRef<DescriptorSet>>>					m_VerticesInstanceDescriptorSets;
 
 		TSharedRef<DescriptorSet>									m_UnwrapDataDescriptorSet;

--- a/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
+++ b/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
@@ -60,8 +60,9 @@ namespace LambdaEngine
 		* Note: Currently only one hitpoint will be handled at each frame
 		*	position - vec3 of the hit point position
 		*	direction - vec3 of the direction the hit position had during collision
+		*	paintingEnabled - true to paint on target, false to remove paint on target
 		*/
-		static void AddHitPoint(const glm::vec3& position, const glm::vec3& direction);
+		static void AddHitPoint(const glm::vec3& position, const glm::vec3& direction, uint32 paintMode);
 
 	private:
 		bool CreateCopyCommandList();
@@ -85,8 +86,9 @@ namespace LambdaEngine
 
 		struct UnwrapData
 		{
-			glm::vec4 TargetPosition;
-			glm::vec4 TargetDirection;
+			glm::vec4	TargetPosition;
+			glm::vec4	TargetDirection;
+			uint32		PaintMode = 1; // TODO: Change to an enum for clearer use
 		};
 
 	private:

--- a/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
@@ -103,7 +103,8 @@ namespace LambdaEngine
 		cmdHitTest.Init("add_hit_point", true);
 		cmdHitTest.AddFlag("p", Arg::EType::FLOAT, 3);
 		cmdHitTest.AddFlag("d", Arg::EType::FLOAT, 3);
-		cmdHitTest.AddDescription("Add a hitpoint for the paint mask renderer\n [-p] position of point in world\n [-d] direction of point in world\n\t'add_hit_point <-p x y z> [-d x y z]'");
+		cmdHitTest.AddFlag("paint", Arg::EType::INT);
+		cmdHitTest.AddDescription("Add a hitpoint for the paint mask renderer\n\t[-p] position of point in world\n\t[-d] direction of point in world\n\t[-paint] true to paint, false to remove paint\n\t'add_hit_point <-p x y z> [-d x y z] [-paint true/false]'");
 		GameConsole::Get().BindCommand(cmdHitTest, [&, this](GameConsole::CallbackInput& input)->void {
 			if (!input.Flags.contains("p"))
 			{
@@ -128,7 +129,13 @@ namespace LambdaEngine
 				GameConsole::Get().PushMsg("Direction not given or too few positions for flag", {0.8f, 0.8f, 0.0f, 1.0f});
 			}
 
-			PaintMaskRenderer::AddHitPoint(pos, dir);
+			uint32 paintMode = 1;
+			if (input.Flags.contains("paint") && input.Flags["paint"].Arg.Value.Int32 >= 0)
+			{
+				paintMode = (uint32)input.Flags["paint"].Arg.Value.Int32;
+			}
+
+			PaintMaskRenderer::AddHitPoint(pos, dir, paintMode);
 			});
 		
 		return false;
@@ -433,11 +440,12 @@ namespace LambdaEngine
 		(*ppFirstExecutionStage) = pCommandList;
 	}
 
-	void PaintMaskRenderer::AddHitPoint(const glm::vec3& position, const glm::vec3& direction)
+	void PaintMaskRenderer::AddHitPoint(const glm::vec3& position, const glm::vec3& direction, uint32 paintMode)
 	{
 		UnwrapData data = {};
 		data.TargetPosition		= { position.x, position.y, position.z, 1.0f };
 		data.TargetDirection	= { direction.x, direction.y, direction.z, 1.0f };
+		data.PaintMode			= paintMode;
 		
 		s_Collisions.push_back(data);
 	}

--- a/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
@@ -129,10 +129,11 @@ namespace LambdaEngine
 				GameConsole::Get().PushMsg("Direction not given or too few positions for flag", {0.8f, 0.8f, 0.0f, 1.0f});
 			}
 
-			uint32 paintMode = 1;
+			EPaintMode paintMode = EPaintMode::PAINT;
 			if (input.Flags.contains("paint") && input.Flags["paint"].Arg.Value.Int32 >= 0)
 			{
-				paintMode = (uint32)input.Flags["paint"].Arg.Value.Int32;
+				int32 mode = input.Flags["paint"].Arg.Value.Int32;
+				paintMode = mode == 0 ? EPaintMode::REMOVE : EPaintMode::PAINT;
 			}
 
 			PaintMaskRenderer::AddHitPoint(pos, dir, paintMode);
@@ -360,7 +361,7 @@ namespace LambdaEngine
 			TSharedRef<Buffer> unwrapDataCopyBuffer = m_UnwrapDataCopyBuffers[modFrameIndex];
 
 			byte* pUniformMapping	= reinterpret_cast<byte*>(unwrapDataCopyBuffer->Map());
-			const UnwrapData& data			= s_Collisions.front();
+			const UnwrapData& data	= s_Collisions.front();
 
 			memcpy(pUniformMapping, &data, sizeof(UnwrapData));
 			s_Collisions.pop_front();
@@ -440,7 +441,7 @@ namespace LambdaEngine
 		(*ppFirstExecutionStage) = pCommandList;
 	}
 
-	void PaintMaskRenderer::AddHitPoint(const glm::vec3& position, const glm::vec3& direction, uint32 paintMode)
+	void PaintMaskRenderer::AddHitPoint(const glm::vec3& position, const glm::vec3& direction, EPaintMode paintMode)
 	{
 		UnwrapData data = {};
 		data.TargetPosition		= { position.x, position.y, position.z, 1.0f };

--- a/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
@@ -212,14 +212,7 @@ namespace LambdaEngine
 			}
 			else
 			{
-				if (m_BrushMaskDescriptorSet.Get())
-				{
-					m_BrushMaskDescriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[0], &sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
-				}
-				else
-				{
-					LOG_ERROR("[Paint Mask Renderer]: Buffer count changed between calls to UpdateBufferResource for resource \"%s\"", resourceName.c_str());
-				}
+				m_BrushMaskDescriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[0], &sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
 			}
 		}
 	}


### PR DESCRIPTION
**Additions**
* PaintMaskRenderer can now remove paint. This is done externally by calling the AddHitPoint function which now takes in a EPaintMode enum which describes if one should remove or paint.