### PR TITLE
Perform component/entity registrations/deletions between phases

### DIFF
--- a/LambdaEngine/Include/ECS/ECSCore.h
+++ b/LambdaEngine/Include/ECS/ECSCore.h
@@ -110,6 +110,10 @@ namespace LambdaEngine
 		void RegisterSystem(System* pSystem, uint32 regularJobID);
 		void DeregisterSystem(uint32 regularJobID);
 
+		void PerformComponentRegistrations();
+		void PerformComponentDeletions();
+		void PerformEntityDeletions();
+
         Timestamp GetDeltaTime() const { return m_DeltaTime; }
 		const IDDVector<System*>& GetSystems() const { return m_Systems; }
 
@@ -126,9 +130,6 @@ namespace LambdaEngine
 		void DescheduleRegularJob(uint32_t phase, uint32 jobID)				{ m_JobScheduler.DescheduleRegularJob(phase, jobID); }
 
 	private:
-		void PerformComponentRegistrations();
-		void PerformComponentDeletions();
-		void PerformEntityDeletions();
 		bool DeleteComponent(Entity entity, const ComponentType* pComponentType);
 
 	private:

--- a/LambdaEngine/Include/ECS/JobScheduler.h
+++ b/LambdaEngine/Include/ECS/JobScheduler.h
@@ -42,6 +42,8 @@ namespace LambdaEngine
         void DeregisterJobExecution(const Job& job);
 
         void SetPhase(uint32_t phase);
+        /*  Advances to the next phase. Performs component registrations and deletions and entity deletions. If it's the last phase already,
+            the next phase might be a previous one, to accumulate regular jobs. */
         void NextPhase();
 
         void AccumulateRegularJobs();

--- a/LambdaEngine/Source/ECS/JobScheduler.cpp
+++ b/LambdaEngine/Source/ECS/JobScheduler.cpp
@@ -1,5 +1,6 @@
 #include "ECS/JobScheduler.h"
 
+#include "ECS/ECSCore.h"
 #include "ECS/EntitySubscriber.h"
 #include "Threading/API/ThreadPool.h"
 
@@ -257,6 +258,10 @@ namespace LambdaEngine
             }
         }
 
+        ECSCore* pECS = ECSCore::GetInstance();
+        pECS->PerformComponentRegistrations();
+        pECS->PerformComponentDeletions();
+        pECS->PerformEntityDeletions();
         SetPhase(upcomingPhase);
     }
 


### PR DESCRIPTION
## Purpose
Projectiles would bounce and be rendered 1 frame after colliding. This PR fixes that, so that projectiles aren't rendered even once after colliding.

## Changes
Perform component/entity registrations/deletions between phases (`JobScheduler::NextPhase`)