### PR TITLE
Velocity component optional for dynamic colliders

### DIFF
--- a/LambdaEngine/Include/ECS/ComponentArray.h
+++ b/LambdaEngine/Include/ECS/ComponentArray.h
@@ -56,6 +56,10 @@ namespace LambdaEngine
 
 		Comp& Insert(Entity entity, const Comp& comp);
 
+		// Fills comp with component data, sets dirty flag if one exists and returns whether the component exists
+		bool GetIf(Entity entity, Comp& comp);
+		// Fills comp with component data and returns whether the component exists
+		bool GetConstIf(Entity entity, Comp& comp) const;
 		Comp& GetData(Entity entity);
 		const Comp& GetConstData(Entity entity) const;
 		const TArray<uint32>& GetIDs() const override final { return m_IDs; }
@@ -101,6 +105,39 @@ namespace LambdaEngine
 		m_EntityToIndex[entity] = newIndex;
 		m_IDs.PushBack(entity);
 		return m_Data.PushBack(comp);
+	}
+
+	template<typename Comp>
+	bool ComponentArray<Comp>::GetIf(Entity entity, Comp& comp)
+	{
+		auto indexItr = m_EntityToIndex.find(entity);
+		if (indexItr == m_EntityToIndex.end())
+		{
+			return false;
+		}
+
+		comp = m_Data[indexItr->second];
+
+		if constexpr (Comp::HasDirtyFlag())
+		{
+			comp.Dirty = true;
+		}
+
+		return true;
+	}
+
+	template<typename Comp>
+	bool ComponentArray<Comp>::GetConstIf(Entity entity, Comp& comp) const
+	{
+		auto indexItr = m_EntityToIndex.find(entity);
+		if (indexItr == m_EntityToIndex.end())
+		{
+			return false;
+		}
+
+		comp = m_Data[indexItr->second];
+
+		return true;
 	}
 
 	template<typename Comp>

--- a/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
@@ -74,7 +74,7 @@ namespace LambdaEngine
 					.pSubscriber = &m_DynamicCollisionEntities,
 					.ComponentAccesses =
 					{
-						{R, DynamicCollisionComponent::Type()}, {RW, PositionComponent::Type()}, {RW, RotationComponent::Type()}, {RW, VelocityComponent::Type()}
+						{R, DynamicCollisionComponent::Type()}, {RW, PositionComponent::Type()}, {RW, RotationComponent::Type()}
 					},
 					.OnEntityAdded = onDynamicCollisionAdded,
 					.OnEntityRemoval = onDynamicCollisionRemoval
@@ -87,6 +87,10 @@ namespace LambdaEngine
 					},
 					.OnEntityRemoval = onCharacterCollisionRemoval
 				}
+			};
+			systemReg.SubscriberRegistration.AdditionalAccesses =
+			{
+				{RW, VelocityComponent::Type()}
 			};
 			systemReg.Phase = 1;
 
@@ -198,7 +202,6 @@ namespace LambdaEngine
 			{
 				PositionComponent& positionComp = pPositionComponents->GetData(entity);
 				RotationComponent& rotationComp = pRotationComponents->GetData(entity);
-				VelocityComponent& velocityComp = pVelocityComponents->GetData(entity);
 
 				const PxTransform transformPX = pActor->getGlobalPose();
 				const PxVec3& positionPX = transformPX.p;
@@ -207,8 +210,12 @@ namespace LambdaEngine
 				const PxQuat& quatPX = transformPX.q;
 				rotationComp.Quaternion = { quatPX.x, quatPX.y, quatPX.z, quatPX.w };
 
-				const PxVec3 velocityPX = pActor->getLinearVelocity();
-				velocityComp.Velocity = { velocityPX.x, velocityPX.y, velocityPX.z };
+				VelocityComponent velocityComp;
+				if (pVelocityComponents->GetIf(entity, velocityComp))
+				{
+					const PxVec3 velocityPX = pActor->getLinearVelocity();
+					velocityComp.Velocity = { velocityPX.x, velocityPX.y, velocityPX.z };
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Purpose
- Having a velocity component for a dynamic (moving) collision entity is optional
- Add `GetIf` and `GetConstIf` functions to `ComponentArray`. Up until now, we've had to do:
```
if (pComponentArray->HasComponent(...))
    pComponentArray->GetData(...);
```

But this requires two lookups into a map. With `GetIf`, the code instead looks like:
```
Comp comp;
if (pComponentArray->GetIf(entity, comp))
    ...
```
