### PR TITLE
Call ClientSystem::Init when benchmarking

### DIFF
--- a/CrazyCanvas/Source/CrazyCanvas.cpp
+++ b/CrazyCanvas/Source/CrazyCanvas.cpp
@@ -76,6 +76,7 @@ CrazyCanvas::CrazyCanvas(const argh::parser& flagParser)
 	}
 	else if (stateStr == "benchmark")
 	{
+		ClientSystem::Init(pGameName);
 		pStartingState = DBG_NEW BenchmarkState();
 	}
 


### PR DESCRIPTION
## Purpose
Benchmarks are crashing on master.
