### PR TITLE
Sampler array no longer necessary

### DIFF
--- a/LambdaEngine/Include/Game/ECS/Systems/Rendering/RenderSystem.h
+++ b/LambdaEngine/Include/Game/ECS/Systems/Rendering/RenderSystem.h
@@ -345,7 +345,6 @@ namespace LambdaEngine
 		// PAINT_MASK_TEXTURES
 		TArray<Texture*>			m_PaintMaskTextures;
 		TArray<TextureView*>		m_PaintMaskTextureViews;
-		TArray<Sampler*>			m_PaintMaskSamplers;
 
 		// Materials
 		TArray<Texture*>			m_AlbedoMaps;

--- a/LambdaEngine/Include/Rendering/Core/API/DescriptorSet.h
+++ b/LambdaEngine/Include/Rendering/Core/API/DescriptorSet.h
@@ -15,7 +15,7 @@ namespace LambdaEngine
 	public:
 		DECL_DEVICE_INTERFACE(DescriptorSet);
 
-		virtual void WriteTextureDescriptors(const TextureView* const* ppTextures, const Sampler* const* ppSamplers, ETextureState textureState, uint32 firstBinding, uint32 descriptorCount, EDescriptorType type)	= 0;
+		virtual void WriteTextureDescriptors(const TextureView* const* ppTextures, const Sampler* const* ppSamplers, ETextureState textureState, uint32 firstBinding, uint32 descriptorCount, EDescriptorType type, bool uniqueSamplers)	= 0;
 		virtual void WriteBufferDescriptors(const Buffer* const * ppBuffers, const uint64* pOffsets, const uint64* pSizes, uint32 firstBinding, uint32 descriptorCount, EDescriptorType type)						= 0;
 		virtual void WriteAccelerationStructureDescriptors(const AccelerationStructure* const * ppAccelerationStructures, uint32 firstBinding, uint32 descriptorCount)												= 0;
 

--- a/LambdaEngine/Include/Rendering/Core/Vulkan/DescriptorSetVK.h
+++ b/LambdaEngine/Include/Rendering/Core/Vulkan/DescriptorSetVK.h
@@ -52,7 +52,7 @@ namespace LambdaEngine
 		virtual void SetName(const String& name) override final;
 
 		// DesciptorSet Interface
-		virtual void WriteTextureDescriptors(const TextureView* const* ppTextures, const Sampler* const* ppSamplers, ETextureState textureState, uint32 firstBinding, uint32 descriptorCount, EDescriptorType type) override final;
+		virtual void WriteTextureDescriptors(const TextureView* const* ppTextures, const Sampler* const* ppSamplers, ETextureState textureState, uint32 firstBinding, uint32 descriptorCount, EDescriptorType type, bool uniqueSamplers) override final;
 		virtual void WriteBufferDescriptors(const Buffer* const* ppBuffers, const uint64* pOffsets, const uint64* pSizes, uint32 firstBinding, uint32 descriptorCount, EDescriptorType type)	override final;
 		virtual void WriteAccelerationStructureDescriptors(const AccelerationStructure* const * ppAccelerationStructures, uint32 firstBinding, uint32 descriptorCount) override final;
 

--- a/LambdaEngine/Include/Rendering/RenderGraph.h
+++ b/LambdaEngine/Include/Rendering/RenderGraph.h
@@ -89,7 +89,7 @@ namespace LambdaEngine
 				TextureView**	ppPerSubImageTextureViews;
 				Sampler**		ppSamplers;
 				uint32			TextureCount;
-				uint16			SamplerCount;
+				uint32			SamplerCount;
 				uint32			PerImageSubImageTextureViewCount;
 			} ExternalTextureUpdate;
 

--- a/LambdaEngine/Include/Rendering/RenderGraph.h
+++ b/LambdaEngine/Include/Rendering/RenderGraph.h
@@ -88,7 +88,8 @@ namespace LambdaEngine
 				TextureView**	ppTextureViews;
 				TextureView**	ppPerSubImageTextureViews;
 				Sampler**		ppSamplers;
