### PR TITLE
Mesh Painting not working on GTX fix

### DIFF
--- a/LambdaEngine/Include/Game/ECS/Systems/Rendering/RenderSystem.h
+++ b/LambdaEngine/Include/Game/ECS/Systems/Rendering/RenderSystem.h
@@ -301,7 +301,7 @@ namespace LambdaEngine
 		void UpdateASInstanceBuffers(CommandList* pCommandList);
 		void BuildTLAS(CommandList* pCommandList);
 		void UpdateLightsBuffer(CommandList* pCommandList);
-		void UpdatePointLightTextureResource();
+		void UpdatePointLightTextureResource(CommandList* pCommandList);
 
 		void UpdateRenderGraph();
 
@@ -323,8 +323,8 @@ namespace LambdaEngine
 		bool					m_RayTracingEnabled	= false;
 		bool					m_MeshShadersEnabled = false;
 		// Mesh/Instance/Entity
-		bool						m_LightsResourceDirty		= true;
-		bool						m_PointLightDirty			= true;
+		bool						m_LightsBufferDirty			= true;
+		bool						m_PointLightsDirty			= true;
 		bool						m_DirectionalExist			= false;
 		bool						m_RemoveTexturesOnDeletion	= false;
 		TArray<LightUpdateData>		m_PointLightTextureUpdateQueue;
@@ -389,6 +389,7 @@ namespace LambdaEngine
 		bool						m_RenderGraphSBTRecordsDirty		= true;
 		bool						m_MaterialsPropertiesBufferDirty	= false;
 		bool						m_MaterialsResourceDirty			= false;
+		bool						m_LightsResourceDirty				= false;
 		bool						m_PerFrameResourceDirty				= true;
 		TSet<DrawArgMaskDesc>		m_DirtyDrawArgs;
 		TSet<MeshEntry*>			m_DirtyASInstanceBuffers;

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -597,7 +597,8 @@ namespace LambdaEngine
 		m_MaterialsResourceDirty			= true;
 		m_MaterialsPropertiesBufferDirty	= true;
 		m_RenderGraphSBTRecordsDirty		= true;
-		m_LightsResourceDirty				= true;
+		m_LightsBufferDirty					= true;
+		m_PointLightsDirty					= true;
 
 		if (m_RayTracingEnabled)
 		{
@@ -700,7 +701,7 @@ namespace LambdaEngine
 			);
 
 			m_DirectionalExist = true;
-			m_LightsResourceDirty = true;
+			m_LightsBufferDirty = true;
 		}
 		else
 		{
@@ -779,10 +780,10 @@ namespace LambdaEngine
 					m_PointLightTextureUpdateQueue.PushBack(lightUpdateData);
 			}
 
-			m_PointLightDirty = true;
+			m_PointLightsDirty = true;
 		}
 
-		m_LightsResourceDirty = true;
+		m_LightsBufferDirty = true;
 	}
 
 	void RenderSystem::AddRenderableEntity(Entity entity, GUID_Lambda meshGUID, GUID_Lambda materialGUID, const glm::mat4& transform, bool isAnimated)
@@ -1365,7 +1366,7 @@ namespace LambdaEngine
 		m_LightBufferData.DirL_ProjViews *= glm::lookAt(position, position - m_LightBufferData.DirL_Direction, g_DefaultUp);
 
 		m_pRenderGraph->TriggerRenderStage("DIRL_SHADOWMAP");
-		m_LightsResourceDirty = true;
+		m_LightsBufferDirty = true;
 	}
 
 	void RenderSystem::UpdatePointLight(Entity entity, const glm::vec3& position, const glm::vec4& colorIntensity, float nearPlane, float farPlane)
@@ -1379,7 +1380,8 @@ namespace LambdaEngine
 		PointLight& pointLight = m_PointLights[index];
 		pointLight.ColorIntensity = colorIntensity;
 
