### PR TITLE
Singleplayer fixes

### DIFF
--- a/CrazyCanvas/Include/Multiplayer/SingleplayerInitializer.h
+++ b/CrazyCanvas/Include/Multiplayer/SingleplayerInitializer.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "LambdaEngine.h"
+
+namespace LambdaEngine
+{
+	class SingleplayerInitializer
+	{
+	public:
+		DECL_STATIC_CLASS(SingleplayerInitializer);
+
+		static void InitSingleplayer();
+	};
+}

--- a/CrazyCanvas/Include/States/PlaySessionState.h
+++ b/CrazyCanvas/Include/States/PlaySessionState.h
@@ -20,7 +20,7 @@ class Level;
 class PlaySessionState : public LambdaEngine::State
 {
 public:
-	PlaySessionState(LambdaEngine::IPAddress* pIPAddress);
+	PlaySessionState(bool singlePlayer, LambdaEngine::IPAddress* pIPAddress);
 	~PlaySessionState();
 
 	void Init() override final;
@@ -32,6 +32,7 @@ public:
 	void FixedTick(LambdaEngine::Timestamp delta) override final;
 
 private:
+	bool m_Singleplayer;
 	LambdaEngine::IPAddress* m_pIPAddress;
 
 	MultiplayerClient m_MultiplayerClient;

--- a/CrazyCanvas/Source/CrazyCanvas.cpp
+++ b/CrazyCanvas/Source/CrazyCanvas.cpp
@@ -69,7 +69,7 @@ CrazyCanvas::CrazyCanvas(const argh::parser& flagParser)
 	else if (stateStr == "client")
 	{
 		ClientSystem::Init(pGameName);
-		pStartingState = DBG_NEW PlaySessionState(NetworkUtils::GetLocalAddress());
+		pStartingState = DBG_NEW PlaySessionState(false, NetworkUtils::GetLocalAddress());
 	}
 	else if (stateStr == "server")
 	{

--- a/CrazyCanvas/Source/GUI/LobbyGUI.cpp
+++ b/CrazyCanvas/Source/GUI/LobbyGUI.cpp
@@ -135,7 +135,7 @@ void LobbyGUI::OnButtonConnectClick(Noesis::BaseComponent* pSender, const Noesis
 
 	SetRenderStagesActive();
 
-	State* pPlayState = DBG_NEW PlaySessionState(pIP);
+	State* pPlayState = DBG_NEW PlaySessionState(false, pIP);
 	StateManager::GetInstance()->EnqueueStateTransition(pPlayState, STATE_TRANSITION::POP_AND_PUSH);
 }
 
@@ -197,7 +197,7 @@ void LobbyGUI::OnButtonHostGameClick(Noesis::BaseComponent* pSender, const Noesi
 
 		SetRenderStagesActive();
 
-		State* pPlaySessionState = DBG_NEW PlaySessionState(NetworkUtils::GetLocalAddress());
+		State* pPlaySessionState = DBG_NEW PlaySessionState(false, NetworkUtils::GetLocalAddress());
 		StateManager::GetInstance()->EnqueueStateTransition(pPlaySessionState, STATE_TRANSITION::POP_AND_PUSH);
 	}
 }
@@ -241,7 +241,7 @@ void LobbyGUI::StartSelectedServer(Noesis::Grid* pGrid)
 
 			SetRenderStagesActive();
 
-			State* pPlaySessionState = DBG_NEW PlaySessionState(server.second.EndPoint.GetAddress());
+			State* pPlaySessionState = DBG_NEW PlaySessionState(false, server.second.EndPoint.GetAddress());
 			StateManager::GetInstance()->EnqueueStateTransition(pPlaySessionState, STATE_TRANSITION::POP_AND_PUSH);
 		}
 	}

--- a/CrazyCanvas/Source/GUI/MainMenuGUI.cpp
+++ b/CrazyCanvas/Source/GUI/MainMenuGUI.cpp
@@ -90,7 +90,7 @@ void MainMenuGUI::OnButtonSingleplayerClick(BaseComponent* pSender, const Routed
 
 	SetRenderStagesSleeping();
 
-	State* pStartingState = DBG_NEW PlaySessionState(IPAddress::LOOPBACK);
+	State* pStartingState = DBG_NEW PlaySessionState(true, IPAddress::LOOPBACK);
 	StateManager::GetInstance()->EnqueueStateTransition(pStartingState, STATE_TRANSITION::POP_AND_PUSH);
 }
 