-				uint32			Count;
+				uint32			TextureCount;
+				uint16			SamplerCount;
 				uint32			PerImageSubImageTextureViewCount;
 			} ExternalTextureUpdate;
 

--- a/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
@@ -501,9 +501,9 @@ namespace LambdaEngine
 			DescriptorSet* pDescriptorSet = CreateOrGetDescriptorSet();
 			pDescriptorSet->WriteBufferDescriptors(&pParamsBuffer, &paramsOffset, &paramsSize, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_CONSTANT_BUFFER);
 			if (batch.pattern != nullptr) 
-				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.pattern)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 1, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.pattern)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 1, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 			if (batch.ramps != nullptr)	
-				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.ramps)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 2, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.ramps)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 2, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 			
 			if (batch.image != nullptr)
 			{
@@ -522,13 +522,13 @@ namespace LambdaEngine
 						ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
 				}
 
-				pDescriptorSet->WriteTextureDescriptors(pTexture->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 3, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				pDescriptorSet->WriteTextureDescriptors(pTexture->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 3, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 			}
 
 			if (batch.glyphs != nullptr)	
-				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.glyphs)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 4, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.glyphs)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 4, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 			if (batch.shadow != nullptr)	
-				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.shadow)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 5, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				pDescriptorSet->WriteTextureDescriptors(reinterpret_cast<GUITexture*>(batch.shadow)->GetTextureViewToBind(), &m_pGUISampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 5, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 
 			pRenderCommandList->BindDescriptorSetGraphics(pDescriptorSet, GUIPipelineStateCache::GetPipelineLayout(), 0);
 		}

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -1104,7 +1104,6 @@ namespace LambdaEngine
 
 					m_PaintMaskTextures.PushBack(pTexture);
 					m_PaintMaskTextureViews.PushBack(pTextureView);
-					Sampler* sampler = Sampler::GetNearestSampler();
 
 					ResourceUpdateDesc unwrappedTextureUpdate = {};
 					unwrappedTextureUpdate.ResourceName = "PAINT_MASK_TEXTURES";
@@ -1112,7 +1111,7 @@ namespace LambdaEngine
 					unwrappedTextureUpdate.ExternalTextureUpdate.ppTextureViews						= m_PaintMaskTextureViews.GetData();
 					unwrappedTextureUpdate.ExternalTextureUpdate.ppPerSubImageTextureViews			= nullptr;
 					unwrappedTextureUpdate.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= 0;
-					unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= &sampler;
+					unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= &pNearestSampler;
 					unwrappedTextureUpdate.ExternalTextureUpdate.TextureCount						= m_PaintMaskTextures.GetSize();
 					unwrappedTextureUpdate.ExternalTextureUpdate.SamplerCount						= 1;
 
@@ -1237,14 +1236,14 @@ namespace LambdaEngine
 					}
 				}	
 
-				Sampler* sampler = Sampler::GetNearestSampler();
+				Sampler* pNearestSampler = Sampler::GetNearestSampler();
 				ResourceUpdateDesc unwrappedTextureUpdate = {};
 				unwrappedTextureUpdate.ResourceName = "PAINT_MASK_TEXTURES";
 				unwrappedTextureUpdate.ExternalTextureUpdate.ppTextures							= m_PaintMaskTextures.GetData();
 				unwrappedTextureUpdate.ExternalTextureUpdate.ppTextureViews						= m_PaintMaskTextureViews.GetData();
 				unwrappedTextureUpdate.ExternalTextureUpdate.ppPerSubImageTextureViews			= nullptr;
 				unwrappedTextureUpdate.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= 0;
-				unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= &sampler;
+				unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= &pNearestSampler;
 				unwrappedTextureUpdate.ExternalTextureUpdate.TextureCount						= m_PaintMaskTextures.GetSize();
 				unwrappedTextureUpdate.ExternalTextureUpdate.SamplerCount						= 1;
 
