### PR TITLE
Networking continued

### DIFF
--- a/LambdaEngine/Include/Networking/API/UDP/ServerNetworkDiscovery.h
+++ b/LambdaEngine/Include/Networking/API/UDP/ServerNetworkDiscovery.h
@@ -50,6 +50,7 @@ namespace LambdaEngine
         SegmentPool m_SegmentPool;
         SpinLock m_Lock;
         uint16 m_PortOfGameServer;
+        uint64 m_ServerUID;
         String m_NameOfGame;
         INetworkDiscoveryServer* m_pHandler;
     };

--- a/LambdaEngine/Source/Networking/API/UDP/ClientNetworkDiscovery.cpp
+++ b/LambdaEngine/Source/Networking/API/UDP/ClientNetworkDiscovery.cpp
@@ -205,7 +205,7 @@ namespace LambdaEngine
 		for (Packet& packet : packets)
 		{
 			BinaryDecoder& decoder = packet.Decoder;
-			m_pHandler->OnServerFound(decoder, IPEndPoint(packet.Sender.GetAddress(), decoder.ReadUInt16()), m_Statistics.GetRemoteSalt());
+			m_pHandler->OnServerFound(decoder, IPEndPoint(packet.Sender.GetAddress(), decoder.ReadUInt16()), decoder.ReadUInt64());
 #ifdef LAMBDA_CONFIG_DEBUG
 			m_SegmentPool.FreeSegment(decoder.GetPacket(), "ClientNetworkDiscovery::HandleReceivedPacketsMainThread");
 #else

--- a/LambdaEngine/Source/Networking/API/UDP/ServerNetworkDiscovery.cpp
+++ b/LambdaEngine/Source/Networking/API/UDP/ServerNetworkDiscovery.cpp
@@ -15,9 +15,11 @@ namespace LambdaEngine
 		m_Transceiver(),
 		m_Statistics(),
 		m_Lock(),
-		m_NameOfGame()
+		m_NameOfGame(),
+		m_ServerUID(0)
 	{
 		m_Transceiver.SetIgnoreSaltMissmatch(true);
+		m_ServerUID = Random::UInt64();
 	}
 
 	ServerNetworkDiscovery::~ServerNetworkDiscovery()
@@ -153,6 +155,7 @@ namespace LambdaEngine
 				BinaryEncoder encoder(pResponse);
 				encoder.WriteString(m_NameOfGame);
 				encoder.WriteUInt16(m_PortOfGameServer);
+				encoder.WriteUInt64(m_ServerUID);
 				m_pHandler->OnNetworkDiscoveryPreTransmit(encoder);
 
 				m_Transceiver.Transmit(&m_SegmentPool, packets, reliableUIDs, sender, &m_Statistics);


### PR DESCRIPTION
## Purpose
  - Fixed ServerUID is always 0 when OnLANServerFound

## Changes
 - The NetworkDiscoveryServer now contains the UID instead of using the salt