### PR TITLE
Fixed Networking was not Generating SegmentUID in Production and Release

### DIFF
--- a/LambdaEngine/Include/Networking/API/NetworkStatistics.h
+++ b/LambdaEngine/Include/Networking/API/NetworkStatistics.h
@@ -144,9 +144,9 @@ namespace LambdaEngine
 		uint32 m_PacketsReceivedFixed;
 
 		uint32 m_PacketsSent;
-		uint32 m_SegmentsRegistered;
+		std::atomic_uint32_t m_SegmentsRegistered;
 		uint32 m_SegmentsSent;
-		uint32 m_ReliableSegmentsSent;
+		std::atomic_uint32_t m_ReliableSegmentsSent;
 		uint32 m_PacketsReceived;
 		uint32 m_SegmentsReceived;
 		uint32 m_BytesSent;

--- a/LambdaEngine/Source/Networking/API/PacketManagerBase.cpp
+++ b/LambdaEngine/Source/Networking/API/PacketManagerBase.cpp
@@ -30,9 +30,6 @@ namespace LambdaEngine
 
 	uint32 PacketManagerBase::EnqueueSegment(NetworkSegment* pSegment, uint32 reliableUID)
 	{
-		if(pSegment->GetType() < 999)
-			ASSERT(pSegment->GetBufferSize() > 0)
-
 		pSegment->GetHeader().UID = m_Statistics.RegisterUniqueSegment();
 		pSegment->GetHeader().ReliableUID = reliableUID;
 		InsertSegment(pSegment);


### PR DESCRIPTION
## Purpose
  - Fixed Networking was not Generating SegmentUID in Production and Release
  **- What value is this change providing?**
To run the game outside Debug 
  **- Why is this change being made or feature being added?**
Same as above....

## Changes
 **- How was the solution or feature implemented?**
I remove the if statement and the assert that caused the error
 **- What new classes, files, or modules were created or modified to implement it?**
I modified the PacketManagerBase class