@@ -2139,7 +2138,7 @@ namespace LambdaEngine
 		if (needUpdate)
 		{
 			uint32 texturesExisting = m_CubeTextures.GetSize();
-			Sampler* nearestSampler = Sampler::GetNearestSampler();
+			Sampler* pNearestSampler = Sampler::GetNearestSampler();
 			ResourceUpdateDesc resourceUpdateDesc = {};
 			resourceUpdateDesc.ResourceName = SCENE_POINT_SHADOWMAPS;
 			resourceUpdateDesc.ExternalTextureUpdate.ppTextures							= m_CubeTextures.GetData();
@@ -2147,7 +2146,7 @@ namespace LambdaEngine
 			resourceUpdateDesc.ExternalTextureUpdate.TextureCount								= texturesExisting;
 			resourceUpdateDesc.ExternalTextureUpdate.ppPerSubImageTextureViews			= m_CubeSubImageTextureViews.GetData();
 			resourceUpdateDesc.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= CUBE_FACE_COUNT;
-			resourceUpdateDesc.ExternalTextureUpdate.ppSamplers							= &nearestSampler;
+			resourceUpdateDesc.ExternalTextureUpdate.ppSamplers							= &pNearestSampler;
 			resourceUpdateDesc.ExternalTextureUpdate.SamplerCount						= 1;
 			m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
 		}
@@ -2289,13 +2288,13 @@ namespace LambdaEngine
 
 			m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
 
-			Sampler* linearSamplers = Sampler::GetLinearSampler();
+			Sampler* pLinearSamplers = Sampler::GetLinearSampler();
 
 			ResourceUpdateDesc albedoMapsUpdateDesc = {};
 			albedoMapsUpdateDesc.ResourceName							= SCENE_ALBEDO_MAPS;
 			albedoMapsUpdateDesc.ExternalTextureUpdate.ppTextures		= m_AlbedoMaps.GetData();
 			albedoMapsUpdateDesc.ExternalTextureUpdate.ppTextureViews	= m_AlbedoMapViews.GetData();
-			albedoMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= &linearSamplers;
+			albedoMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= &pLinearSamplers;
 			albedoMapsUpdateDesc.ExternalTextureUpdate.TextureCount		= m_AlbedoMaps.GetSize();
 			albedoMapsUpdateDesc.ExternalTextureUpdate.SamplerCount		= 1;
 
@@ -2303,7 +2302,7 @@ namespace LambdaEngine
 			normalMapsUpdateDesc.ResourceName							= SCENE_NORMAL_MAPS;
 			normalMapsUpdateDesc.ExternalTextureUpdate.ppTextures		= m_NormalMaps.GetData();
 			normalMapsUpdateDesc.ExternalTextureUpdate.ppTextureViews	= m_NormalMapViews.GetData();
-			normalMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= &linearSamplers;
+			normalMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= &pLinearSamplers;
 			normalMapsUpdateDesc.ExternalTextureUpdate.TextureCount		= m_NormalMapViews.GetSize();
 			normalMapsUpdateDesc.ExternalTextureUpdate.SamplerCount		= 1;
 
@@ -2311,7 +2310,7 @@ namespace LambdaEngine
 			combinedMaterialMapsUpdateDesc.ResourceName								= SCENE_COMBINED_MATERIAL_MAPS;
 			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppTextures			= m_CombinedMaterialMaps.GetData();
 			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppTextureViews		= m_CombinedMaterialMapViews.GetData();
-			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppSamplers			= &linearSamplers;
+			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppSamplers			= &pLinearSamplers;
 			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.TextureCount		= m_CombinedMaterialMaps.GetSize();
 			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.SamplerCount		= 1;
 

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -1100,13 +1100,11 @@ namespace LambdaEngine
 					{
 						m_PaintMaskTextures.PushBack(ResourceManager::GetTexture(GUID_TEXTURE_DEFAULT_MASK_MAP));
 						m_PaintMaskTextureViews.PushBack(ResourceManager::GetTextureView(GUID_TEXTURE_DEFAULT_MASK_MAP));
-						m_PaintMaskSamplers.PushBack(Sampler::GetNearestSampler());
 					}
 
 					m_PaintMaskTextures.PushBack(pTexture);
 					m_PaintMaskTextureViews.PushBack(pTextureView);
