### PR TITLE
Projectile trigger shape

### DIFF
--- a/CrazyCanvas/Include/ECS/Components/Player/Player.h
+++ b/CrazyCanvas/Include/ECS/Components/Player/Player.h
@@ -23,7 +23,6 @@ namespace LambdaEngine
 	public:
 		GroupedComponent<PlayerBaseComponent> PlayerBaseComponent;
 
-
 		// Transform
 		GroupedComponent<PositionComponent>	Position;
 		GroupedComponent<ScaleComponent>	Scale;

--- a/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
@@ -133,6 +133,7 @@ void WeaponSystem::Fire(WeaponComponent& weaponComponent, const glm::vec3& start
 		/* Scale */				pECS->AddComponent<ScaleComponent>(projectileEntity, {true, { 0.3f, 0.3f, 0.3f }}),
 		/* Rotation */			pECS->AddComponent<RotationComponent>(projectileEntity, {true, direction}),
 		/* Mesh */				pECS->AddComponent<MeshComponent>(projectileEntity, {m_ProjectileMeshComponent}),
+		/* Shape Type */		EShapeType::TRIGGER,
 		/* CollisionGroup */	FCollisionGroup::COLLISION_GROUP_DYNAMIC,
 		/* CollisionMask */		FCollisionGroup::COLLISION_GROUP_PLAYER | FCollisionGroup::COLLISION_GROUP_STATIC,
 		/* CollisionCallback */ std::bind(&WeaponSystem::OnProjectileHit, this, std::placeholders::_1, std::placeholders::_2),

--- a/CrazyCanvas/Source/EventHandlers/AudioEffectHandler.cpp
+++ b/CrazyCanvas/Source/EventHandlers/AudioEffectHandler.cpp
@@ -13,7 +13,7 @@ AudioEffectHandler::~AudioEffectHandler()
 void AudioEffectHandler::Init()
 {
 	using namespace LambdaEngine;
-	GUID_Lambda projectileHitID = ResourceManager::LoadSoundEffectFromFile("Fart.wav");
+	GUID_Lambda projectileHitID = ResourceManager::LoadSoundEffectFromFile("9_mm_gunshot-mike-koenig-123.wav");
 	m_pProjectileHitSound = ResourceManager::GetSoundEffect(projectileHitID);
 
 	EventQueue::RegisterEventHandler<ProjectileHitEvent, AudioEffectHandler>(this, &AudioEffectHandler::OnProjectileHit);

--- a/CrazyCanvas/Source/States/BenchmarkState.cpp
+++ b/CrazyCanvas/Source/States/BenchmarkState.cpp
@@ -214,6 +214,7 @@ void BenchmarkState::Init()
 					.Scale			= pECS->AddComponent<ScaleComponent>(entity, { true, scale }),
 					.Rotation		= pECS->AddComponent<RotationComponent>(entity, { true, glm::identity<glm::quat>() }),
 					.Mesh			= pECS->AddComponent<MeshComponent>(entity, sphereMeshComp),
+					.ShapeType		= EShapeType::SIMULATION,
 					.CollisionGroup	= FCollisionGroup::COLLISION_GROUP_STATIC,
 					.CollisionMask	= ~FCollisionGroup::COLLISION_GROUP_STATIC // Collide with any non-static object
 				};

--- a/CrazyCanvas/Source/States/PlaySessionState.cpp
+++ b/CrazyCanvas/Source/States/PlaySessionState.cpp
@@ -156,6 +156,7 @@ void PlaySessionState::Init()
 	//				.Scale			= pECS->AddComponent<ScaleComponent>(entity, { true, scale }),
 	//				.Rotation		= pECS->AddComponent<RotationComponent>(entity, { true, glm::identity<glm::quat>() }),
 	//				.Mesh			= pECS->AddComponent<MeshComponent>(entity, sphereMeshComp),
+	//				.ShapeType		= EShapeType::SIMULATION,
 	//				.CollisionGroup	= FCollisionGroup::COLLISION_GROUP_STATIC,
 	//				.CollisionMask	= ~FCollisionGroup::COLLISION_GROUP_STATIC // Collide with any non-static object
 	//			};

--- a/CrazyCanvas/Source/States/SandboxState.cpp
+++ b/CrazyCanvas/Source/States/SandboxState.cpp
@@ -241,6 +241,7 @@ void SandboxState::Init()
 	//				.Scale = pECS->AddComponent<ScaleComponent>(entity, { true, scale }),
 	//				.Rotation = pECS->AddComponent<RotationComponent>(entity, { true, glm::identity<glm::quat>() }),
 	//				.Mesh = pECS->AddComponent<MeshComponent>(entity, sphereMeshComp),
+	//				.ShapeType		= EShapeType::SIMULATION,
 	//				.CollisionGroup = FCollisionGroup::COLLISION_GROUP_STATIC,
 	//				.CollisionMask = ~FCollisionGroup::COLLISION_GROUP_STATIC // Collide with any non-static object
 	//			};

--- a/CrazyCanvas/Source/World/LevelObjectCreator.cpp
+++ b/CrazyCanvas/Source/World/LevelObjectCreator.cpp
@@ -138,6 +138,7 @@ LambdaEngine::Entity LevelObjectCreator::CreateStaticGeometry(const LambdaEngine
 		.Scale			= pECS->AddComponent<ScaleComponent>(entity, { true, glm::vec3(1.0f) }),
 		.Rotation		= pECS->AddComponent<RotationComponent>(entity, { true, glm::identity<glm::quat>() }),
 		.Mesh			= pECS->AddComponent<MeshComponent>(entity, meshComponent),
+		.ShapeType		= EShapeType::SIMULATION,
 		.CollisionGroup = FCollisionGroup::COLLISION_GROUP_STATIC,
 		.CollisionMask	= ~FCollisionGroup::COLLISION_GROUP_STATIC // Collide with any non-static object
 	};

--- a/LambdaEngine/Include/Game/ECS/Systems/Physics/PhysicsSystem.h
+++ b/LambdaEngine/Include/Game/ECS/Systems/Physics/PhysicsSystem.h
@@ -21,6 +21,12 @@ namespace LambdaEngine
 	struct RotationComponent;
 	struct VelocityComponent;
 
+	enum class EShapeType
+	{
+		SIMULATION,	// A simulation shape is a regular physics object with collision detection and handling
+		TRIGGER		// A trigger shape does not take part in the simulation, it only generates overlap reports
+	};
+
 	enum FCollisionGroup : uint32
 	{
 		COLLISION_GROUP_NONE	= 0,
@@ -52,6 +58,7 @@ namespace LambdaEngine
 		const ScaleComponent& Scale;
 		const RotationComponent& Rotation;
 		const MeshComponent& Mesh;
+		EShapeType ShapeType;
 		FCollisionGroup CollisionGroup;				// The category of the object
 		uint32 CollisionMask;						// Includes the masks of the groups this object collides with
 		// Optional. The first collision info is on the entity whose callback is called.
@@ -104,8 +111,8 @@ namespace LambdaEngine
 		PxScene* GetScene() { return m_pScene; }
 
 		/* Implement PxSimulationEventCallback */
-		void onContact(const PxContactPairHeader& pairHeader, const PxContactPair* pairs, PxU32 nbPairs) override final;
-		void onTrigger(PxTriggerPair*, PxU32) override final {}
+		void onContact(const PxContactPairHeader& pairHeader, const PxContactPair* pPairs, PxU32 nbPairs) override final;
+		void onTrigger(PxTriggerPair* pTriggerPairs, PxU32 nbPairs) override final;
 		void onConstraintBreak(PxConstraintInfo*, PxU32) override final {}
 		void onWake(PxActor**, PxU32 ) override final {}
 		void onSleep(PxActor**, PxU32 ) override final {}
@@ -136,6 +143,8 @@ namespace LambdaEngine
 		DynamicCollisionComponent FinalizeDynamicCollisionActor(const DynamicCollisionCreateInfo& collisionInfo, PxShape* pShape, const glm::quat& additionalRotation = glm::identity<glm::quat>());
 		CharacterColliderComponent FinalizeCharacterController(const CharacterColliderCreateInfo& characterColliderInfo, PxControllerDesc& controllerDesc);
 		void FinalizeCollisionActor(const CollisionCreateInfo& collisionInfo, PxRigidActor* pActor, PxShape* pShape);
+
+		void TriggerCallbacks(const std::array<PxRigidActor*, 2>& actors);
 
 	private:
 		static PhysicsSystem s_Instance;

--- a/LambdaEngine/Include/Physics/PhysX/FilterShader.h
+++ b/LambdaEngine/Include/Physics/PhysX/FilterShader.h
@@ -14,19 +14,22 @@ physx::PxFilterFlags FilterShader(
 {
 	using namespace physx;
 
-	// Let triggers through
-	if (PxFilterObjectIsTrigger(attributes0) || PxFilterObjectIsTrigger(attributes1))
-	{
-		pairFlags = PxPairFlag::eTRIGGER_DEFAULT;
-		return PxFilterFlag::eDEFAULT;
-	}
-
-	// Generate contacts for all that were not filtered above
 	pairFlags = PxPairFlag::eCONTACT_DEFAULT;
 
 	// Trigger the contact callback for pairs (A,B) where the filtermask of A contains the ID of B and vice versa
 	if ((filterData0.word0 & filterData1.word1) && (filterData1.word0 & filterData0.word1))
-		pairFlags |= PxPairFlag::eNOTIFY_TOUCH_FOUND;
+	{
+		if (PxFilterObjectIsTrigger(attributes0) || PxFilterObjectIsTrigger(attributes1))
+		{
+			// Call onTrigger when PxScene::fetchResults is called
+			pairFlags = PxPairFlag::eTRIGGER_DEFAULT;
+		}
+		else
+		{
+			// Call onContact when PxScene::fetchResults is called
+			pairFlags |= PxPairFlag::eNOTIFY_TOUCH_FOUND;
+		}
+	}
 
 	return PxFilterFlag::eDEFAULT;
 }

--- a/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
@@ -277,52 +277,32 @@ namespace LambdaEngine
 		return FinalizeCharacterController(characterColliderInfo, controllerDesc);
 	}
 
-	void PhysicsSystem::onContact(const PxContactPairHeader& pairHeader, const PxContactPair* pairs, PxU32 nbPairs)
+	void PhysicsSystem::onContact(const PxContactPairHeader& pairHeader, const PxContactPair* pPairs, PxU32 nbPairs)
 	{
 		for (PxU32 pairIdx = 0; pairIdx < nbPairs; pairIdx++)
 		{
-			const PxContactPair& contactPair = pairs[pairIdx];
+			const PxContactPair& contactPair = pPairs[pairIdx];
 
 			if (contactPair.events & PxPairFlag::eNOTIFY_TOUCH_FOUND)
 			{
-				ActorUserData* pActorUserDatas[2] =
-				{
-					reinterpret_cast<ActorUserData*>(pairHeader.actors[0]->userData),
-					reinterpret_cast<ActorUserData*>(pairHeader.actors[1]->userData)
-				};
-
-				if (!pActorUserDatas[0]->CollisionCallback && !pActorUserDatas[1]->CollisionCallback)
-				{
-					continue;
-				}
-
-				// At least one of the entities has a callback function. Create collision info for both entities.
-				EntityCollisionInfo collisionInfos[2];
-				for (uint32 actorIdx = 0; actorIdx < 2; actorIdx++)
-				{
-					const PxRigidActor* pActor = pairHeader.actors[actorIdx];
-
-					const PxTransform transformPX = pActor->getGlobalPose();
-					const glm::quat rotation = { transformPX.q.x, transformPX.q.y, transformPX.q.z, transformPX.q.w };
-
-					collisionInfos[actorIdx] =
-					{
-						.Entity = pActorUserDatas[actorIdx]->Entity,
-						.Position	= { transformPX.p.x, transformPX.p.y, transformPX.p.z },
-						.Direction	= GetForward(rotation)
-					};
-				}
-
-				if (pActorUserDatas[0]->CollisionCallback)
-				{
-					pActorUserDatas[0]->CollisionCallback(collisionInfos[0], collisionInfos[1]);
-				}
-
-				if (pActorUserDatas[1]->CollisionCallback)
-				{
-					pActorUserDatas[1]->CollisionCallback(collisionInfos[1], collisionInfos[0]);
-				}
+				TriggerCallbacks({ pairHeader.actors[0], pairHeader.actors[1] });
 			}
+		}
+	}
+
+	void PhysicsSystem::onTrigger(PxTriggerPair* pTriggerPairs, PxU32 nbPairs)
+	{
+		for (PxU32 pairIdx = 0; pairIdx < nbPairs; pairIdx++)
+		{
+			const PxTriggerPair& triggerPair = pTriggerPairs[pairIdx];
+
+			// Ignore pairs when shapes have been deleted
+			if (triggerPair.flags & (PxTriggerPairFlag::eREMOVED_SHAPE_TRIGGER | PxTriggerPairFlag::eREMOVED_SHAPE_OTHER))
+			{
+				continue;
+			}
+
+			TriggerCallbacks({ triggerPair.triggerActor, triggerPair.otherActor });
 		}
 	}
 
@@ -523,27 +503,6 @@ namespace LambdaEngine
 		return { pActor };
 	}
 
-	void PhysicsSystem::FinalizeCollisionActor(const CollisionCreateInfo& collisionInfo, PxRigidActor* pActor, PxShape* pShape)
-	{
-		// Set shape's filter data
-		PxFilterData filterData;
-		filterData.word0 = (PxU32)collisionInfo.CollisionGroup;
-		filterData.word1 = (PxU32)collisionInfo.CollisionMask;
-		pShape->setSimulationFilterData(filterData);
-		pShape->setQueryFilterData(filterData);
-
-		pActor->attachShape(*pShape);
-
-		// Decreases the ref count to 1, which will drop to 0 when the actor is deleted
-		pShape->release();
-
-		// Set collision callback
-		pActor->userData = DBG_NEW ActorUserData;
-		ActorUserData* pUserData = reinterpret_cast<ActorUserData*>(pActor->userData);
-		pUserData->Entity = collisionInfo.Entity;
-		pUserData->CollisionCallback = collisionInfo.CollisionCallback;
-	}
-
 	CharacterColliderComponent PhysicsSystem::FinalizeCharacterController(const CharacterColliderCreateInfo& characterColliderInfo, PxControllerDesc& controllerDesc)
 	{
 		/*	For information about PhysX character controllers in general:
@@ -575,5 +534,73 @@ namespace LambdaEngine
 		PxControllerFilters controllerFilters(pFilterData);
 
 		return { pController, controllerFilters };
+	}
+
+	void PhysicsSystem::FinalizeCollisionActor(const CollisionCreateInfo& collisionInfo, PxRigidActor* pActor, PxShape* pShape)
+	{
+		// Set shape's filter data
+		PxFilterData filterData;
+		filterData.word0 = (PxU32)collisionInfo.CollisionGroup;
+		filterData.word1 = (PxU32)collisionInfo.CollisionMask;
+		pShape->setSimulationFilterData(filterData);
+		pShape->setQueryFilterData(filterData);
+
+		if (collisionInfo.ShapeType == EShapeType::TRIGGER)
+		{
+			pShape->setFlag(PxShapeFlag::eSIMULATION_SHAPE, false);
+			pShape->setFlag(PxShapeFlag::eTRIGGER_SHAPE, true);
+		}
+
+		pActor->attachShape(*pShape);
+
+		// Decreases the ref count to 1, which will drop to 0 when the actor is deleted
+		pShape->release();
+
+		// Set collision callback
+		pActor->userData = DBG_NEW ActorUserData;
+		ActorUserData* pUserData = reinterpret_cast<ActorUserData*>(pActor->userData);
+		pUserData->Entity = collisionInfo.Entity;
+		pUserData->CollisionCallback = collisionInfo.CollisionCallback;
+	}
+
+	void PhysicsSystem::TriggerCallbacks(const std::array<PxRigidActor*, 2>& actors)
+	{
+		ActorUserData* pActorUserDatas[2] =
+		{
+			reinterpret_cast<ActorUserData*>(actors[0]->userData),
+			reinterpret_cast<ActorUserData*>(actors[1]->userData)
+		};
+
+		if (!pActorUserDatas[0]->CollisionCallback && !pActorUserDatas[1]->CollisionCallback)
+		{
+			return;
+		}
+
+		// At least one of the entities has a callback function. Create collision info for both entities.
+		EntityCollisionInfo collisionInfos[2];
+		for (uint32 actorIdx = 0; actorIdx < 2; actorIdx++)
+		{
+			const PxRigidActor* pActor = actors[actorIdx];
+
+			const PxTransform transformPX = pActor->getGlobalPose();
+			const glm::quat rotation = { transformPX.q.x, transformPX.q.y, transformPX.q.z, transformPX.q.w };
+
+			collisionInfos[actorIdx] =
+			{
+				.Entity = pActorUserDatas[actorIdx]->Entity,
+				.Position	= { transformPX.p.x, transformPX.p.y, transformPX.p.z },
+				.Direction	= GetForward(rotation)
+			};
+		}
+
+		if (pActorUserDatas[0]->CollisionCallback)
+		{
+			pActorUserDatas[0]->CollisionCallback(collisionInfos[0], collisionInfos[1]);
+		}
+
+		if (pActorUserDatas[1]->CollisionCallback)
+		{
+			pActorUserDatas[1]->CollisionCallback(collisionInfos[1], collisionInfos[0]);
+		}
 	}
 }


### PR DESCRIPTION
Projectiles were behaving like any other object - they had both collision detection and handling. There's a more suitable option called trigger shapes, which only trigger callbacks when colliding. They don't trigger any collision handling.