### PR TITLE
Input fix

### DIFF
--- a/LambdaEngine/Include/Application/API/Events/Event.h
+++ b/LambdaEngine/Include/Application/API/Events/Event.h
@@ -100,6 +100,8 @@ namespace LambdaEngine
 		{
 		}
 
+		virtual ~Event() = default;
+
 		DECLATE_STATIC_EVENT_TYPE(Event);
 
 		virtual String ToString() const = 0;

--- a/LambdaEngine/Include/Application/API/Events/EventQueue.h
+++ b/LambdaEngine/Include/Application/API/Events/EventQueue.h
@@ -4,259 +4,91 @@
 
 #include "Containers/TUniquePtr.h"
 
+#include "Memory/API/Malloc.h"
+#include "Memory/API/StackAllocator.h"
+
 namespace LambdaEngine
 {
 	/*
 	* EventContainer
 	*/
-	struct EventContainer
+
+	class EventContainer
 	{
 	public:
-		using Iterator = Event*;
-		using ConstIterator = const Event*;
-
-		virtual ~EventContainer() = default;
-
-		inline EventContainer(EventType eventType) noexcept
-			: ContainerEventType(eventType)
+		inline EventContainer()
+			: m_Allocator()
+			, m_Events()
 		{
 		}
 
-		virtual void Push(const Event& event) = 0;
-		virtual void Clear() = 0;
-		
-		virtual uint32 Size() const = 0;
+		~EventContainer() = default;
 
-		virtual EventContainer* Copy(void* pMemory) = 0;
-		virtual EventContainer* Move(void* pMemory) = 0;
-		
-		virtual Event& GetAt(uint32 index) = 0;
-		virtual const Event& GetAt(uint32 index) const = 0;
-
-	public:
-		EventType ContainerEventType;
-	};
-
-	/*
-	* TEventContainer
-	*/
-	template<typename TEvent>
-	struct TEventContainer : public EventContainer
-	{
-	public:
-		inline TEventContainer(uint32 size = 1) noexcept
-			: EventContainer(TEvent::GetStaticType())
-			, Events()
+		template<typename TEvent>
+		FORCEINLINE void Push(const TEvent& event)
 		{
-			Events.Reserve(size);
+			void* pMemory = m_Allocator.Push(sizeof(TEvent));
+			new(pMemory) TEvent(event);
+			m_Events.EmplaceBack(reinterpret_cast<TEvent*>(pMemory));
 		}
 
-		inline TEventContainer(const TEventContainer& other) noexcept
-			: EventContainer(TEvent::GetStaticType())
-			, Events(other.Events)
+		FORCEINLINE void Pop()
 		{
+			// Call destructor
+			m_Events.GetBack()->~Event();
+
+			// Then remove
+			m_Allocator.Pop();
+			m_Events.PopBack();
 		}
 
-		inline TEventContainer(TEventContainer&& other) noexcept
-			: EventContainer(TEvent::GetStaticType())
-			, Events(std::move(other.Events))
+		FORCEINLINE Event& At(uint32 index)
 		{
+			return *m_Events[index];
 		}
 
-		virtual void Push(const Event& event) override final
+		FORCEINLINE const Event& At(uint32 index) const
 		{
-			VALIDATE(ContainerEventType == event.GetType());
-			Events.EmplaceBack(EventCast<TEvent>(event));
-		}
-
-		virtual void Clear() override final
-		{
-			Events.Clear();
-		}
-
-		virtual uint32 Size() const override final
-		{
-			return static_cast<uint32>(Events.GetSize());
-		}
-
-		virtual EventContainer* Copy(void* pMemory)
-		{
-			new(pMemory) TEventContainer(*this);
-			return reinterpret_cast<EventContainer*>(pMemory);
-		}
-
-		virtual EventContainer* Move(void* pMemory)
-		{
-			new(pMemory) TEventContainer(std::move(*this));
-			return reinterpret_cast<EventContainer*>(pMemory);
-		}
-
-		virtual Event& GetAt(uint32 index) override final
-		{
-			VALIDATE(index < Events.GetSize());
-			return Events[index];
-		}
-
-		virtual const Event& GetAt(uint32 index) const override final
-		{
-			VALIDATE(index < Events.GetSize());
-			return Events[index];
-		}
-
-	public:
-		TArray<TEvent> Events;
-	};
-
-	/*
-	* EventContainerProxy
-	*/
-	struct EventContainerProxy
-	{
-	public:
-		inline EventContainerProxy() noexcept
-			: m_StackBuffer()
-			, m_pContainer(nullptr)
-		{
-			ZERO_MEMORY(m_StackBuffer, sizeof(m_StackBuffer));
-			m_pContainer = nullptr;
-		}
-
-		inline EventContainerProxy(const EventContainerProxy& other) noexcept
-			: m_StackBuffer()
-			, m_pContainer(nullptr)
-		{
-			if (!other.m_pContainer)
-			{
-				ZERO_MEMORY(m_StackBuffer, sizeof(m_StackBuffer));
-				m_pContainer = nullptr;
-			}
-			else
-			{
-				m_pContainer = other.m_pContainer->Copy(reinterpret_cast<void*>(m_StackBuffer));
-			}
-		}
-
-		inline EventContainerProxy(EventContainerProxy&& other) noexcept
-			: m_StackBuffer()
-			, m_pContainer(nullptr)
-		{
-			if (!other.m_pContainer)
-			{
-				ZERO_MEMORY(m_StackBuffer, sizeof(m_StackBuffer));
-				m_pContainer = nullptr;
-			}
-			else
-			{
-				m_pContainer = other.m_pContainer->Move(reinterpret_cast<void*>(m_StackBuffer));
-			}
-		}
-
-		inline ~EventContainerProxy()
-		{
-			if (m_pContainer)
-			{
-				m_pContainer->~EventContainer();
-			}
-		}
-
-		FORCEINLINE void Push(const Event& event)
-		{
-			m_pContainer->Push(event);
-		}
-
-		FORCEINLINE void Clear()
-		{
-			m_pContainer->Clear();
-		}
-
-		FORCEINLINE Event& GetAt(uint32 index)
-		{
-			return m_pContainer->GetAt(index);
-		}
-
-		FORCEINLINE const Event& GetAt(uint32 index) const
-		{
-			return m_pContainer->GetAt(index);
+			return *m_Events[index];
 		}
 
 		FORCEINLINE uint32 Size() const
 		{
-			return m_pContainer->Size();
+			return m_Events.GetSize();
+		}
+
+		FORCEINLINE void Clear()
+		{
+			// Call destructor for all events
+			for (Event* pEvent : m_Events)
+			{
+				pEvent->~Event();
+			}
+			
+			// Clear containers
+			m_Events.Clear();
+			m_Allocator.Reset();
 		}
 
 		FORCEINLINE Event& operator[](uint32 index)
 		{
-			return GetAt(index);
+			return At(index);
 		}
 
 		FORCEINLINE const Event& operator[](uint32 index) const
 		{
-			return GetAt(index);
-		}
-
-		FORCEINLINE EventContainerProxy& operator=(const EventContainerProxy& other)
-		{
-			if (this != &other)
-			{
-				if (!other.m_pContainer)
-				{
-					ZERO_MEMORY(m_StackBuffer, sizeof(m_StackBuffer));
-					m_pContainer = nullptr;
-				}
-				else
-				{
-					m_pContainer = other.m_pContainer->Copy(reinterpret_cast<void*>(m_StackBuffer));
-				}
-			}
-
-			return *this;
-		}
-
-		FORCEINLINE EventContainerProxy& operator=(EventContainerProxy&& other)
-		{
-			if (this != &other)
-			{
-				if (!other.m_pContainer)
-				{
-					ZERO_MEMORY(m_StackBuffer, sizeof(m_StackBuffer));
-					m_pContainer = nullptr;
-				}
-				else
-				{
-					m_pContainer = other.m_pContainer->Move(reinterpret_cast<void*>(m_StackBuffer));
-				}
-			}
-
-			return *this;
-		}
-
-		FORCEINLINE bool operator==(const EventContainerProxy& other) const
-		{
-			return (memcmp(m_StackBuffer, other.m_StackBuffer, sizeof(m_StackBuffer)) == 0);
-		}
-
-	public:
-		template<typename TEvent>
-		inline static EventContainerProxy Create(uint32 count)
-		{
-			EventContainerProxy container;
-			static_assert(sizeof(TEventContainer<TEvent>) <= sizeof(container.m_StackBuffer));
-
-			new(reinterpret_cast<void*>(container.m_StackBuffer)) TEventContainer<TEvent>(count);
-			container.m_pContainer = reinterpret_cast<EventContainer*>(container.m_StackBuffer);
-
-			return std::move(container);
+			return At(index);
 		}
 
 	private:
-		// No reason to use KeyPressedEvent other than the fact that we need some 
-		byte m_StackBuffer[sizeof(TEventContainer<KeyPressedEvent>)];
-		EventContainer* m_pContainer;
+		StackAllocator m_Allocator;
+		TArray<Event*> m_Events;
 	};
 
 	/*
 	* EventQueue
 	*/
+
 	class EventQueue
 	{
 	public:
@@ -317,13 +149,7 @@ namespace LambdaEngine
 			EventType eventType = event.GetType();
 			VALIDATE(eventType == TEvent::GetStaticType());
 
-			auto deferredEvents = s_DeferredEvents.find(eventType);
-			if (deferredEvents == s_DeferredEvents.end())
-			{
-				s_DeferredEvents[eventType] = std::move(EventContainerProxy::Create<TEvent>(5));
-			}
-
-			s_DeferredEvents[eventType].Push(event);
+			s_DeferredEvents.Push(event);
 		}
 		
 		static bool SendEventImmediate(Event& event);
@@ -334,9 +160,7 @@ namespace LambdaEngine
 		static void InternalSendEventToHandlers(Event& event, const TArray<EventHandler>& handlers);
 
 	private:
-		using EventTable = std::unordered_map<EventType, EventContainerProxy, EventTypeHasher>;
-
-		static EventTable s_DeferredEvents;
+		static EventContainer s_DeferredEvents;
 		static SpinLock s_EventLock;
 	};
 }