-					m_PaintMaskSamplers.PushBack(pNearestSampler); // In an ideal world we would only have one sampler instead of a list
-					// TODO: Update rendergraph to support only one sampler for several texture views
+					Sampler* sampler = Sampler::GetNearestSampler();
 
 					ResourceUpdateDesc unwrappedTextureUpdate = {};
 					unwrappedTextureUpdate.ResourceName = "PAINT_MASK_TEXTURES";
@@ -1114,8 +1112,9 @@ namespace LambdaEngine
 					unwrappedTextureUpdate.ExternalTextureUpdate.ppTextureViews						= m_PaintMaskTextureViews.GetData();
 					unwrappedTextureUpdate.ExternalTextureUpdate.ppPerSubImageTextureViews			= nullptr;
 					unwrappedTextureUpdate.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= 0;
-					unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= m_PaintMaskSamplers.GetData();
-					unwrappedTextureUpdate.ExternalTextureUpdate.Count								= m_PaintMaskTextures.GetSize();
+					unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= &sampler;
+					unwrappedTextureUpdate.ExternalTextureUpdate.TextureCount						= m_PaintMaskTextures.GetSize();
+					unwrappedTextureUpdate.ExternalTextureUpdate.SamplerCount						= 1;
 
 					RenderSystem::GetInstance().GetRenderGraph()->UpdateResource(&unwrappedTextureUpdate);
 				}
@@ -1228,8 +1227,6 @@ namespace LambdaEngine
 				m_PaintMaskTextures.PopBack();
 				m_PaintMaskTextureViews[textureIndex]	= m_PaintMaskTextureViews.GetBack();
 				m_PaintMaskTextureViews.PopBack();
-				m_PaintMaskSamplers[textureIndex]		= m_PaintMaskSamplers.GetBack();
-				m_PaintMaskSamplers.PopBack();
 
 				// Update custom indicies
 				for (auto& instance : asInstances)
@@ -1240,14 +1237,16 @@ namespace LambdaEngine
 					}
 				}	
 
+				Sampler* sampler = Sampler::GetNearestSampler();
 				ResourceUpdateDesc unwrappedTextureUpdate = {};
 				unwrappedTextureUpdate.ResourceName = "PAINT_MASK_TEXTURES";
 				unwrappedTextureUpdate.ExternalTextureUpdate.ppTextures							= m_PaintMaskTextures.GetData();
 				unwrappedTextureUpdate.ExternalTextureUpdate.ppTextureViews						= m_PaintMaskTextureViews.GetData();
 				unwrappedTextureUpdate.ExternalTextureUpdate.ppPerSubImageTextureViews			= nullptr;
 				unwrappedTextureUpdate.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= 0;
-				unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= m_PaintMaskSamplers.GetData();
-				unwrappedTextureUpdate.ExternalTextureUpdate.Count								= m_PaintMaskTextures.GetSize();
+				unwrappedTextureUpdate.ExternalTextureUpdate.ppSamplers							= &sampler;
+				unwrappedTextureUpdate.ExternalTextureUpdate.TextureCount						= m_PaintMaskTextures.GetSize();
+				unwrappedTextureUpdate.ExternalTextureUpdate.SamplerCount						= 1;
 
 				RenderSystem::GetInstance().GetRenderGraph()->UpdateResource(&unwrappedTextureUpdate);
 			}
