### PR TITLE
Register components first, then publish

### DIFF
--- a/LambdaEngine/Source/ECS/ECSCore.cpp
+++ b/LambdaEngine/Source/ECS/ECSCore.cpp
@@ -192,9 +192,14 @@ namespace LambdaEngine
 
 	void ECSCore::PerformComponentRegistrations()
 	{
+		// Register all components first, then publish them
 		for (const std::pair<Entity, const ComponentType*>& component : m_ComponentsToRegister)
 		{
 			m_EntityRegistry.RegisterComponentType(component.first, component.second);
+		}
+
+		for (const std::pair<Entity, const ComponentType*>& component : m_ComponentsToRegister)
+		{
 			m_EntityPublisher.PublishComponent(component.first, component.second);
 		}
 

--- a/LambdaEngine/Source/ECS/EntityPublisher.cpp
+++ b/LambdaEngine/Source/ECS/EntityPublisher.cpp
@@ -147,9 +147,10 @@ namespace LambdaEngine
             EntitySubscription& sysSub = m_SubscriptionStorage.IndexID(subBucketItr->second.SystemID)[subBucketItr->second.SubIdx];
 
             const bool entityHasExcludedTypes = m_pEntityRegistry->EntityHasAnyOfTypes(entity, sysSub.ExcludedComponentTypes);
+            const bool subscriberHasEntity = sysSub.pSubscriber->HasElement(entity);
 
             // Check if an excluded type was added. If so, remove the entity
-            if (sysSub.pSubscriber->HasElement(entity) && entityHasExcludedTypes)
+            if (subscriberHasEntity && entityHasExcludedTypes)
             {
                 if (sysSub.OnEntityRemoval)
                 {
@@ -159,7 +160,7 @@ namespace LambdaEngine
                 sysSub.pSubscriber->Pop(entity);
             }
             // Check if the entity should be added to the subscription
-            else if (!entityHasExcludedTypes && m_pEntityRegistry->EntityHasAllTypes(entity, sysSub.ComponentTypes))
+            else if (!subscriberHasEntity && !entityHasExcludedTypes && m_pEntityRegistry->EntityHasAllTypes(entity, sysSub.ComponentTypes))
             {
                 sysSub.pSubscriber->PushBack(entity);
 


### PR DESCRIPTION
Scenario:
1. A system `S` subscribes to component type `A` and excludes `B`
2. Create an entity `E` with components `A` and `B` (in that specific order)
In `ECSCore::Tick`:
3. A is registered and published. `S::OnEntityAdded` is called
4. B is registered and published. `S::OnEntityRemoval` is called

If we instead registered `A` and `B` before publishing them, `S::OnEntityAdded` would never be called because when publishing `A`, the excluded component `B` had already been registered. This is what this PR achieves.