--- a/LambdaEngine/Include/Application/API/Events/EventQueue.h
+++ b/LambdaEngine/Include/Application/API/Events/EventQueue.h
@@ -32,16 +32,6 @@ namespace LambdaEngine
 			m_Events.EmplaceBack(reinterpret_cast<TEvent*>(pMemory));
 		}
 
-		FORCEINLINE void Pop()
-		{
-			// Call destructor
-			m_Events.GetBack()->~Event();
-
-			// Then remove
-			m_Allocator.Pop();
-			m_Events.PopBack();
-		}
-
 		FORCEINLINE Event& At(uint32 index)
 		{
 			return *m_Events[index];
@@ -146,9 +136,7 @@ namespace LambdaEngine
 		{
 			std::scoped_lock<SpinLock> lock(s_EventLock);
 
-			EventType eventType = event.GetType();
-			VALIDATE(eventType == TEvent::GetStaticType());
-
+			VALIDATE(event.GetType() == TEvent::GetStaticType());
 			s_DeferredEvents.Push(event);
 		}
 		

--- a/LambdaEngine/Include/Defines.h
+++ b/LambdaEngine/Include/Defines.h
@@ -92,7 +92,7 @@
 * Helper Macros
 */ 
 
-#define ZERO_MEMORY(memory, size)	memset((void*)memory, 0, size)
+#define ZERO_MEMORY(memory, size)	memset(reinterpret_cast<void*>(memory), 0, size)
 #define ARR_SIZE(arr)				sizeof(arr) / sizeof(arr[0])
 
 /*

--- a/LambdaEngine/Include/Memory/API/Malloc.h
+++ b/LambdaEngine/Include/Memory/API/Malloc.h
@@ -40,6 +40,18 @@ namespace LambdaEngine
 		static void* Allocate(uint64 sizeInBytes);
 		static void* Allocate(uint64 sizeInBytes, uint64 alignment);
 
+		template<typename T>
+		static T* AllocateType(uint64 sizeInBytes)
+		{
+			return reinterpret_cast<T*>(Allocate(sizeInBytes));
+		}
+
+		template<typename T>
+		static T* AllocateType()
+		{
+			return reinterpret_cast<T*>(Allocate(sizeof(T)));
+		}
+
 		static void* AllocateDbg(uint64 sizeInBytes, const char* pFileName, int32 lineNumber);
 		static void* AllocateDbg(uint64 sizeInBytes, uint64 alignment, const char* pFileName, int32 lineNumber);
 		

--- a/LambdaEngine/Include/Memory/API/StackAllocator.h
+++ b/LambdaEngine/Include/Memory/API/StackAllocator.h
@@ -16,8 +16,10 @@ namespace LambdaEngine
 			, m_SizeInBytes(sizeInBytes)
 		{
 			m_pMemory = Malloc::AllocateType<byte>(m_SizeInBytes);
-			ZERO_MEMORY(m_pMemory, m_SizeInBytes);
 
+#if LAMBDA_DEVELOPMENT
+			ZERO_MEMORY(m_pMemory, m_SizeInBytes);
+#endif
 			Reset();
 		}
 

--- a/LambdaEngine/Include/Memory/API/StackAllocator.h
+++ b/LambdaEngine/Include/Memory/API/StackAllocator.h
@@ -1,0 +1,103 @@
+#pragma once
+#include "LambdaEngine.h"
+
+namespace LambdaEngine
+{
+	/*
+	* MemoryArena
+	*/
+
+	class MemoryArena
+	{
+	public:
+		inline MemoryArena(uint32 sizeInBytes = 4096)
+			: m_pMemory(nullptr)
+			, m_Offset(0)
+			, m_SizeInBytes(sizeInBytes)
+		{
+			m_pMemory = Malloc::AllocateType<byte>(m_SizeInBytes);
+			ZERO_MEMORY(m_pMemory, m_SizeInBytes);
+
+			Reset();
+		}
+
+		inline ~MemoryArena()
+		{
+			Malloc::Free(m_pMemory);
+		}
+
+		FORCEINLINE void* Allocate(uint32 size)
+		{
+			if (!CanAllocate(size))
+			{
+				return nullptr;
+			}
+
+			byte* pResult = m_pMemory + m_Offset;
+			m_Offset += size;
+			return pResult;
+		}
+
+		FORCEINLINE void Pop(uint32 size)
+		{
+			if (CanPop(size))
+			{
+				m_Offset -= size;
+			}
+		}
+
+		FORCEINLINE void Reset()
+		{
+			m_Offset = 0;
+		}
+
+		FORCEINLINE bool CanAllocate(uint32 size) const
+		{
+			return (m_Offset + size) < m_SizeInBytes;
+		}
+
+		FORCEINLINE bool CanPop(uint32 size) const
+		{
+			return (int32(m_Offset) - int32(size)) >= 0;
+		}
+
+	private:
+		byte*	m_pMemory;
+		uint32	m_Offset;
+		uint32	m_SizeInBytes;
+	};
+
+	/*
+	* StackAllocator -> Can resize, but cannot allocate arbitrarily
+	*/
+
+	class StackAllocator
+	{
+	public:
+		StackAllocator(uint32 sizePerArena = 4096);
+		~StackAllocator() = default;
+
+		// Allocates a certain amounts of bytes
+		void* Push(uint32 size);
+
+		// Removes the last element
+		void Pop();
+
+		// Resets the whole stack
+		void Reset();
+
+		template<typename T>
+		FORCEINLINE void* Allocate()
+		{
+			return Allocate(sizeof(T));
+		}
+
+	private:
+		uint32 m_LastSize;
+		uint32 m_ArenaIndex;
+		uint32 m_SizePerArena;
+
+		MemoryArena* m_pCurrentArena;
+		TArray<MemoryArena> m_Arenas;
+	};
+}