@@ -2140,15 +2139,16 @@ namespace LambdaEngine
 		if (needUpdate)
 		{
 			uint32 texturesExisting = m_CubeTextures.GetSize();
-			TArray<Sampler*> nearestSamplers(texturesExisting, Sampler::GetNearestSampler());
+			Sampler* nearestSampler = Sampler::GetNearestSampler();
 			ResourceUpdateDesc resourceUpdateDesc = {};
 			resourceUpdateDesc.ResourceName = SCENE_POINT_SHADOWMAPS;
 			resourceUpdateDesc.ExternalTextureUpdate.ppTextures							= m_CubeTextures.GetData();
 			resourceUpdateDesc.ExternalTextureUpdate.ppTextureViews						= m_CubeTextureViews.GetData();
-			resourceUpdateDesc.ExternalTextureUpdate.Count								= texturesExisting;
+			resourceUpdateDesc.ExternalTextureUpdate.TextureCount								= texturesExisting;
 			resourceUpdateDesc.ExternalTextureUpdate.ppPerSubImageTextureViews			= m_CubeSubImageTextureViews.GetData();
 			resourceUpdateDesc.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= CUBE_FACE_COUNT;
-			resourceUpdateDesc.ExternalTextureUpdate.ppSamplers							= nearestSamplers.GetData();
+			resourceUpdateDesc.ExternalTextureUpdate.ppSamplers							= &nearestSampler;
+			resourceUpdateDesc.ExternalTextureUpdate.SamplerCount						= 1;
 			m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
 		}
 	}
@@ -2289,28 +2289,31 @@ namespace LambdaEngine
 
 			m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
 
-			TArray<Sampler*> linearSamplers(m_AlbedoMaps.GetSize(), Sampler::GetLinearSampler());
+			Sampler* linearSamplers = Sampler::GetLinearSampler();
 
 			ResourceUpdateDesc albedoMapsUpdateDesc = {};
 			albedoMapsUpdateDesc.ResourceName							= SCENE_ALBEDO_MAPS;
 			albedoMapsUpdateDesc.ExternalTextureUpdate.ppTextures		= m_AlbedoMaps.GetData();
 			albedoMapsUpdateDesc.ExternalTextureUpdate.ppTextureViews	= m_AlbedoMapViews.GetData();
-			albedoMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= linearSamplers.GetData();
-			albedoMapsUpdateDesc.ExternalTextureUpdate.Count			= m_AlbedoMaps.GetSize();
+			albedoMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= &linearSamplers;
+			albedoMapsUpdateDesc.ExternalTextureUpdate.TextureCount		= m_AlbedoMaps.GetSize();
+			albedoMapsUpdateDesc.ExternalTextureUpdate.SamplerCount		= 1;
 
 			ResourceUpdateDesc normalMapsUpdateDesc = {};
 			normalMapsUpdateDesc.ResourceName							= SCENE_NORMAL_MAPS;
 			normalMapsUpdateDesc.ExternalTextureUpdate.ppTextures		= m_NormalMaps.GetData();
 			normalMapsUpdateDesc.ExternalTextureUpdate.ppTextureViews	= m_NormalMapViews.GetData();
-			normalMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= linearSamplers.GetData();
-			normalMapsUpdateDesc.ExternalTextureUpdate.Count			= m_NormalMapViews.GetSize();
+			normalMapsUpdateDesc.ExternalTextureUpdate.ppSamplers		= &linearSamplers;
+			normalMapsUpdateDesc.ExternalTextureUpdate.TextureCount		= m_NormalMapViews.GetSize();
+			normalMapsUpdateDesc.ExternalTextureUpdate.SamplerCount		= 1;
 
 			ResourceUpdateDesc combinedMaterialMapsUpdateDesc = {};
 			combinedMaterialMapsUpdateDesc.ResourceName								= SCENE_COMBINED_MATERIAL_MAPS;
 			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppTextures			= m_CombinedMaterialMaps.GetData();
 			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppTextureViews		= m_CombinedMaterialMapViews.GetData();
-			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppSamplers			= linearSamplers.GetData();
-			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.Count				= m_CombinedMaterialMaps.GetSize();
+			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.ppSamplers			= &linearSamplers;
+			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.TextureCount		= m_CombinedMaterialMaps.GetSize();
+			combinedMaterialMapsUpdateDesc.ExternalTextureUpdate.SamplerCount		= 1;
 
 			m_pRenderGraph->UpdateResource(&albedoMapsUpdateDesc);
 			m_pRenderGraph->UpdateResource(&normalMapsUpdateDesc);

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/DescriptorSetVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/DescriptorSetVK.cpp
@@ -64,7 +64,7 @@ namespace LambdaEngine
 		m_pDevice->SetVulkanObjectName(debugName, reinterpret_cast<uint64>(m_DescriptorSet), VK_OBJECT_TYPE_DESCRIPTOR_SET);
 	}
 