-		m_LightsResourceDirty = true;
+		m_LightsBufferDirty = true;
+		m_PointLightsDirty = true;
 
 		if (pointLight.Position != position
 			|| pointLight.FarPlane != farPlane
@@ -1425,7 +1427,7 @@ namespace LambdaEngine
 			lightTextureUpdate.TextureIndex = m_PointLights[index].TextureIndex;
 			m_PointLightTextureUpdateQueue.PushBack(lightTextureUpdate);
 
-			m_PointLightDirty = true;
+			m_PointLightsDirty = true;
 		}
 	}
 
@@ -1591,6 +1593,7 @@ namespace LambdaEngine
 		// Update Light Data
 		{
 			UpdateLightsBuffer(pGraphicsCommandList);
+			UpdatePointLightTextureResource(pGraphicsCommandList);
 		}
 
 		//Update Empty MaterialData
@@ -2039,134 +2042,155 @@ namespace LambdaEngine
 		}
 	}
 
-	void RenderSystem::UpdatePointLightTextureResource()
+	void RenderSystem::UpdatePointLightTextureResource(CommandList* pCommandList)
 	{
-		uint32 pointLightCount = m_PointLights.GetSize();
-		if (pointLightCount == m_CubeTextures.GetSize())
-			return;
-
-		bool needUpdate = m_RemoveTexturesOnDeletion;
-
-		constexpr uint32 CUBE_FACE_COUNT = 6;
-		if (pointLightCount > m_CubeTextures.GetSize())
+		if (m_PointLightsDirty)
 		{
-			GraphicsDevice* pGraphicsDevice = RenderAPI::GetDevice();
-			uint32 diff = pointLightCount - m_CubeTextures.GetSize();
+			m_PointLightsDirty = false;
+			m_LightsResourceDirty = true;
 
-			// TODO: Create inteface for changing resolution
-			const uint32 width = 512;
-			const uint32 height = 512;
+			uint32 pointLightCount = m_PointLights.GetSize();
+			if (pointLightCount == m_CubeTextures.GetSize())
+				return;
 
-			uint32 prevSubImageCount = m_CubeSubImageTextureViews.GetSize();
-			m_CubeSubImageTextureViews.Resize(prevSubImageCount + CUBE_FACE_COUNT * diff);
+			bool needUpdate = m_RemoveTexturesOnDeletion;
 
-			for (uint32 c = 0; c < diff; c++)
+			constexpr uint32 CUBE_FACE_COUNT = 6;
+			if (pointLightCount > m_CubeTextures.GetSize())
 			{
-				// Create cube texture
-				TextureDesc cubeTexDesc = {};
-				cubeTexDesc.DebugName = "PointLight Texture Cube " + std::to_string(c);
-				cubeTexDesc.MemoryType = EMemoryType::MEMORY_TYPE_GPU;
-				cubeTexDesc.Format = EFormat::FORMAT_D24_UNORM_S8_UINT;
-				cubeTexDesc.Type = ETextureType::TEXTURE_TYPE_2D;
-				cubeTexDesc.Flags = FTextureFlag::TEXTURE_FLAG_DEPTH_STENCIL | FTextureFlag::TEXTURE_FLAG_SHADER_RESOURCE | FTextureFlag::TEXTURE_FLAG_CUBE_COMPATIBLE;
-				cubeTexDesc.Width = width;
-				cubeTexDesc.Height = height;
-				cubeTexDesc.Depth = 1U;
-				cubeTexDesc.ArrayCount = 6;
-				cubeTexDesc.Miplevels = 1;
-				cubeTexDesc.SampleCount = 1;
+				GraphicsDevice* pGraphicsDevice = RenderAPI::GetDevice();
+				uint32 diff = pointLightCount - m_CubeTextures.GetSize();
 
-				Texture* pCubeTexture = pGraphicsDevice->CreateTexture(&cubeTexDesc);
-				m_CubeTextures.PushBack(pCubeTexture);
+				// TODO: Create inteface for changing resolution
+				const uint32 width = 512;
+				const uint32 height = 512;
 
-				// Create cube texture view
-				TextureViewDesc cubeTexViewDesc = {};
-				cubeTexViewDesc.DebugName = "PointLight Texture Cube View " + std::to_string(c);
-				cubeTexViewDesc.pTexture = pCubeTexture;
-				cubeTexViewDesc.Flags = FTextureViewFlag::TEXTURE_VIEW_FLAG_DEPTH_STENCIL | FTextureViewFlag::TEXTURE_VIEW_FLAG_SHADER_RESOURCE;
-				cubeTexViewDesc.Format = cubeTexDesc.Format;
-				cubeTexViewDesc.Type = ETextureViewType::TEXTURE_VIEW_TYPE_CUBE;
-				cubeTexViewDesc.MiplevelCount = 1;
-				cubeTexViewDesc.ArrayCount = 6;
-				cubeTexViewDesc.Miplevel = 0U;
-				cubeTexViewDesc.ArrayIndex = 0U;
+				uint32 prevSubImageCount = m_CubeSubImageTextureViews.GetSize();
+				m_CubeSubImageTextureViews.Resize(prevSubImageCount + CUBE_FACE_COUNT * diff);
 
-				m_CubeTextureViews.PushBack(pGraphicsDevice->CreateTextureView(&cubeTexViewDesc)); // Used for reading from CubeTexture
-
-				// Create per face texture views
-				TextureViewDesc subImageTextureViewDesc = {};
-				subImageTextureViewDesc.pTexture = pCubeTexture;
-				subImageTextureViewDesc.Flags = FTextureViewFlag::TEXTURE_VIEW_FLAG_DEPTH_STENCIL;
-				subImageTextureViewDesc.Format = cubeTexDesc.Format;
-				subImageTextureViewDesc.Type = ETextureViewType::TEXTURE_VIEW_TYPE_2D;
-				subImageTextureViewDesc.Miplevel = cubeTexViewDesc.Miplevel;
-				subImageTextureViewDesc.MiplevelCount = cubeTexViewDesc.MiplevelCount;
-				subImageTextureViewDesc.ArrayCount = 1;
-
-				TextureView** ppSubImageView = &m_CubeSubImageTextureViews[prevSubImageCount + (CUBE_FACE_COUNT) * c];
-				for (uint32 si = 0; si < CUBE_FACE_COUNT; si++)
+				for (uint32 c = 0; c < diff; c++)
 				{
-					subImageTextureViewDesc.DebugName = "PointLight Sub Image Texture View " + std::to_string(si);
-					subImageTextureViewDesc.ArrayIndex = si;
+					// Create cube texture
+					TextureDesc cubeTexDesc = {};
+					cubeTexDesc.DebugName = "PointLight Texture Cube " + std::to_string(c);
+					cubeTexDesc.MemoryType = EMemoryType::MEMORY_TYPE_GPU;
+					cubeTexDesc.Format = EFormat::FORMAT_D24_UNORM_S8_UINT;
+					cubeTexDesc.Type = ETextureType::TEXTURE_TYPE_2D;
+					cubeTexDesc.Flags = FTextureFlag::TEXTURE_FLAG_DEPTH_STENCIL | FTextureFlag::TEXTURE_FLAG_SHADER_RESOURCE | FTextureFlag::TEXTURE_FLAG_CUBE_COMPATIBLE;
+					cubeTexDesc.Width = width;
+					cubeTexDesc.Height = height;
+					cubeTexDesc.Depth = 1U;
+					cubeTexDesc.ArrayCount = 6;
+					cubeTexDesc.Miplevels = 1;
+					cubeTexDesc.SampleCount = 1;
 
-					(*ppSubImageView) = pGraphicsDevice->CreateTextureView(&subImageTextureViewDesc); // Used for writing to CubeTexture
-					ppSubImageView++;
-				}
+					Texture* pCubeTexture = pGraphicsDevice->CreateTexture(&cubeTexDesc);
+					m_CubeTextures.PushBack(pCubeTexture);
 
-				needUpdate = true;
-			}
-		}
-		else if (pointLightCount < m_CubeTextures.GetSize())
-		{
-			if (m_RemoveTexturesOnDeletion)
-			{
-				uint32 diff =  m_CubeTextures.GetSize() - pointLightCount;
+					// Create cube texture view
+					TextureViewDesc cubeTexViewDesc = {};
+					cubeTexViewDesc.DebugName = "PointLight Texture Cube View " + std::to_string(c);
+					cubeTexViewDesc.pTexture = pCubeTexture;
+					cubeTexViewDesc.Flags = FTextureViewFlag::TEXTURE_VIEW_FLAG_DEPTH_STENCIL | FTextureViewFlag::TEXTURE_VIEW_FLAG_SHADER_RESOURCE;
+					cubeTexViewDesc.Format = cubeTexDesc.Format;
+					cubeTexViewDesc.Type = ETextureViewType::TEXTURE_VIEW_TYPE_CUBE;
+					cubeTexViewDesc.MiplevelCount = 1;
+					cubeTexViewDesc.ArrayCount = 6;
+					cubeTexViewDesc.Miplevel = 0U;
+					cubeTexViewDesc.ArrayIndex = 0U;
 
-				// Remove Cube Texture Context for removed pointlights
-				for (uint32 r = 0; r < diff; r++)
-				{
-					DeleteDeviceResource(m_CubeTextures.GetBack());
-					m_CubeTextures.PopBack();
+					m_CubeTextureViews.PushBack(pGraphicsDevice->CreateTextureView(&cubeTexViewDesc)); // Used for reading from CubeTexture
 
-					DeleteDeviceResource(m_CubeTextureViews.GetBack());
-					m_CubeTextureViews.PopBack();
+					// Create per face texture views
+					TextureViewDesc subImageTextureViewDesc = {};
+					subImageTextureViewDesc.pTexture = pCubeTexture;
+					subImageTextureViewDesc.Flags = FTextureViewFlag::TEXTURE_VIEW_FLAG_DEPTH_STENCIL;
+					subImageTextureViewDesc.Format = cubeTexDesc.Format;
+					subImageTextureViewDesc.Type = ETextureViewType::TEXTURE_VIEW_TYPE_2D;
+					subImageTextureViewDesc.Miplevel = cubeTexViewDesc.Miplevel;
+					subImageTextureViewDesc.MiplevelCount = cubeTexViewDesc.MiplevelCount;
+					subImageTextureViewDesc.ArrayCount = 1;
 
-					for (uint32 f = 0; f < CUBE_FACE_COUNT && !m_CubeSubImageTextureViews.IsEmpty(); f++)
+					TextureView** ppSubImageView = &m_CubeSubImageTextureViews[prevSubImageCount + (CUBE_FACE_COUNT) * c];
+					for (uint32 si = 0; si < CUBE_FACE_COUNT; si++)
 					{
-						DeleteDeviceResource(m_CubeSubImageTextureViews.GetBack());
-						m_CubeSubImageTextureViews.PopBack();
+						subImageTextureViewDesc.DebugName = "PointLight Sub Image Texture View " + std::to_string(si);
+						subImageTextureViewDesc.ArrayIndex = si;
+
+						(*ppSubImageView) = pGraphicsDevice->CreateTextureView(&subImageTextureViewDesc); // Used for writing to CubeTexture
+						ppSubImageView++;
+					}
+
+					PipelineTextureBarrierDesc transitionToReadOnlyBarrier = { };
+					transitionToReadOnlyBarrier.pTexture				= pCubeTexture;
+					transitionToReadOnlyBarrier.StateBefore				= ETextureState::TEXTURE_STATE_UNKNOWN;
+					transitionToReadOnlyBarrier.StateAfter				= ETextureState::TEXTURE_STATE_SHADER_READ_ONLY;
+					transitionToReadOnlyBarrier.QueueBefore				= ECommandQueueType::COMMAND_QUEUE_TYPE_GRAPHICS;
+					transitionToReadOnlyBarrier.QueueAfter				= ECommandQueueType::COMMAND_QUEUE_TYPE_GRAPHICS;
+					transitionToReadOnlyBarrier.SrcMemoryAccessFlags	= 0;
+					transitionToReadOnlyBarrier.DstMemoryAccessFlags	= FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ;
+					transitionToReadOnlyBarrier.TextureFlags			= cubeTexDesc.Flags;
+					transitionToReadOnlyBarrier.Miplevel				= 0;
+					transitionToReadOnlyBarrier.MiplevelCount			= cubeTexDesc.Miplevels;
+					transitionToReadOnlyBarrier.ArrayIndex				= 0;
+					transitionToReadOnlyBarrier.ArrayCount				= cubeTexDesc.ArrayCount;
+
+					pCommandList->PipelineTextureBarriers(FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP, FPipelineStageFlag::PIPELINE_STAGE_FLAG_BOTTOM, &transitionToReadOnlyBarrier, 1);
+
+					needUpdate = true;
+				}
+			}
+			else if (pointLightCount < m_CubeTextures.GetSize())
+			{
+				if (m_RemoveTexturesOnDeletion)
+				{
+					uint32 diff =  m_CubeTextures.GetSize() - pointLightCount;
+
+					// Remove Cube Texture Context for removed pointlights
+					for (uint32 r = 0; r < diff; r++)
+					{
+						DeleteDeviceResource(m_CubeTextures.GetBack());
+						m_CubeTextures.PopBack();
+
+						DeleteDeviceResource(m_CubeTextureViews.GetBack());
+						m_CubeTextureViews.PopBack();
+
+						for (uint32 f = 0; f < CUBE_FACE_COUNT && !m_CubeSubImageTextureViews.IsEmpty(); f++)
+						{
+							DeleteDeviceResource(m_CubeSubImageTextureViews.GetBack());
+							m_CubeSubImageTextureViews.PopBack();
+						}
 					}
 				}
 			}
-		}
 
-		/*
-			If textures are not removed on pointlight deletion(m_RemoveTexturesOnDeletion == false), updates are only needed when new point light textures are added
-		*/
-		if (needUpdate)
-		{
-			uint32 texturesExisting = m_CubeTextures.GetSize();
-			Sampler* pNearestSampler = Sampler::GetNearestSampler();
-			ResourceUpdateDesc resourceUpdateDesc = {};
-			resourceUpdateDesc.ResourceName = SCENE_POINT_SHADOWMAPS;
-			resourceUpdateDesc.ExternalTextureUpdate.ppTextures							= m_CubeTextures.GetData();
-			resourceUpdateDesc.ExternalTextureUpdate.ppTextureViews						= m_CubeTextureViews.GetData();
-			resourceUpdateDesc.ExternalTextureUpdate.TextureCount								= texturesExisting;
-			resourceUpdateDesc.ExternalTextureUpdate.ppPerSubImageTextureViews			= m_CubeSubImageTextureViews.GetData();
-			resourceUpdateDesc.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= CUBE_FACE_COUNT;
-			resourceUpdateDesc.ExternalTextureUpdate.ppSamplers							= &pNearestSampler;
-			resourceUpdateDesc.ExternalTextureUpdate.SamplerCount						= 1;
-			m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
+			/*
+				If textures are not removed on pointlight deletion(m_RemoveTexturesOnDeletion == false), updates are only needed when new point light textures are added
+			*/
+			if (needUpdate)
+			{
+				uint32 texturesExisting = m_CubeTextures.GetSize();
+				Sampler* pNearestSampler = Sampler::GetNearestSampler();
+				ResourceUpdateDesc resourceUpdateDesc = {};
+				resourceUpdateDesc.ResourceName = SCENE_POINT_SHADOWMAPS;
+				resourceUpdateDesc.ExternalTextureUpdate.ppTextures							= m_CubeTextures.GetData();
+				resourceUpdateDesc.ExternalTextureUpdate.ppTextureViews						= m_CubeTextureViews.GetData();
+				resourceUpdateDesc.ExternalTextureUpdate.TextureCount								= texturesExisting;
+				resourceUpdateDesc.ExternalTextureUpdate.ppPerSubImageTextureViews			= m_CubeSubImageTextureViews.GetData();
+				resourceUpdateDesc.ExternalTextureUpdate.PerImageSubImageTextureViewCount	= CUBE_FACE_COUNT;
+				resourceUpdateDesc.ExternalTextureUpdate.ppSamplers							= &pNearestSampler;
+				resourceUpdateDesc.ExternalTextureUpdate.SamplerCount						= 1;
+				m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
+			}
 		}
 	}
 
 	void RenderSystem::UpdateLightsBuffer(CommandList* pCommandList)
 	{
 		// Light Buffer Initilization
-		if (m_LightsResourceDirty)
+		if (m_LightsBufferDirty)
 		{
-			// Resource only needs to be updated if new buffers are allocated
-			m_LightsResourceDirty = false;
+			m_LightsBufferDirty = false;
 
 			size_t pointLightCount			= m_PointLights.GetSize();
 			size_t dirLightBufferSize		= sizeof(LightBuffer);
@@ -2209,7 +2233,6 @@ namespace LambdaEngine
 
 				m_pLightsBuffer = RenderAPI::GetDevice()->CreateBuffer(&lightBufferDesc);
 				m_LightsResourceDirty = true;
-
 			}
 
 			pCommandList->CopyBuffer(pCurrentStagingBuffer, 0, m_pLightsBuffer, 0, lightBufferSize);
@@ -2270,19 +2293,13 @@ namespace LambdaEngine
 			m_pRenderGraph->TriggerRenderStage("RENDER_STAGE_LIGHT");
 		}
 