--- a/LambdaEngine/Include/Memory/API/StackAllocator.h
+++ b/LambdaEngine/Include/Memory/API/StackAllocator.h
@@ -58,7 +58,7 @@ namespace LambdaEngine
 
 		FORCEINLINE bool CanPop(uint32 size) const
 		{
-			return (int32(m_Offset) - int32(size)) >= 0;
+			return m_Offset >= size;
 		}
 
 	private:

--- a/LambdaEngine/Include/Memory/API/StackAllocator.h
+++ b/LambdaEngine/Include/Memory/API/StackAllocator.h
@@ -81,10 +81,16 @@ namespace LambdaEngine
 		void* Push(uint32 size);
 
 		// Removes the last element
-		void Pop();
+		void Pop(uint32 size);
 
 		// Resets the whole stack
 		void Reset();
+
+		FORCEINLINE bool CanPop(uint32 size) const
+		{
+			VALIDATE(m_pCurrentArena != nullptr);
+			return m_pCurrentArena->CanPop(size);
+		}
 
 		template<typename T>
 		FORCEINLINE void* Allocate()
@@ -93,7 +99,6 @@ namespace LambdaEngine
 		}
 
 	private:
-		uint32 m_LastSize;
 		uint32 m_ArenaIndex;
 		uint32 m_SizePerArena;
 