-	void DescriptorSetVK::WriteTextureDescriptors(const TextureView* const* ppTextures, const Sampler* const* ppSamplers, ETextureState textureState, uint32 firstBinding, uint32 descriptorCount, EDescriptorType descriptorType)
+	void DescriptorSetVK::WriteTextureDescriptors(const TextureView* const* ppTextures, const Sampler* const* ppSamplers, ETextureState textureState, uint32 firstBinding, uint32 descriptorCount, EDescriptorType descriptorType, bool uniqueSamplers)
 	{
 		VALIDATE(ppTextures != nullptr);
 		VALIDATE(firstBinding < m_Bindings.GetSize());
@@ -92,8 +92,8 @@ namespace LambdaEngine
 					{
 						if (ppVkSamplers != nullptr)
 						{
-							VALIDATE(ppVkSamplers[i] != nullptr);
-							imageInfo.sampler = ppVkSamplers[i]->GetSampler();
+							VALIDATE(ppVkSamplers[uniqueSamplers ? i : 0] != nullptr);
+							imageInfo.sampler = ppVkSamplers[uniqueSamplers ? i : 0]->GetSampler();
 						}
 						else
 						{

--- a/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
@@ -137,7 +137,7 @@ namespace LambdaEngine
 			return false;
 		}
 
-		m_DescriptorSet->WriteTextureDescriptors(&m_FontTextureView, &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+		m_DescriptorSet->WriteTextureDescriptors(&m_FontTextureView, &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 
 		EventHandler eventHandler(this, &ImGuiRenderer::OnEvent);
 
@@ -241,12 +241,12 @@ namespace LambdaEngine
 						descriptorSets.Resize(1);
 						TSharedRef<DescriptorSet> descriptorSet = m_pGraphicsDevice->CreateDescriptorSet("ImGui Custom Texture Descriptor Set", m_PipelineLayout.Get(), 0, m_DescriptorHeap.Get());
 						descriptorSets[0] = descriptorSet;
-						descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[imageIndex], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+						descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[imageIndex], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 					}
 					else
 					{
 						TArray<TSharedRef<DescriptorSet>>& descriptorSets = m_TextureResourceNameDescriptorSetsMap[currentResourceName];
-						descriptorSets[0]->WriteTextureDescriptors(&ppPerImageTextureViews[imageIndex], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+						descriptorSets[0]->WriteTextureDescriptors(&ppPerImageTextureViews[imageIndex], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 					}
 				}
 			}
@@ -265,7 +265,7 @@ namespace LambdaEngine
 							TSharedRef<DescriptorSet> descriptorSet = m_pGraphicsDevice->CreateDescriptorSet("ImGui Custom Texture Descriptor Set", m_PipelineLayout.Get(), 0, m_DescriptorHeap.Get());
 							descriptorSets[b] = descriptorSet;
 
-							descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+							descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 						}
 					}
 					else
@@ -276,7 +276,7 @@ namespace LambdaEngine
 							TSharedRef<DescriptorSet> descriptorSet = m_pGraphicsDevice->CreateDescriptorSet("ImGui Custom Texture Descriptor Set", m_PipelineLayout.Get(), 0, m_DescriptorHeap.Get());
 							descriptorSets[b] = descriptorSet;
 
-							descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+							descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 						}
 					}
 				}
@@ -291,7 +291,7 @@ namespace LambdaEngine
 							for (uint32 b = 0; b < backBufferCount; b++)
 							{
 								TSharedRef<DescriptorSet> descriptorSet = descriptorSets[b];
-								descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+								descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 							}
 						}
 					}
