### PR TITLE
Fixed Sandbox State Crash

### DIFF
--- a/CrazyCanvas/Include/States/SandboxState.h
+++ b/CrazyCanvas/Include/States/SandboxState.h
@@ -15,7 +15,6 @@
 #include "Application/API/Events/KeyEvents.h"
 #include "Application/API/Events/NetworkEvents.h"
 
-#include "ECS/Systems/Player/WeaponSystem.h"
 #include "EventHandlers/AudioEffectHandler.h"
 #include "EventHandlers/MeshPaintHandler.h"
 
@@ -69,9 +68,6 @@ private:
 	LambdaEngine::TArray<LambdaEngine::ImGuiTexture> m_TextureDebuggingNames;
 
 	LambdaEngine::TArray<LambdaEngine::Entity> m_Entities;
-
-	/* Systems */
-	WeaponSystem m_WeaponSystem;
 
 	/* Event handlers */
 	AudioEffectHandler m_AudioEffectHandler;

--- a/CrazyCanvas/Source/States/SandboxState.cpp
+++ b/CrazyCanvas/Source/States/SandboxState.cpp
@@ -28,6 +28,7 @@
 #include "Game/ECS/Systems/Physics/PhysicsSystem.h"
 #include "Game/ECS/Systems/Rendering/RenderSystem.h"
 #include "Game/ECS/Systems/TrackSystem.h"
+#include "ECS/Systems/Player/WeaponSystem.h"
 #include "Game/GameConsole.h"
 
 #include "Input/API/Input.h"


### PR DESCRIPTION
## Purpose
  - Make it go "no no no" when trying to crash

## Changes
  - Removed weaponsystem from sandbox state (it is now static)