-		if (m_LightsResourceDirty || m_PointLightDirty)
+		if (m_LightsResourceDirty)
 		{
 			ResourceUpdateDesc resourceUpdateDesc = {};
 			resourceUpdateDesc.ResourceName						= SCENE_LIGHTS_BUFFER;
 			resourceUpdateDesc.ExternalBufferUpdate.ppBuffer	= &m_pLightsBuffer;
 			resourceUpdateDesc.ExternalBufferUpdate.Count		= 1;
 			m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
-
-			if (m_PointLightDirty)
-			{
-				UpdatePointLightTextureResource();
-				m_PointLightDirty = false;
-			}
 
 			m_LightsResourceDirty = false;
 		}

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
@@ -599,7 +599,7 @@ namespace LambdaEngine
 			m_ImageBarriers[i].srcAccessMask					= ConvertMemoryAccessFlags(barrier.SrcMemoryAccessFlags);
 			m_ImageBarriers[i].dstAccessMask					= ConvertMemoryAccessFlags(barrier.DstMemoryAccessFlags);
 
-			if (barrier.TextureFlags == FTextureFlag::TEXTURE_FLAG_DEPTH_STENCIL)
+			if ((barrier.TextureFlags & FTextureFlag::TEXTURE_FLAG_DEPTH_STENCIL) > 0)
 			{
 				m_ImageBarriers[i].subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 			}

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -1980,11 +1980,11 @@ namespace LambdaEngine
 							pResource->LastPipelineStageOfFirstRenderStage = lastPipelineStageFlags;
 
 							pResource->Texture.InitialTransitionBarrier.pTexture				= nullptr;