@@ -302,7 +302,7 @@ namespace LambdaEngine
 							for (uint32 b = 0; b < imageCount; b++)
 							{
 								TSharedRef<DescriptorSet> descriptorSet = descriptorSets[b];
-								descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+								descriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[b], &m_Sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 							}
 						}
 						else

--- a/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
@@ -219,11 +219,11 @@ namespace LambdaEngine
 			if (!m_BrushMaskDescriptorSet.Get())
 			{
 				m_BrushMaskDescriptorSet = m_pGraphicsDevice->CreateDescriptorSet("Paint Mask Renderer Custom Buffer Descriptor Set", m_PipelineLayout.Get(), 1, m_DescriptorHeap.Get());
-				m_BrushMaskDescriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[0], &sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				m_BrushMaskDescriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[0], &sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 			}
 			else
 			{
-				m_BrushMaskDescriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[0], &sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				m_BrushMaskDescriptorSet->WriteTextureDescriptors(&ppPerImageTextureViews[0], &sampler, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, 0, 1, EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER, true);
 			}
 		}
 	}

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -3324,6 +3324,12 @@ namespace LambdaEngine
 		{
 			uniqueSamplers = pDesc->ExternalTextureUpdate.TextureCount == pDesc->ExternalTextureUpdate.SamplerCount;
 
+			if (!uniqueSamplers && pDesc->ExternalTextureUpdate.SamplerCount > 1)
+			{
+				LOG_WARNING("[RenderGraph, UpdateResourceTexture]: SamplerCount does not match TextureCount and is not equal to 1. Only the first sampler will be used. TextureCount = %d, SamplerCount = %d",
+				pDesc->ExternalTextureUpdate.TextureCount, pDesc->ExternalTextureUpdate.SamplerCount);
+			}
+
 			//We don't know the subresource count until now so we must update all container arrays
 			actualSubResourceCount = pDesc->ExternalTextureUpdate.TextureCount;
 			pResource->Texture.Textures.Resize(actualSubResourceCount);

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -664,7 +664,8 @@ namespace LambdaEngine
 									pResourceBinding->TextureState,
 									pResourceBinding->Binding,
 									1,
-									pResourceBinding->DescriptorType);
+									pResourceBinding->DescriptorType,
+									true);
 							}
 						}
 						else
@@ -677,7 +678,8 @@ namespace LambdaEngine
 									pResourceBinding->TextureState,
 									pResourceBinding->Binding,
 									pResource->Texture.PerImageTextureViews.GetSize(),
-									pResourceBinding->DescriptorType);
+									pResourceBinding->DescriptorType,
+									pResource->Texture.Samplers.GetSize() == pResource->Texture.PerImageTextureViews.GetSize());
 							}
 						}
 					}
@@ -828,7 +830,8 @@ namespace LambdaEngine
 											ETextureState::TEXTURE_STATE_SHADER_READ_ONLY,
 											binding++,
 											textureCount,
-											EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+											EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER,
+											true);
 									}
 
 									ppNewDrawArgsExtensionsPerFrame[d] = pExtensionsWriteDescriptorSet;
@@ -845,7 +848,8 @@ namespace LambdaEngine
 										ETextureState::TEXTURE_STATE_SHADER_READ_ONLY,
 										0,
 										1,
-										EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER
+										EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER,
+										true
 									);
 
 									ppNewDrawArgsExtensionsPerFrame[d] = pExtensionsWriteDescriptorSet;
@@ -1234,7 +1238,8 @@ namespace LambdaEngine
 							binding.TextureState,
 							binding.Binding,
 							1,
-							binding.DescriptorType);
+							binding.DescriptorType,
+							true);
 					}
 				}
 			}