--- a/LambdaEngine/Source/Memory/API/StackAllocator.cpp
+++ b/LambdaEngine/Source/Memory/API/StackAllocator.cpp
@@ -8,7 +8,6 @@ namespace LambdaEngine
 
 	StackAllocator::StackAllocator(uint32 sizePerArena)
 		: m_ArenaIndex(0)
-		, m_LastSize(0)
 		, m_SizePerArena(sizePerArena)
 		, m_pCurrentArena(nullptr)
 		, m_Arenas()
@@ -40,7 +39,6 @@ namespace LambdaEngine
 		// Allocate
 		if (m_pCurrentArena->CanAllocate(size))
 		{
-			m_LastSize = size;
 			return m_pCurrentArena->Allocate(size);
 		}
 		else
@@ -49,11 +47,11 @@ namespace LambdaEngine
 		}
 	}
 
-	void StackAllocator::Pop()
+	void StackAllocator::Pop(uint32 size)
 	{
 		VALIDATE(m_pCurrentArena != nullptr);
 
-		if (!m_pCurrentArena->CanPop(m_LastSize))
+		if (!m_pCurrentArena->CanPop(size))
 		{
 			if (m_ArenaIndex > 0)
 			{
@@ -64,11 +62,11 @@ namespace LambdaEngine
 			}
 			else
 			{
-				m_pCurrentArena->Reset();
+				return;
 			}
 		}
 		
-		m_pCurrentArena->Pop(m_LastSize);
+		m_pCurrentArena->Pop(size);
 	}
 
 	void StackAllocator::Reset()

