### PR TITLE
Render graph memory leak fix

### DIFF
--- a/Assets/RenderGraphs/RT_DEFERRED_PBR.lrg
+++ b/Assets/RenderGraphs/RT_DEFERRED_PBR.lrg
@@ -308,20 +308,6 @@
             }
         },
         {
-            "name": "SCENE_POINT_SHADOWMAPS",
-            "type": "TEXTURE",
-            "back_buffer_bound": false,
-            "sub_resource_count": 1,
-            "editable": true,
-            "external": true,
-            "type_params": {
-                "texture_format": "FORMAT_D24_UNORM_S8_UINT",
-                "is_of_array_type": false,
-                "unbounded_array": true,
-                "texture_type": "TEXTURE_CUBE"
-            }
-        },
-        {
             "name": "NOESIS_GUI_DEPTH_STENCIL",
             "type": "TEXTURE",
             "back_buffer_bound": false,
@@ -343,6 +329,20 @@
                 "sampler_address_mode": "REPEAT",
                 "sampler_border_color": "BORDER_COLOR_FLOAT_OPAQUE_BLACK",
                 "memory_type": "MEMORY_TYPE_GPU"
+            }
+        },
+        {
+            "name": "SCENE_POINT_SHADOWMAPS",
+            "type": "TEXTURE",
+            "back_buffer_bound": false,
+            "sub_resource_count": 1,
+            "editable": true,
+            "external": true,
+            "type_params": {
+                "texture_format": "FORMAT_D24_UNORM_S8_UINT",
+                "is_of_array_type": false,
+                "unbounded_array": true,
+                "texture_type": "TEXTURE_CUBE"
             }
         },
         {
@@ -468,8 +468,8 @@
             "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "/Geometry\\Geom.vert",
+                "mesh_shader": "/Geometry\\Geom.vert",
+                "vertex_shader": "",
                 "geometry_shader": "",
                 "hull_shader": "",
                 "domain_shader": "",
@@ -564,6 +564,58 @@
             ]
         },
         {
+            "name": "DIRL_SHADOWMAP",
+            "type": "GRAPHICS",
+            "custom_renderer": false,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "TRIGGERED",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "CONSTANT",
+            "y_dim_type": "CONSTANT",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 1024.0,
+            "y_dim_var": 1024.0,
+            "z_dim_var": 1.0,
+            "draw_type": "SCENE_INSTANCES",
+            "depth_test_enabled": true,
+            "cull_mode": "CULL_MODE_FRONT",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
+            "shaders": {
+                "task_shader": "",
+                "mesh_shader": "",
+                "vertex_shader": "/ShadowMap\\DirLShadowMap.vert",
+                "geometry_shader": "",
+                "hull_shader": "",
+                "domain_shader": "",
+                "pixel_shader": "/ShadowMap\\DirLShadowMap.frag"
+            },
+            "resource_states": [
+                {
+                    "name": "SCENE_DRAW_ARGS",
+                    "removable": true,
+                    "draw_args_mask": 1,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_LIGHTS_BUFFER",
+                    "removable": true,
+                    "draw_args_mask": 1,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "DIRL_SHADOWMAP",
+                    "removable": true,
+                    "draw_args_mask": 1,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": ""
+                }
+            ]
+        },
+        {
             "name": "SKYBOX_PASS",
             "type": "GRAPHICS",
             "custom_renderer": false,
@@ -623,58 +675,6 @@
             ]
         },
         {
-            "name": "DIRL_SHADOWMAP",
-            "type": "GRAPHICS",
-            "custom_renderer": false,
-            "allow_overriding_of_binding_types": false,
-            "trigger_type": "TRIGGERED",
-            "frame_delay": 0,
-            "frame_offset": 0,
-            "x_dim_type": "CONSTANT",
-            "y_dim_type": "CONSTANT",
-            "z_dim_type": "CONSTANT",
-            "x_dim_var": 1024.0,
-            "y_dim_var": 1024.0,
-            "z_dim_var": 1.0,
-            "draw_type": "SCENE_INSTANCES",
-            "depth_test_enabled": true,
-            "cull_mode": "CULL_MODE_BACK",
-            "polygon_mode": "POLYGON_MODE_FILL",
-            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
-            "shaders": {
-                "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "/ShadowMap\\DirLShadowMap.vert",
-                "geometry_shader": "",
-                "hull_shader": "",
-                "domain_shader": "",
-                "pixel_shader": "/ShadowMap\\DirLShadowMap.frag"
-            },
-            "resource_states": [
-                {
-                    "name": "SCENE_DRAW_ARGS",
-                    "removable": true,
-                    "draw_args_mask": 1,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_LIGHTS_BUFFER",
-                    "removable": true,
-                    "draw_args_mask": 1,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "DIRL_SHADOWMAP",
-                    "removable": true,
-                    "draw_args_mask": 1,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": ""
-                }
-            ]
-        },
-        {
             "name": "FXAA",
             "type": "GRAPHICS",
             "custom_renderer": false,
@@ -690,7 +690,7 @@
             "z_dim_var": 1.0,
             "draw_type": "FULLSCREEN_QUAD",
             "depth_test_enabled": false,
-            "cull_mode": "CULL_MODE_BACK",
+            "cull_mode": "CULL_MODE_NONE",
             "polygon_mode": "POLYGON_MODE_FILL",
             "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
@@ -712,6 +712,58 @@
                 },
                 {
                     "name": "BACK_BUFFER_TEXTURE",
+                    "removable": true,
+                    "draw_args_mask": 1,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": ""
+                }
+            ]
+        },
+        {
+            "name": "RENDER_STAGE_LIGHT",
+            "type": "GRAPHICS",
+            "custom_renderer": true,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "TRIGGERED",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "CONSTANT",
+            "y_dim_type": "CONSTANT",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 512.0,
+            "y_dim_var": 512.0,
+            "z_dim_var": 1.0,
+            "draw_type": "SCENE_INSTANCES",
+            "depth_test_enabled": true,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
+            "shaders": {
+                "task_shader": "",
+                "mesh_shader": "",
+                "vertex_shader": "",
+                "geometry_shader": "",
+                "hull_shader": "",
+                "domain_shader": "",
+                "pixel_shader": ""
+            },
+            "resource_states": [
+                {
+                    "name": "SCENE_DRAW_ARGS",
+                    "removable": true,
+                    "draw_args_mask": 1,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_LIGHTS_BUFFER",
+                    "removable": true,
+                    "draw_args_mask": 1,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_POINT_SHADOWMAPS",
                     "removable": true,
                     "draw_args_mask": 1,
                     "binding_type": "ATTACHMENT",
@@ -817,58 +869,6 @@
                     "draw_args_mask": 1,
                     "binding_type": "COMBINED_SAMPLER",
                     "src_stage": "RENDER_STAGE_LIGHT"
-                }
-            ]
-        },
-        {
-            "name": "RENDER_STAGE_LIGHT",
-            "type": "GRAPHICS",
-            "custom_renderer": true,
-            "allow_overriding_of_binding_types": false,
-            "trigger_type": "TRIGGERED",
-            "frame_delay": 0,
-            "frame_offset": 0,
-            "x_dim_type": "CONSTANT",
-            "y_dim_type": "CONSTANT",
-            "z_dim_type": "CONSTANT",
-            "x_dim_var": 512.0,
-            "y_dim_var": 512.0,
-            "z_dim_var": 1.0,
-            "draw_type": "SCENE_INSTANCES",
-            "depth_test_enabled": true,
-            "cull_mode": "CULL_MODE_BACK",
-            "polygon_mode": "POLYGON_MODE_FILL",
-            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
-            "shaders": {
-                "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "",
-                "geometry_shader": "",
-                "hull_shader": "",
-                "domain_shader": "",
-                "pixel_shader": ""
-            },
-            "resource_states": [
-                {
-                    "name": "SCENE_DRAW_ARGS",
-                    "removable": true,
-                    "draw_args_mask": 1,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_LIGHTS_BUFFER",
-                    "removable": true,
-                    "draw_args_mask": 1,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_POINT_SHADOWMAPS",
-                    "removable": true,
-                    "draw_args_mask": 1,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": ""
                 }
             ]
         },
