### PR TITLE
MeshPaint MipZero has a potential Memory Leak, this fixes it

### DIFF
--- a/LambdaEngine/Include/Game/ECS/Components/Rendering/MeshPaintComponent.h
+++ b/LambdaEngine/Include/Game/ECS/Components/Rendering/MeshPaintComponent.h
@@ -11,8 +11,9 @@ namespace LambdaEngine
 	struct MeshPaintComponent
 	{
 		DECL_COMPONENT(MeshPaintComponent);
-		Texture*		pTexture		= nullptr;
-		TextureView*	pTextureView	= nullptr;
+		Texture*		pTexture			= nullptr;
+		TextureView*	pTextureView		= nullptr;
+		TextureView*	pMipZeroTextureView	= nullptr;
 	};
 
 	namespace MeshPaint

--- a/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
+++ b/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
@@ -85,7 +85,7 @@ namespace LambdaEngine
 	private:
 		struct RenderTarget
 		{
-			TextureView*	TextureView		= nullptr;
+			TextureView*	pTextureView	= nullptr;
 			uint32			DrawArgIndex	= 0;
 			uint32			InstanceIndex	= 0;
 		};

--- a/LambdaEngine/Source/Game/ECS/ComponentOwners/Rendering/MeshPaintComponentOwner.cpp
+++ b/LambdaEngine/Source/Game/ECS/ComponentOwners/Rendering/MeshPaintComponentOwner.cpp
@@ -17,5 +17,6 @@ namespace LambdaEngine
 	{
 		SAFERELEASE(meshPaintComponent.pTexture);
 		SAFERELEASE(meshPaintComponent.pTextureView);
+		SAFERELEASE(meshPaintComponent.pMipZeroTextureView);
 	}
 }

--- a/LambdaEngine/Source/Game/ECS/Components/Rendering/MeshPaintComponent.cpp
+++ b/LambdaEngine/Source/Game/ECS/Components/Rendering/MeshPaintComponent.cpp
@@ -31,14 +31,7 @@ namespace LambdaEngine
 		textureViewDesc.ArrayCount		= textureViewDesc.pTexture->GetDesc().ArrayCount;
 		textureViewDesc.Miplevel		= 0;
 		textureViewDesc.ArrayIndex		= 0;
-
-		meshPaintComponent.pTextureView = RenderAPI::GetDevice()->CreateTextureView(&textureViewDesc);;
-
-		DrawArgExtensionData drawArgExtensionData = {};
-		drawArgExtensionData.TextureCount = 1;
-		drawArgExtensionData.ppTextures[0]		= meshPaintComponent.pTexture;
-		drawArgExtensionData.ppTextureViews[0]	= meshPaintComponent.pTextureView;
-		drawArgExtensionData.ppSamplers[0]		= Sampler::GetNearestSampler();
+		meshPaintComponent.pTextureView = RenderAPI::GetDevice()->CreateTextureView(&textureViewDesc);
 
 		TextureViewDesc mipZeroTextureViewDesc = {};
 		mipZeroTextureViewDesc.DebugName		= textureName + " Mip Zero Texture View";
@@ -50,8 +43,14 @@ namespace LambdaEngine
 		mipZeroTextureViewDesc.ArrayCount		= textureViewDesc.pTexture->GetDesc().ArrayCount;
 		mipZeroTextureViewDesc.Miplevel			= 0;
 		mipZeroTextureViewDesc.ArrayIndex		= 0;
+		meshPaintComponent.pMipZeroTextureView	= RenderAPI::GetDevice()->CreateTextureView(&mipZeroTextureViewDesc);
 
-		drawArgExtensionData.ppMipZeroTextureViews[0] = RenderAPI::GetDevice()->CreateTextureView(&mipZeroTextureViewDesc);
+		DrawArgExtensionData drawArgExtensionData = {};
+		drawArgExtensionData.TextureCount = 1;
+		drawArgExtensionData.ppTextures[0]				= meshPaintComponent.pTexture;
+		drawArgExtensionData.ppTextureViews[0]			= meshPaintComponent.pTextureView;
+		drawArgExtensionData.ppMipZeroTextureViews[0]	= meshPaintComponent.pMipZeroTextureView;
+		drawArgExtensionData.ppSamplers[0]				= Sampler::GetNearestSampler();
 
 		EntityMaskManager::AddExtensionToEntity(entity, MeshPaintComponent::Type(), &drawArgExtensionData);
 

--- a/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
@@ -58,11 +58,6 @@ namespace LambdaEngine
 			SAFEDELETE_ARRAY(m_ppRenderCommandAllocators);
 			m_pDeviceResourcesToDestroy.Clear();
 		}
-
-		for (auto& renderTarget : m_RenderTargets)
-		{
-			renderTarget.TextureView->Release();
-		}
 	}
 
 	bool PaintMaskRenderer::init(GraphicsDevice* pGraphicsDevice, uint32 backBufferCount)
@@ -330,8 +325,8 @@ namespace LambdaEngine
 						if ((mask & meshPaintBit) != invertedUInt)
 						{
 							DrawArgExtensionData& extension = extensionGroup->pExtensions[e];
-							TextureView* textureView = extension.ppMipZeroTextureViews[0];
-							m_RenderTargets.PushBack({ .TextureView = textureView, .DrawArgIndex = d, .InstanceIndex = i });
+							TextureView* pTextureView = extension.ppMipZeroTextureViews[0];
+							m_RenderTargets.PushBack({ .pTextureView = pTextureView, .DrawArgIndex = d, .InstanceIndex = i });
 						}
 					}
 				}
@@ -388,7 +383,7 @@ namespace LambdaEngine
 			uint32			drawArgIndex		= renderTargetDesc.DrawArgIndex;
 			uint32			instanceIndex		= renderTargetDesc.InstanceIndex;
 			const DrawArg&	drawArg				= m_pDrawArgs[drawArgIndex];
-			TextureView*	renderTarget		= renderTargetDesc.TextureView;
+			TextureView*	renderTarget		= renderTargetDesc.pTextureView;
 
 			uint32 width	= renderTarget->GetDesc().pTexture->GetDesc().Width;
 			uint32 height	= renderTarget->GetDesc().pTexture->GetDesc().Height;


### PR DESCRIPTION
## Purpose
  - The Mip Zero Texture View had a potential memory leak because it was not deleted like the other mesh paint textures/texture views were. The Mip Zero Texture View was stored and released in the PaintMaskRenderer, this could potentially cause a memory leak if a DrawArg update occurred which didn't include some of the previous DrawArgs (since this would clear `PaintMaskRenderer::m_RenderTargets` and thus they would not be released in `~PaintMaskRenderer()`).

## Changes
 - The texture view is now stored in the component instead, and is released in the MeshPaintComponent ComponentOwner.