--- a/LambdaEngine/Source/Memory/API/StackAllocator.cpp
+++ b/LambdaEngine/Source/Memory/API/StackAllocator.cpp
@@ -1,0 +1,84 @@
+#include "Memory/API/StackAllocator.h"
+
+namespace LambdaEngine
+{
+	/*
+	* StackAllocator
+	*/
+
+	StackAllocator::StackAllocator(uint32 sizePerArena)
+		: m_ArenaIndex(0)
+		, m_LastSize(0)
+		, m_SizePerArena(sizePerArena)
+		, m_pCurrentArena(nullptr)
+		, m_Arenas()
+	{
+		m_pCurrentArena = &m_Arenas.EmplaceBack(m_SizePerArena);
+	}
+
+	void* StackAllocator::Push(uint32 size)
+	{
+		VALIDATE(m_pCurrentArena != nullptr);
+		
+		// Do we need a new arena or can we take next one?
+		if (!m_pCurrentArena->CanAllocate(size))
+		{
+			m_ArenaIndex++;
+			if (m_Arenas.GetSize() <= m_ArenaIndex)
+			{
+				m_pCurrentArena = &m_Arenas.EmplaceBack(m_SizePerArena);
+			}
+			else
+			{
+				m_pCurrentArena = &m_Arenas[m_ArenaIndex];
+				m_pCurrentArena->Reset();
+			}
+		}
+
+		VALIDATE(m_pCurrentArena != nullptr);
+		
+		// Allocate
+		if (m_pCurrentArena->CanAllocate(size))
+		{
+			m_LastSize = size;
+			return m_pCurrentArena->Allocate(size);
+		}
+		else
+		{
+			return nullptr;
+		}
+	}
+
+	void StackAllocator::Pop()
+	{
+		VALIDATE(m_pCurrentArena != nullptr);
+
+		if (!m_pCurrentArena->CanPop(m_LastSize))
+		{
+			if (m_ArenaIndex > 0)
+			{
+				m_ArenaIndex--;
+				m_pCurrentArena = &m_Arenas[m_ArenaIndex];
+				
+				VALIDATE(m_pCurrentArena != nullptr);
+			}
+			else
+			{
+				m_pCurrentArena->Reset();
+			}
+		}
+		
+		m_pCurrentArena->Pop(m_LastSize);
+	}
+
+	void StackAllocator::Reset()
+	{
+		for (MemoryArena& arena : m_Arenas)
+		{
+			arena.Reset();
+		}
+
+		m_ArenaIndex	= 0;
+		m_pCurrentArena	= &m_Arenas[m_ArenaIndex];
+	}
+}

--- a/LambdaEngine/Source/Memory/API/StackAllocator.cpp
+++ b/LambdaEngine/Source/Memory/API/StackAllocator.cpp
@@ -32,19 +32,18 @@ namespace LambdaEngine
 				m_pCurrentArena = &m_Arenas[m_ArenaIndex];
 				m_pCurrentArena->Reset();
 			}
+
+			VALIDATE(m_pCurrentArena != nullptr);
+
+			// In case we still cannot allocate
+			if (!m_pCurrentArena->CanAllocate(size))
+			{
+				return nullptr;
+			}
 		}
 
-		VALIDATE(m_pCurrentArena != nullptr);
-		
 		// Allocate