@@ -1101,8 +1101,8 @@
             "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
             "shaders": {
                 "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "/Geometry\\Geom.vert",
+                "mesh_shader": "/Geometry\\Geom.vert",
+                "vertex_shader": "",
                 "geometry_shader": "",
                 "hull_shader": "",
                 "domain_shader": "",

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -1079,11 +1079,15 @@ namespace LambdaEngine
 		if (m_RayTracingEnabled)
 		{
 			AccelerationStructureInstance asInstance = {};
-			asInstance.Transform		= glm::transpose(transform);
-			asInstance.CustomIndex		= materialIndex;
-			asInstance.Mask				= 0xFF;
-			asInstance.SBTRecordOffset	= 0;
-			asInstance.Flags			= RAY_TRACING_INSTANCE_FLAG_FORCE_OPAQUE;
+			asInstance.Transform						= glm::transpose(transform);
+			asInstance.CustomIndex						= materialIndex;
+			asInstance.Mask								= 0xFF;
+			asInstance.SBTRecordOffset					= 0;
+			asInstance.Flags							= RAY_TRACING_INSTANCE_FLAG_FORCE_OPAQUE;
+
+			//If the BLAS is already built, set it here
+			if (meshAndInstancesIt->second.pBLAS != nullptr)
+				asInstance.AccelerationStructureAddress	= meshAndInstancesIt->second.pBLAS->GetDeviceAdress();
 
 			meshAndInstancesIt->second.ASInstances.PushBack(asInstance);
 			m_DirtyASInstanceBuffers.insert(&meshAndInstancesIt->second);
@@ -1113,8 +1117,6 @@ namespace LambdaEngine
 
 	void RenderSystem::RemoveRenderableEntity(Entity entity)
 	{
-		LOG_ERROR("Remove Entity %d", entity);
-
 		THashTable<GUID_Lambda, InstanceKey>::iterator instanceKeyIt = m_EntityIDsToInstanceKey.find(entity);
 		if (instanceKeyIt == m_EntityIDsToInstanceKey.end())
 		{

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -712,6 +712,9 @@ namespace LambdaEngine
 							DescriptorSet** ppPrevDrawArgsPerFrame = pRenderStage->pppDrawArgDescriptorSets[b];
 							DescriptorSet** ppNewDrawArgsPerFrame = nullptr;
 
+							DescriptorSet** pTemp[3];
+							memcpy(pTemp, pRenderStage->pppDrawArgDescriptorSets, sizeof(pTemp));
+
 							DescriptorSet** ppPrevDrawArgsExtensionsPerFrame = pRenderStage->pppDrawArgExtensionsDescriptorSets ? pRenderStage->pppDrawArgExtensionsDescriptorSets[b] : nullptr;
 							DescriptorSet** ppNewDrawArgsExtensionsPerFrame = nullptr;
 
@@ -863,10 +866,12 @@ namespace LambdaEngine
 								}
 							}
 
+							SAFEDELETE_ARRAY(pRenderStage->pppDrawArgDescriptorSets[b]);
 							pRenderStage->pppDrawArgDescriptorSets[b] = ppNewDrawArgsPerFrame;
 
 							if (pRenderStage->pppDrawArgExtensionsDescriptorSets)
 							{
+								SAFEDELETE_ARRAY(pRenderStage->pppDrawArgExtensionsDescriptorSets[b]);
 								pRenderStage->pppDrawArgExtensionsDescriptorSets[b] = ppNewDrawArgsExtensionsPerFrame;
 							}
 						}

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -712,14 +712,13 @@ namespace LambdaEngine
 							DescriptorSet** ppPrevDrawArgsPerFrame = pRenderStage->pppDrawArgDescriptorSets[b];
 							DescriptorSet** ppNewDrawArgsPerFrame = nullptr;
 
-							DescriptorSet** pTemp[3];
-							memcpy(pTemp, pRenderStage->pppDrawArgDescriptorSets, sizeof(pTemp));
-
 							DescriptorSet** ppPrevDrawArgsExtensionsPerFrame = pRenderStage->pppDrawArgExtensionsDescriptorSets ? pRenderStage->pppDrawArgExtensionsDescriptorSets[b] : nullptr;
 							DescriptorSet** ppNewDrawArgsExtensionsPerFrame = nullptr;
 
 							// Check if it need to expand the list of descriptor sets
-							if (pRenderStage->NumDrawArgsPerFrame < drawArgsMaskToArgsIt->second.Args.GetSize())
+							bool resizeArr = pRenderStage->NumDrawArgsPerFrame < drawArgsMaskToArgsIt->second.Args.GetSize();
+
+							if (resizeArr)
 							{
 								ppNewDrawArgsPerFrame = DBG_NEW DescriptorSet * [drawArgsMaskToArgsIt->second.Args.GetSize()];
 
@@ -866,12 +865,13 @@ namespace LambdaEngine
 								}
 							}
 