-							pResource->Texture.InitialTransitionBarrier.StateBefore				= ETextureState::TEXTURE_STATE_UNKNOWN;
+							pResource->Texture.InitialTransitionBarrier.StateBefore				= pResource->OwnershipType == EResourceOwnershipType::INTERNAL ? ETextureState::TEXTURE_STATE_UNKNOWN : ETextureState::TEXTURE_STATE_SHADER_READ_ONLY;
 							pResource->Texture.InitialTransitionBarrier.StateAfter				= CalculateResourceTextureState(pResource->Type, pResourceStateDesc->BindingType == ERenderGraphResourceBindingType::ATTACHMENT ? pResourceStateDesc->AttachmentSynchronizations.PrevBindingType : pResourceStateDesc->BindingType, pResource->Texture.Format);
 							pResource->Texture.InitialTransitionBarrier.QueueBefore				= ConvertPipelineStateTypeToQueue(pRenderStageDesc->Type);
 							pResource->Texture.InitialTransitionBarrier.QueueAfter				= pResource->Texture.InitialTransitionBarrier.QueueBefore;
-							pResource->Texture.InitialTransitionBarrier.SrcMemoryAccessFlags	= FMemoryAccessFlag::MEMORY_ACCESS_FLAG_UNKNOWN;
+							pResource->Texture.InitialTransitionBarrier.SrcMemoryAccessFlags	= FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ;
 							pResource->Texture.InitialTransitionBarrier.DstMemoryAccessFlags	= CalculateResourceAccessFlags(pResourceStateDesc->BindingType);
 							pResource->Texture.InitialTransitionBarrier.TextureFlags			= pResource->Texture.Format == EFormat::FORMAT_D24_UNORM_S8_UINT ? FTextureFlag::TEXTURE_FLAG_DEPTH_STENCIL : 0;
 						}