@@ -3311,15 +3316,19 @@ namespace LambdaEngine
 	void RenderGraph::UpdateResourceTexture(Resource* pResource, const ResourceUpdateDesc* pDesc)
 	{
 		uint32 actualSubResourceCount = 0;
+		// If true, every texture has a unique sampler (or atleast a sampler array the same size of the texture array)
+		bool uniqueSamplers = true;
 
 		//Unbounded arrays are handled differently compared to normal textures
 		if (pResource->Texture.UnboundedArray)
 		{
+			uniqueSamplers = pDesc->ExternalTextureUpdate.TextureCount == pDesc->ExternalTextureUpdate.SamplerCount;
+
 			//We don't know the subresource count until now so we must update all container arrays
-			actualSubResourceCount = pDesc->ExternalTextureUpdate.Count;
+			actualSubResourceCount = pDesc->ExternalTextureUpdate.TextureCount;
 			pResource->Texture.Textures.Resize(actualSubResourceCount);
 			pResource->Texture.PerImageTextureViews.Resize(actualSubResourceCount);
-			pResource->Texture.Samplers.Resize(actualSubResourceCount);
+			pResource->Texture.Samplers.Resize(uniqueSamplers ? pDesc->ExternalTextureUpdate.TextureCount : 1);
 			pResource->Texture.PerSubImageTextureViews.Resize(actualSubResourceCount * (pDesc->ExternalTextureUpdate.ppPerSubImageTextureViews != nullptr ? pDesc->ExternalTextureUpdate.PerImageSubImageTextureViewCount : 1));
 
 			//We must clear all non-template barriers
@@ -3353,7 +3362,7 @@ namespace LambdaEngine
 		{
 			Texture** ppTexture			= &pResource->Texture.Textures[sr];
 			TextureView** ppTextureView = &pResource->Texture.PerImageTextureViews[sr];
-			Sampler** ppSampler			= &pResource->Texture.Samplers[sr];
+			Sampler** ppSampler			= &pResource->Texture.Samplers[uniqueSamplers ? sr : 0];
 
 			Texture* pTexture						= nullptr;
 			TextureView* pTextureView				= nullptr;
@@ -3432,7 +3441,7 @@ namespace LambdaEngine
 				//Update Sampler
 				if (pDesc->ExternalTextureUpdate.ppSamplers != nullptr)
 				{
-					pSampler = pDesc->ExternalTextureUpdate.ppSamplers[sr];
+					pSampler = pDesc->ExternalTextureUpdate.ppSamplers[uniqueSamplers ? sr : 0];
 				}
 			}
 			else

--- a/LambdaEngine/Source/Resources/ResourceManager.cpp
+++ b/LambdaEngine/Source/Resources/ResourceManager.cpp
@@ -790,7 +790,8 @@ namespace LambdaEngine
 				ETextureState::TEXTURE_STATE_SHADER_READ_ONLY,
 				0,
 				1,
-				EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER,
+				true);
 
 			s_pMaterialDescriptorSet->WriteTextureDescriptors(
 				&pMetallicMapView,
@@ -798,7 +799,8 @@ namespace LambdaEngine
 				ETextureState::TEXTURE_STATE_SHADER_READ_ONLY,
 				1,
 				1,
-				EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER,
+				true);
 
 			s_pMaterialDescriptorSet->WriteTextureDescriptors(
 				&pRoughnessMapView,
@@ -806,7 +808,8 @@ namespace LambdaEngine
 				ETextureState::TEXTURE_STATE_SHADER_READ_ONLY,
 				2,
 				1,
-				EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER);
+				EDescriptorType::DESCRIPTOR_TYPE_SHADER_RESOURCE_COMBINED_SAMPLER,
+				true);
 
 			s_pMaterialDescriptorSet->WriteTextureDescriptors(
 				&pCombinedMaterialTextureView,
@@ -814,7 +817,8 @@ namespace LambdaEngine
 				ETextureState::TEXTURE_STATE_GENERAL,
 				3,
 				1,
-				EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_TEXTURE);
+				EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_TEXTURE,
+				true);
 		}
 
 		PipelineTextureBarrierDesc transitionToCopyDstBarrier = { };


### PR DESCRIPTION
### Changes
* When using updateResoruce or writeDescriptorSet it is no longer necessary to have the same length for the sampler as the texture arrays. This is done since most of the time we are using the same sampler for all of the textures (nearest or linear).