-							SAFEDELETE_ARRAY(pRenderStage->pppDrawArgDescriptorSets[b]);
+							if (resizeArr) SAFEDELETE_ARRAY(pRenderStage->pppDrawArgDescriptorSets[b]);
+
 							pRenderStage->pppDrawArgDescriptorSets[b] = ppNewDrawArgsPerFrame;
 
 							if (pRenderStage->pppDrawArgExtensionsDescriptorSets)
 							{
-								SAFEDELETE_ARRAY(pRenderStage->pppDrawArgExtensionsDescriptorSets[b]);
+								if (resizeArr) SAFEDELETE_ARRAY(pRenderStage->pppDrawArgExtensionsDescriptorSets[b]);
 								pRenderStage->pppDrawArgExtensionsDescriptorSets[b] = ppNewDrawArgsExtensionsPerFrame;
 							}
 						}

--- a/LambdaEngine/Source/Resources/ResourceManager.cpp
+++ b/LambdaEngine/Source/Resources/ResourceManager.cpp
@@ -942,11 +942,6 @@ namespace LambdaEngine
 						return false;
 					}
 				}
-				else
-				{
-					LOG_ERROR("[ResourceManager]: UnloadMesh Failed at s_FileNamesToAnimationGUIDs");
-					return false;
-				}
 			}
 			else
 			{


### PR DESCRIPTION
Fixes Memory Leak in RenderGraph Draw Args Descriptor Sets
Fixes BLAS bug for new Instances that use the same BLAS build as previous instances, this also hopefully fixes the Device Lost problem with removing entities with ray tracing enabled.