--- a/CrazyCanvas/Source/Multiplayer/SingleplayerInitializer.cpp
+++ b/CrazyCanvas/Source/Multiplayer/SingleplayerInitializer.cpp
@@ -1,0 +1,31 @@
+#include "Multiplayer/SingleplayerInitializer.h"
+
+#include "Game/Multiplayer/MultiplayerUtils.h"
+#include "Game/Multiplayer/Client/ClientSystem.h"
+
+#include "Multiplayer/Packet/PacketType.h"
+
+#include "World/LevelObjectCreator.h"
+
+namespace LambdaEngine
+{
+	void SingleplayerInitializer::InitSingleplayer()
+	{
+		using namespace LambdaEngine;
+
+		MultiplayerUtils::SetIsSingleplayer(true);
+		ClientSystem& clientSystem = ClientSystem::GetInstance();
+		ClientBase* pClient = clientSystem.GetClient();
+
+		NetworkSegment* pPacket = pClient->GetFreePacket(PacketType::CREATE_LEVEL_OBJECT);
+		BinaryEncoder encoder(pPacket);
+		encoder.WriteUInt8(ELevelObjectType::LEVEL_OBJECT_TYPE_PLAYER);
+		encoder.WriteBool(true);
+		encoder.WriteInt32(0);
+		encoder.WriteVec3(glm::vec3(0.0f, 2.0f, 0.0f));
+		encoder.WriteVec3(glm::vec3(1.0f, 0.0f, 0.0f));
+		encoder.WriteUInt32(0);
+		clientSystem.OnPacketReceived(pClient, pPacket);
+		pClient->ReturnPacket(pPacket);
+	}
+}

--- a/CrazyCanvas/Source/States/BenchmarkState.cpp
+++ b/CrazyCanvas/Source/States/BenchmarkState.cpp
@@ -39,6 +39,7 @@
 #include "World/Level.h"
 
 #include "Multiplayer/Packet/PacketType.h"
+#include "Multiplayer/SingleplayerInitializer.h"
 
 BenchmarkState::~BenchmarkState()
 {
@@ -248,7 +249,7 @@ void BenchmarkState::Init()
 	}
 
 	// Triggers OnPacketReceived, which creates players
-	ClientSystem::GetInstance().Connect(IPAddress::LOOPBACK);
+	SingleplayerInitializer::InitSingleplayer();
 }
 
 void BenchmarkState::Tick(LambdaEngine::Timestamp delta)

--- a/CrazyCanvas/Source/States/PlaySessionState.cpp
+++ b/CrazyCanvas/Source/States/PlaySessionState.cpp
@@ -32,8 +32,10 @@
 #include "Application/API/Events/EventQueue.h"
 
 #include "Multiplayer/Packet/PacketType.h"
+#include "Multiplayer/SingleplayerInitializer.h"
 
-PlaySessionState::PlaySessionState(LambdaEngine::IPAddress* pIPAddress) :
+PlaySessionState::PlaySessionState(bool singlePlayer, LambdaEngine::IPAddress* pIPAddress) :
+	m_Singleplayer(singlePlayer),
 	m_pIPAddress(pIPAddress),
 	m_MultiplayerClient()
 {
@@ -182,7 +184,14 @@ void PlaySessionState::Init()
 		pECS->AddComponent<AudibleComponent>(entity, { pSoundInstance });
 	}
 
-	ClientSystem::GetInstance().Connect(m_pIPAddress);
+	if (m_Singleplayer)
+	{
+		SingleplayerInitializer::InitSingleplayer();
+	}
+	else
+	{
+		ClientSystem::GetInstance().Connect(m_pIPAddress);
+	}
 }
 
 void PlaySessionState::Tick(LambdaEngine::Timestamp delta)