@@ -2027,7 +2027,7 @@ namespace LambdaEngine
 							drawArgsData.InitialTextureTransitionBarrierTemplate.QueueAfter				= drawArgsData.InitialTextureTransitionBarrierTemplate.QueueBefore;
 							drawArgsData.InitialTextureTransitionBarrierTemplate.SrcMemoryAccessFlags	= FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE;
 							drawArgsData.InitialTextureTransitionBarrierTemplate.DstMemoryAccessFlags	= FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ;
-							drawArgsData.InitialTextureTransitionBarrierTemplate.StateBefore			= ETextureState::TEXTURE_STATE_UNKNOWN;
+							drawArgsData.InitialTextureTransitionBarrierTemplate.StateBefore			= ETextureState::TEXTURE_STATE_SHADER_READ_ONLY;
 							drawArgsData.InitialTextureTransitionBarrierTemplate.StateAfter				= ETextureState::TEXTURE_STATE_SHADER_READ_ONLY;
 
 							pResource->DrawArgs.FullMaskToArgs[maskDesc.FullMask] = drawArgsData;

--- a/LambdaEngine/Source/Resources/ResourceManager.cpp
+++ b/LambdaEngine/Source/Resources/ResourceManager.cpp
@@ -874,18 +874,34 @@ namespace LambdaEngine
 		s_pMaterialGraphicsCommandAllocator->Reset();
 		s_pMaterialGraphicsCommandList->Begin(nullptr);
 