-		if (m_pCurrentArena->CanAllocate(size))
-		{
-			return m_pCurrentArena->Allocate(size);
-		}
-		else
-		{
-			return nullptr;
-		}
+		return m_pCurrentArena->Allocate(size);
 	}
 
 	void StackAllocator::Pop(uint32 size)

--- a/LambdaEngine/Source/Memory/API/StackAllocator.cpp
+++ b/LambdaEngine/Source/Memory/API/StackAllocator.cpp
@@ -34,12 +34,6 @@ namespace LambdaEngine
 			}
 
 			VALIDATE(m_pCurrentArena != nullptr);
-
-			// In case we still cannot allocate
-			if (!m_pCurrentArena->CanAllocate(size))
-			{
-				return nullptr;
-			}
 		}
 
 		// Allocate
@@ -50,19 +44,12 @@ namespace LambdaEngine
 	{
 		VALIDATE(m_pCurrentArena != nullptr);
 
-		if (!m_pCurrentArena->CanPop(size))
+		if (!m_pCurrentArena->CanPop(size) && (m_ArenaIndex > 0))
 		{
-			if (m_ArenaIndex > 0)
-			{
-				m_ArenaIndex--;
-				m_pCurrentArena = &m_Arenas[m_ArenaIndex];
+			m_ArenaIndex--;
+			m_pCurrentArena = &m_Arenas[m_ArenaIndex];
 				
-				VALIDATE(m_pCurrentArena != nullptr);
-			}
-			else
-			{
-				return;
-			}
+			VALIDATE(m_pCurrentArena != nullptr);
 		}
 		
 		m_pCurrentArena->Pop(size);

--- a/LambdaEngine/Source/Rendering/RenderAPI.cpp
+++ b/LambdaEngine/Source/Rendering/RenderAPI.cpp
@@ -36,7 +36,7 @@ namespace LambdaEngine
 	{
 		GraphicsDeviceDesc deviceDesc = { };
 #ifdef LAMBDA_DEVELOPMENT
-		deviceDesc.Debug = false;
+		deviceDesc.Debug = true;
 #else
 		deviceDesc.Debug = false;
 #endif

--- a/LambdaEngine/Source/Rendering/RenderGraphEditor.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraphEditor.cpp
@@ -1391,10 +1391,10 @@ namespace LambdaEngine
 				ImGui::InputInt(" ##Render Stage Frame Delay", &pRenderStage->FrameDelay);
 				pRenderStage->FrameDelay = glm::clamp<uint32>(pRenderStage->FrameDelay, 0, 360);
 
-				ImGui::Text("Frame Offset: ");
+				ImGui::Text("Frame m_Offset: ");
 				ImGui::SameLine();
 				ImGui::SetNextItemWidth(ImGui::CalcTextSize("         ").x + ImGui::GetFrameHeight() * 2 + 4.0f);
-				ImGui::InputInt("##Render Stage Frame Offset", &pRenderStage->FrameOffset);
+				ImGui::InputInt("##Render Stage Frame m_Offset", &pRenderStage->FrameOffset);
 				pRenderStage->FrameOffset = glm::clamp<uint32>(pRenderStage->FrameOffset, 0, pRenderStage->FrameDelay);
 			}
 

--- a/LambdaEngine/Source/Rendering/RenderGraphEditor.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraphEditor.cpp
@@ -1391,10 +1391,10 @@ namespace LambdaEngine
 				ImGui::InputInt(" ##Render Stage Frame Delay", &pRenderStage->FrameDelay);
 				pRenderStage->FrameDelay = glm::clamp<uint32>(pRenderStage->FrameDelay, 0, 360);
 
-				ImGui::Text("Frame m_Offset: ");
+				ImGui::Text("Frame offset: ");
 				ImGui::SameLine();
 				ImGui::SetNextItemWidth(ImGui::CalcTextSize("         ").x + ImGui::GetFrameHeight() * 2 + 4.0f);
-				ImGui::InputInt("##Render Stage Frame m_Offset", &pRenderStage->FrameOffset);
+				ImGui::InputInt("##Render Stage Frame offset", &pRenderStage->FrameOffset);
 				pRenderStage->FrameOffset = glm::clamp<uint32>(pRenderStage->FrameOffset, 0, pRenderStage->FrameDelay);
 			}
 


### PR DESCRIPTION
* Fixes broken input were keys get stuck in a pressed state. This was because the event queue stores all event types in different arrays; however, this did not take into account the events' order. Now all events instead lye in a single array, and therefore the order in which events were sent is taken into account. The bug cannot be reproduced; however, if people still have stuck keys, we have to look into this even further. 