--- a/CrazyCanvas/Source/States/SandboxState.cpp
+++ b/CrazyCanvas/Source/States/SandboxState.cpp
@@ -56,6 +56,7 @@
 #include "Game/Multiplayer/Client/ClientSystem.h"
 
 #include "Multiplayer/Packet/PacketType.h"
+#include "Multiplayer/SingleplayerInitializer.h"
 
 #include <imgui.h>
 
@@ -343,7 +344,7 @@ void SandboxState::Init()
 			}
 		});
 
-	ClientSystem::GetInstance().Connect(IPAddress::LOOPBACK);
+	SingleplayerInitializer::InitSingleplayer();
 }
 
 void SandboxState::Resume()

--- a/LambdaEngine/Include/Game/Multiplayer/Client/ClientSystem.h
+++ b/LambdaEngine/Include/Game/Multiplayer/Client/ClientSystem.h
@@ -10,6 +10,7 @@ namespace LambdaEngine
 	class ClientSystem : protected IClientHandler, protected INetworkDiscoveryClient
 	{
 		friend class EngineLoop;
+		friend class SingleplayerInitializer;
 
 	public:
 		DECL_UNIQUE_CLASS(ClientSystem);

--- a/LambdaEngine/Include/Game/Multiplayer/MultiplayerUtils.h
+++ b/LambdaEngine/Include/Game/Multiplayer/MultiplayerUtils.h
@@ -13,7 +13,6 @@ namespace LambdaEngine
 	{
 		friend class ClientSystem;
 		friend class ServerSystem;
-		friend class ClientRemoteSystem;
 		friend class NetworkSystem;
 
 	public:
@@ -24,6 +23,8 @@ namespace LambdaEngine
 		static int32 GetNetworkUID(Entity entity);
 		static bool IsSingleplayer();
 		static bool HasWriteAccessToEntity(Entity entity);
+
+		static void SetIsSingleplayer(bool value);
 
 	private:
 		static void Init(bool server);

--- a/LambdaEngine/Source/Game/Multiplayer/Client/ClientSystem.cpp
+++ b/LambdaEngine/Source/Game/Multiplayer/Client/ClientSystem.cpp
@@ -57,24 +57,6 @@ namespace LambdaEngine
 	{
 		NetworkDiscovery::DisableClient();
 
-		if (pAddress == IPAddress::LOOPBACK)
-		{
-			MultiplayerUtils::s_IsSinglePlayer = true;
-
-			NetworkSegment* pPacket = m_pClient->GetFreePacket(1); //PacketType::CREATE_ENTITY
-			BinaryEncoder encoder3(pPacket);
-			encoder3.WriteUInt8(5); //ELevelObjectType::LEVEL_OBJECT_TYPE_PLAYER
-			encoder3.WriteBool(true);
-			encoder3.WriteInt32(0);
-			encoder3.WriteVec3(glm::vec3(0.0f, 2.0f, 0.0f));
-			encoder3.WriteVec3(glm::vec3(1.0f, 0.0f, 0.0f));
-			encoder3.WriteUInt32(0);
-			OnPacketReceived(m_pClient, pPacket);
-			m_pClient->ReturnPacket(pPacket);
-
-			return true;
-		}
-
 		MultiplayerUtils::s_IsSinglePlayer = false;
 
 		if (!m_pClient->Connect(IPEndPoint(pAddress, (uint16)EngineConfig::GetIntProperty("NetworkPort"))))

--- a/LambdaEngine/Source/Game/Multiplayer/MultiplayerUtils.cpp
+++ b/LambdaEngine/Source/Game/Multiplayer/MultiplayerUtils.cpp
@@ -51,6 +51,11 @@ namespace LambdaEngine
 		return true;
 	}
 
+	void MultiplayerUtils::SetIsSingleplayer(bool value)
+	{
+		s_IsSinglePlayer = value;
+	}
+
 	void MultiplayerUtils::Init(bool server)
 	{
 		Release();


### PR DESCRIPTION
## Purpose
  - The Benchmark didn't spawn any Players, this fixes that.
  - The root cause was that Singleplayer was implemented in Engine, not in CrazyCanvas.
  - This also makes it easier to define what should happen on Singleplayer Initialize.

## Changes
 - There is a SingleplayerInitializer in CrazyCanvas now.