-		s_pMaterialGraphicsCommandList->QueueTransferBarrier(
-			pCombinedMaterialTexture, 
-			FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP, 
-			FPipelineStageFlag::PIPELINE_STAGE_FLAG_COPY,
-			FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE, 
-			FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ,
-			ECommandQueueType::COMMAND_QUEUE_TYPE_COMPUTE, 
-			ECommandQueueType::COMMAND_QUEUE_TYPE_GRAPHICS,
-			ETextureState::TEXTURE_STATE_GENERAL,
-			ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
+		if (miplevels > 1)
+		{
+			s_pMaterialGraphicsCommandList->QueueTransferBarrier(
+				pCombinedMaterialTexture,
+				FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP,
+				FPipelineStageFlag::PIPELINE_STAGE_FLAG_COPY,
+				FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE,
+				FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ,
+				ECommandQueueType::COMMAND_QUEUE_TYPE_COMPUTE,
+				ECommandQueueType::COMMAND_QUEUE_TYPE_GRAPHICS,
+				ETextureState::TEXTURE_STATE_GENERAL,
+				ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
 
-		s_pMaterialGraphicsCommandList->GenerateMiplevels(pCombinedMaterialTexture, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
+			s_pMaterialGraphicsCommandList->GenerateMiplevels(pCombinedMaterialTexture, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
+		}
+		else
+		{
+			s_pMaterialGraphicsCommandList->QueueTransferBarrier(
+				pCombinedMaterialTexture,
+				FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP,
+				FPipelineStageFlag::PIPELINE_STAGE_FLAG_BOTTOM,
+				FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE,
+				FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ,
+				ECommandQueueType::COMMAND_QUEUE_TYPE_COMPUTE,
+				ECommandQueueType::COMMAND_QUEUE_TYPE_GRAPHICS,
+				ETextureState::TEXTURE_STATE_GENERAL,
+				ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
+		}
 
 		s_pMaterialGraphicsCommandList->End();
 

--- a/LambdaEngine/Source/Resources/ResourceManager.cpp
+++ b/LambdaEngine/Source/Resources/ResourceManager.cpp
@@ -871,29 +871,26 @@ namespace LambdaEngine
 		}
 
 		//Execute Mipmap Pass
-		if (miplevels > 1)
-		{
-			s_pMaterialGraphicsCommandAllocator->Reset();
-			s_pMaterialGraphicsCommandList->Begin(nullptr);
+		s_pMaterialGraphicsCommandAllocator->Reset();
+		s_pMaterialGraphicsCommandList->Begin(nullptr);
 
-			s_pMaterialGraphicsCommandList->QueueTransferBarrier(
-				pCombinedMaterialTexture, 
-				FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP, 
-				FPipelineStageFlag::PIPELINE_STAGE_FLAG_COPY,
-				FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE, 
-				FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ,
-				ECommandQueueType::COMMAND_QUEUE_TYPE_COMPUTE, 
-				ECommandQueueType::COMMAND_QUEUE_TYPE_GRAPHICS,
-				ETextureState::TEXTURE_STATE_GENERAL,
-				ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
+		s_pMaterialGraphicsCommandList->QueueTransferBarrier(
+			pCombinedMaterialTexture, 
+			FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP, 
+			FPipelineStageFlag::PIPELINE_STAGE_FLAG_COPY,
+			FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE, 
+			FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ,
+			ECommandQueueType::COMMAND_QUEUE_TYPE_COMPUTE, 
+			ECommandQueueType::COMMAND_QUEUE_TYPE_GRAPHICS,
+			ETextureState::TEXTURE_STATE_GENERAL,
+			ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
 
-			s_pMaterialGraphicsCommandList->GenerateMiplevels(pCombinedMaterialTexture, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
+		s_pMaterialGraphicsCommandList->GenerateMiplevels(pCombinedMaterialTexture, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY, ETextureState::TEXTURE_STATE_SHADER_READ_ONLY);
 
-			s_pMaterialGraphicsCommandList->End();
+		s_pMaterialGraphicsCommandList->End();
 
-			signalValue++;
-			RenderAPI::GetGraphicsQueue()->ExecuteCommandLists(&s_pMaterialGraphicsCommandList, 1, FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP, s_pMaterialFence, signalValue - 1, s_pMaterialFence, signalValue);
-		}
+		signalValue++;
+		RenderAPI::GetGraphicsQueue()->ExecuteCommandLists(&s_pMaterialGraphicsCommandList, 1, FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP, s_pMaterialFence, signalValue - 1, s_pMaterialFence, signalValue);
 
 		s_pMaterialFence->Wait(signalValue, UINT64_MAX);
 


### PR DESCRIPTION
## Purpose
  - How it's possible for this to randomly surface as a problem on GTX computers after months of using this system is beyond me, but this fixes the Mesh Painting bug that happened for computers without an RTX graphics card.
  - The problem was in the RenderGraph (as usual), where textures were assumed to be in a UNKNOWN state when first introduced to the RenderGraph. This works fine for internal resources and is even required but for external resources this is not a good idea. When a barrier is executed for a resource which says that the source state for the resource is UNKNOWN, Vulkan is free to do whatever it wants with that resource previous to the barrier execution, that includes clearing the texture. 

So basically:
Frame 0: Draw Args were updated -> RenderGraph transitions textures to initial state and assumes the textures are in UNKNOWN -> Paint Mask rendered to -> Paint Mask displayed correctly
Frame 1: A new renderable entity was added -> Triggers a Draw Args update -> RenderGraph transitions textures to initial state and assumes the textures are in UNKNOWN state, thus possibly clearing the result from Frame 0 -> Paint Mask not rendered because we don't have a collision yet -> Paint Mask just becomes cleared

## Changes
 - The fix is that the RenderGraph now assumes that all external textures are in a READ_ONLY state before being sent to the RenderGraph, this meant some changes to RenderSystem and ResourceManager.
