### PR TITLE
Player Network Component Fix

### DIFF
--- a/CrazyCanvas/Source/World/LevelObjectCreator.cpp
+++ b/CrazyCanvas/Source/World/LevelObjectCreator.cpp
@@ -242,7 +242,6 @@ bool LevelObjectCreator::CreatePlayer(
 	PhysicsSystem* pPhysicsSystem = PhysicsSystem::GetInstance();
 	CharacterColliderComponent characterColliderComponent = pPhysicsSystem->CreateCharacterCapsule(colliderInfo, std::max(0.0f, PLAYER_CAPSULE_HEIGHT - 2.0f * PLAYER_CAPSULE_RADIUS), PLAYER_CAPSULE_RADIUS);
 	pECS->AddComponent<CharacterColliderComponent>(playerEntity, characterColliderComponent);
-	pECS->AddComponent<NetworkComponent>(playerEntity, { (int32)playerEntity });
 
 	Entity weaponEntity = pECS->CreateEntity();
 	pECS->AddComponent<WeaponComponent>(weaponEntity, { .WeaponOwner = playerEntity, });
@@ -253,6 +252,7 @@ bool LevelObjectCreator::CreatePlayer(
 		pECS->AddComponent<MeshComponent>(playerEntity, MeshComponent{.MeshGUID = pPlayerDesc->MeshGUID, .MaterialGUID = TeamHelper::GetTeamColorMaterialGUID(pPlayerDesc->TeamIndex)});
 		pECS->AddComponent<AnimationComponent>(playerEntity, pPlayerDesc->AnimationComponent);
 		pECS->AddComponent<MeshPaintComponent>(playerEntity, MeshPaint::CreateComponent(playerEntity, "PlayerUnwrappedTexture", 512, 512));
+		pECS->AddComponent<NetworkComponent>(playerEntity, { pPlayerDesc->NetworkUID });
 
 		if (!pPlayerDesc->IsLocal)
 		{
@@ -316,6 +316,7 @@ bool LevelObjectCreator::CreatePlayer(
 	}
 	else
 	{
+		pECS->AddComponent<NetworkComponent>(playerEntity, { (int32)playerEntity });
 		saltUIDs.PushBack(pPlayerDesc->pClient->GetStatistics()->GetSalt());
 
 		ClientRemoteBase* pClient = reinterpret_cast<ClientRemoteBase*>(pPlayerDesc->pClient);


### PR DESCRIPTION
## Purpose
  - It solves a bug that has to do with the Network Component for Players

## Changes
 - On the client, the ID in Network component should not be the Entity ID, instead it should be the Player NetworkUID, this is fixed now.
