### PR TITLE
Device Lost Fix

### DIFF
--- a/Assets/Shaders/RayTracing/PrimaryClosestHit.rchit
+++ b/Assets/Shaders/RayTracing/PrimaryClosestHit.rchit
@@ -58,8 +58,7 @@ SRayHitDescription CalculateHitData()
 
 	vec2 texCoord = (v0.TexCoord.xy * barycentricCoords.x + v1.TexCoord.xy * barycentricCoords.y + v2.TexCoord.xy * barycentricCoords.z);
 
-	uint materialIndex		= gl_InstanceCustomIndexEXT & 0xFF00;
-	materialIndex			= materialIndex >> 8;
+	uint materialIndex		= (gl_InstanceCustomIndexEXT & 0xFF00) >> 8;
 	uint paintMaskIndex		= gl_InstanceCustomIndexEXT & 0xFF;
 
 	vec3 shadingNormal		= texture(u_NormalMaps[materialIndex], texCoord).xyz;

--- a/CrazyCanvas/engine_config_crazycanvas.json
+++ b/CrazyCanvas/engine_config_crazycanvas.json
@@ -7,7 +7,7 @@
   "FixedTimestep": 60,
   "NetworkPort": 4444,
   "RayTracingEnabled": true,
-  "MeshShadersEnabled": false,
+  "MeshShadersEnabled": true,
   "ShowRenderGraph": false,
   "EnableLineRenderer": false,
   "RenderGraphName": "DEFERRED_PBR.lrg",

--- a/LambdaEngine/Include/Game/ECS/Systems/Rendering/RenderSystem.h
+++ b/LambdaEngine/Include/Game/ECS/Systems/Rendering/RenderSystem.h
@@ -373,7 +373,8 @@ namespace LambdaEngine
 		// Ray Tracing
 		Buffer*						m_ppStaticStagingInstanceBuffers[BACK_BUFFER_COUNT];
 		Buffer*						m_pCompleteInstanceBuffer		= nullptr;
-		uint32						m_MaxInstances					= 0;
+		uint32						m_MaxSupportedTLASInstances		= 0;
+		uint32						m_BuiltTLASInstanceCount		= 0;
 		AccelerationStructure*		m_pTLAS							= nullptr;
 		TArray<PendingBufferUpdate>	m_CompleteInstanceBufferPendingCopies;
 		TArray<SBTRecord>			m_SBTRecords;

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -1090,7 +1090,7 @@ namespace LambdaEngine
 
 				Texture* pTexture			= comp.pTexture;
 				TextureView* pTextureView	= comp.pTextureView;
-				Sampler* pNearestSampler	= Sampler::GetNearestSampler();
+				Sampler* pNearestSampler	= Sampler::GetLinearSampler();
 
 				// If the texture has not been added before, update resource
 				auto paintMaskTexturesIt = std::find(m_PaintMaskTextures.begin(), m_PaintMaskTextures.end(), pTexture);
@@ -1127,16 +1127,18 @@ namespace LambdaEngine
 
 		if (m_RayTracingEnabled)
 		{
-			uint32 index = materialIndex;
-			index = index << 8;
-			index |= hasPaintMask ? ((uint32)(std::max(0u, m_PaintMaskTextures.GetSize() - 1))) & 0xFF : 0;
+			uint32 customIndex = (materialIndex & 0xFF) << 8;
+			customIndex |= hasPaintMask ? ((uint32)(std::max(0u, m_PaintMaskTextures.GetSize() - 1))) & 0xFF : 0;
 
 			AccelerationStructureInstance asInstance = {};
-			asInstance.Transform						= glm::transpose(transform);
-			asInstance.CustomIndex						= index;
-			asInstance.Mask								= 0xFF;
-			asInstance.SBTRecordOffset					= 0;
-			asInstance.Flags							= RAY_TRACING_INSTANCE_FLAG_FORCE_OPAQUE;
+			asInstance.Transform		= glm::transpose(transform);
+			asInstance.CustomIndex		= customIndex;
+			asInstance.Mask				= 0xFF;
+			asInstance.Flags			= RAY_TRACING_INSTANCE_FLAG_FORCE_OPAQUE | RAY_TRACING_INSTANCE_FLAG_FRONT_CCW;
+
+			//If the SBT Record is already created in another instance, set it here
+			if (!meshAndInstancesIt->second.ASInstances.IsEmpty())
+				asInstance.SBTRecordOffset = meshAndInstancesIt->second.ASInstances[0].SBTRecordOffset;
 
 			//If the BLAS is already built, set it here
 			if (meshAndInstancesIt->second.pBLAS != nullptr)
@@ -1997,24 +1999,30 @@ namespace LambdaEngine
 
 			bool update = true;
 
-			//Recreate TLAS completely if oldInstanceCount != newInstanceCount
-			if (m_MaxInstances < newInstanceCount)
+			//Recreate TLAS completely if m_MaxSupportedTLASInstances < newInstanceCount
+			if (m_MaxSupportedTLASInstances < newInstanceCount)
 			{
 				if (m_pTLAS != nullptr) DeleteDeviceResource(m_pTLAS);
 
-				m_MaxInstances = newInstanceCount;
+				m_MaxSupportedTLASInstances = newInstanceCount;
+				m_BuiltTLASInstanceCount = newInstanceCount;
 
 				AccelerationStructureDesc createTLASDesc = {};
-				createTLASDesc.DebugName		= "TLAS";
-				createTLASDesc.Type				= EAccelerationStructureType::ACCELERATION_STRUCTURE_TYPE_TOP;
-				createTLASDesc.Flags			= FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
-				createTLASDesc.InstanceCount	= m_MaxInstances;
+				createTLASDesc.DebugName = "TLAS";
+				createTLASDesc.Type = EAccelerationStructureType::ACCELERATION_STRUCTURE_TYPE_TOP;
+				createTLASDesc.Flags = FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
+				createTLASDesc.InstanceCount = m_MaxSupportedTLASInstances;
 
 				m_pTLAS = RenderAPI::GetDevice()->CreateAccelerationStructure(&createTLASDesc);
 
 				update = false;
 
 				m_TLASResourceDirty = true;
+			}
+			else if (m_BuiltTLASInstanceCount != newInstanceCount)
+			{
+				m_BuiltTLASInstanceCount = newInstanceCount;
+				update = false;
 			}
 
 			if (m_pTLAS != nullptr)


### PR DESCRIPTION
The Device Lost problem seems to have had to causes.

The first one was that the SBT Record Offset, which has to be set in each Acceleration Structure Instance, only got set when the SBT needed an Update, which it didn't when we added new instances that used the same Mesh as previous instances. This could cause an Out of Bounds Read in the Ray Tracing Shader when accessing vertex data. I have no idea why it worked with Mesh Shaders on and not with Vertex Shaders.

The second Device Lost cause seems to be that we tried to do a TLAS update when the instance count decreased. This seems to not be supported. This however, is not mentioned in the Vulkan spec, but it is in the DXR spec. I'm not sure if the DXR spec means that changing the instance count at all is unsupported, or if it's only unsupported for TLAS updates. In any case, the fix is that if the instance count has decreased, we just do a rebuild, not an update, and not a recreate.

Remind me that if this problem starts to happen again, to try always doing a recreate and see if that fixes it.