### PR TITLE
Seperate input from GUI and game

### DIFF
--- a/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
@@ -149,7 +149,7 @@ void WeaponSystem::Tick(LambdaEngine::Timestamp deltaTime)
 		}
 		else if (!onCooldown) // If we did not hit the reload try and shoot
 		{
-			if (Input::GetMouseState(InputMode::GAME).IsButtonPressed(EMouseButton::MOUSE_BUTTON_FORWARD))
+			if (Input::GetMouseState(InputMode::GAME).IsButtonPressed(EMouseButton::MOUSE_BUTTON_LEFT))
 			{
 				const PositionComponent& positionComp = pPositionComponents->GetConstData(playerEntity);
 				const VelocityComponent& velocityComp = pVelocityComponents->GetConstData(playerEntity);
@@ -157,7 +157,7 @@ void WeaponSystem::Tick(LambdaEngine::Timestamp deltaTime)
 
 				TryFire(EAmmoType::AMMO_TYPE_PAINT, weaponComponent, positionComp.Position, rotationComp.Quaternion, velocityComp.Velocity);
 			}
-			else if (Input::GetMouseState(InputMode::GAME).IsButtonPressed(EMouseButton::MOUSE_BUTTON_BACK))
+			else if (Input::GetMouseState(InputMode::GAME).IsButtonPressed(EMouseButton::MOUSE_BUTTON_RIGHT))
 			{
 				const PositionComponent& positionComp = pPositionComponents->GetConstData(playerEntity);
 				const VelocityComponent& velocityComp = pVelocityComponents->GetConstData(playerEntity);

--- a/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
@@ -143,13 +143,13 @@ void WeaponSystem::Tick(LambdaEngine::Timestamp deltaTime)
 		}
 
 		// Reload if we are not reloading
-		if (Input::IsKeyDown(EKey::KEY_R) && !isReloading)
+		if (Input::IsKeyDown(InputMode::GAME, EKey::KEY_R) && !isReloading)
 		{
 			StartReload(weaponComponent);
 		}
 		else if (!onCooldown) // If we did not hit the reload try and shoot
 		{
-			if (Input::GetMouseState().IsButtonPressed(EMouseButton::MOUSE_BUTTON_FORWARD))
+			if (Input::GetMouseState(InputMode::GAME).IsButtonPressed(EMouseButton::MOUSE_BUTTON_FORWARD))
 			{
 				const PositionComponent& positionComp = pPositionComponents->GetConstData(playerEntity);
 				const VelocityComponent& velocityComp = pVelocityComponents->GetConstData(playerEntity);
@@ -157,7 +157,7 @@ void WeaponSystem::Tick(LambdaEngine::Timestamp deltaTime)
 
 				TryFire(EAmmoType::AMMO_TYPE_PAINT, weaponComponent, positionComp.Position, rotationComp.Quaternion, velocityComp.Velocity);
 			}
-			else if (Input::GetMouseState().IsButtonPressed(EMouseButton::MOUSE_BUTTON_BACK))
+			else if (Input::GetMouseState(InputMode::GAME).IsButtonPressed(EMouseButton::MOUSE_BUTTON_BACK))
 			{
 				const PositionComponent& positionComp = pPositionComponents->GetConstData(playerEntity);
 				const VelocityComponent& velocityComp = pVelocityComponents->GetConstData(playerEntity);

--- a/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
@@ -42,7 +42,7 @@ void PlayerActionSystem::TickMainThread(Timestamp deltaTime, Entity entityPlayer
 
 	if (m_MouseEnabled)
 	{
-		const MouseState& mouseState = Input::GetMouseState();
+		const MouseState& mouseState = Input::GetMouseState(InputMode::GAME);
 
 		TSharedRef<Window> window = CommonApplication::Get()->GetMainWindow();
 		const int32 halfWidth		= int32(0.5f * float32(window->GetWidth()));

--- a/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
@@ -80,7 +80,7 @@ void PlayerActionSystem::TickMainThread(Timestamp deltaTime, Entity entityPlayer
 
 bool PlayerActionSystem::OnKeyPressed(const KeyPressedEvent& event)
 {
-	if (event.Key == EKey::KEY_KEYPAD_0)
+	if (event.Key == EKey::KEY_KEYPAD_0 || event.Key == EKey::KEY_END)
 	{
 		m_MouseEnabled = !m_MouseEnabled;
 		CommonApplication::Get()->SetMouseVisibility(!m_MouseEnabled);

--- a/LambdaEngine/Include/Input/API/Input.h
+++ b/LambdaEngine/Include/Input/API/Input.h
@@ -5,10 +5,19 @@
 
 #include "Threading/API/SpinLock.h"
 
+#include <stack>
+
 namespace LambdaEngine
 {
 	#define STATE_READ_INDEX 0
 	#define STATE_WRITE_INDEX 1
+
+	enum class InputMode : uint8
+	{
+		GUI		= 0,
+		GAME	= 1,
+		NONE	= UINT8_MAX,
+	};
 
 	/*
 	* Input
@@ -28,16 +37,31 @@ namespace LambdaEngine
 			s_InputEnabled = true;
 		}
 
-		static void Disable();
-
-		FORCEINLINE static bool IsKeyDown(EKey key)
+		FORCEINLINE static void PushInputMode(InputMode inputMode)
 		{
-			return s_KeyboardStates[STATE_READ_INDEX].IsKeyDown(key);
+			s_InputModeStack.push(inputMode);
 		}
 
-		FORCEINLINE static bool IsKeyUp(EKey key)
+		FORCEINLINE static void PopInputMode()
 		{
-			return s_KeyboardStates[STATE_READ_INDEX].IsKeyUp(key);
+			s_InputModeStack.pop();
+		}
+
+		FORCEINLINE static InputMode GetCurrentInputmode()
+		{
+			return s_InputModeStack.top();
+		}
+
+		static void Disable();
+
+		FORCEINLINE static bool IsKeyDown(InputMode inputMode, EKey key)
+		{
+			return s_KeyboardStates[ConvertInputModeUINT8(inputMode)][STATE_READ_INDEX].IsKeyDown(key);
+		}
+
+		FORCEINLINE static bool IsKeyUp(InputMode inputMode, EKey key)
+		{
+			return s_KeyboardStates[ConvertInputModeUINT8(inputMode)][STATE_READ_INDEX].IsKeyUp(key);
 		}
 
 		FORCEINLINE static bool IsInputEnabled()
@@ -45,26 +69,30 @@ namespace LambdaEngine
 			return s_InputEnabled;
 		}
 
-		FORCEINLINE static const KeyboardState& GetKeyboardState()
+		FORCEINLINE static const KeyboardState& GetKeyboardState(InputMode inputMode)
 		{
-			return s_KeyboardStates[STATE_READ_INDEX];
+			return s_KeyboardStates[ConvertInputModeUINT8(inputMode)][STATE_READ_INDEX];
 		}
 
-		FORCEINLINE static const MouseState& GetMouseState()
+		FORCEINLINE static const MouseState& GetMouseState(InputMode inputMode)
 		{
-			return s_MouseStates[STATE_READ_INDEX];
+			return s_MouseStates[ConvertInputModeUINT8(inputMode)][STATE_READ_INDEX];
 		}
 
 	private:
 		static bool HandleEvent(const Event& event);
+		static uint8 ConvertInputModeUINT8(InputMode inputMode);
 
 	private:
 		// Input states are double buffered. The first one is read from, the second is written to.
-		static KeyboardState s_KeyboardStates[2];
-		static MouseState s_MouseStates[2];
+		static KeyboardState s_KeyboardStates[2][2];
+		static MouseState s_MouseStates[2][2];
+
 		// Make sure nothing is being written to the write buffer when copying write buffer to read buffer in Input::Tick
 		static SpinLock s_WriteBufferLockMouse;
 		static SpinLock s_WriteBufferLockKeyboard;
 		static std::atomic_bool s_InputEnabled;
+
+		static std::stack<InputMode> s_InputModeStack;
 	};
 }

--- a/LambdaEngine/Include/Rendering/RenderGraphEditor.h
+++ b/LambdaEngine/Include/Rendering/RenderGraphEditor.h
@@ -108,6 +108,8 @@ namespace LambdaEngine
 		bool						m_ParsedGraphRenderDirty		= true;
 		bool						m_ApplyRenderGraph				= false;
 
+		bool						m_GraphActive					= false;
+
 	private:
 		static int32 s_NextNodeID;
 		static int32 s_NextAttributeID;

--- a/LambdaEngine/Source/Debug/CPUProfiler.cpp
+++ b/LambdaEngine/Source/Debug/CPUProfiler.cpp
@@ -105,7 +105,7 @@ namespace LambdaEngine
 	void CPUProfiler::ToggleSample(EKey key, uint32_t frameCount)
 	{
 		static uint32_t frameCounter = 0;
-		if (Input::GetKeyboardState().IsKeyDown(key))
+		if (Input::GetKeyboardState(InputMode::GAME).IsKeyDown(key))
 		{
 			frameCounter = 0;
 			CPUProfiler::g_RunProfilingSample = true;

--- a/LambdaEngine/Source/Game/ECS/Systems/CameraSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/CameraSystem.cpp
@@ -105,7 +105,7 @@ namespace LambdaEngine
 				}
 
 				#ifdef LAMBDA_DEBUG
-					if (Input::IsKeyDown(EKey::KEY_T))
+					if (Input::IsKeyDown(InputMode::GAME, EKey::KEY_T))
 					{
 						RenderFrustum(entity, pPositionComponents->GetData(entity), rotationComp);
 					}
@@ -206,7 +206,7 @@ namespace LambdaEngine
 
 		if (m_MouseEnabled)
 		{
-			const MouseState& mouseState = Input::GetMouseState();
+			const MouseState& mouseState = Input::GetMouseState(InputMode::GAME);
 
 			TSharedRef<Window> window = CommonApplication::Get()->GetMainWindow();
 			const uint16 width = window->GetWidth();

--- a/LambdaEngine/Source/Game/GameConsole.cpp
+++ b/LambdaEngine/Source/Game/GameConsole.cpp
@@ -828,6 +828,10 @@ namespace LambdaEngine
 		if (event.Key == EKey::KEY_GRAVE_ACCENT && !event.IsRepeat)
 		{
 			m_IsActive = !m_IsActive;
+			if (m_IsActive)
+				Input::PushInputMode(InputMode::GUI);
+			else
+				Input::PopInputMode();
 			return true;
 		}
 

--- a/LambdaEngine/Source/Input/API/InputActionSystem.cpp
+++ b/LambdaEngine/Source/Input/API/InputActionSystem.cpp
@@ -107,7 +107,7 @@ namespace LambdaEngine
 
 		if (itr != m_CurrentKeyBindings.end()) {
 			EKey keyPressed = itr->second;
-			return Input::IsKeyDown(keyPressed);
+			return Input::IsKeyDown(InputMode::GAME, keyPressed);
 		}
 
 		LOG_ERROR("Action %s is not defined.", action.c_str());

--- a/LambdaEngine/Source/Rendering/RenderGraphEditor.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraphEditor.cpp
@@ -11,6 +11,8 @@
 #include "Utilities/IOUtilities.h"
 #include "Time/API/Clock.h"
 
+#include "Input/API/Input.h"
+
 #define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 #include <imgui.h>
 #include <imgui_internal.h>
@@ -104,6 +106,12 @@ namespace LambdaEngine
 	{
 		if (ImGui::Begin("Render Graph Editor"))
 		{
+			if (!m_GraphActive)
+			{
+				m_GraphActive = true;
+				Input::PushInputMode(InputMode::GUI);
+			}
+
 			ImVec2 contentRegionMin = ImGui::GetWindowContentRegionMin();
 			ImVec2 contentRegionMax = ImGui::GetWindowContentRegionMax();
 
@@ -209,6 +217,11 @@ namespace LambdaEngine
 			}
 
 			ImGui::EndChild();
+		}
+		else if (m_GraphActive)
+		{
+			m_GraphActive = false;
+			Input::PopInputMode();
 		}
 		ImGui::End();
 
@@ -1132,6 +1145,7 @@ namespace LambdaEngine
 
 		if (ImGui::BeginMenuBar())
 		{
+
 			if (ImGui::BeginMenu("Menu"))
 			{
 				if (ImGui::MenuItem("New"))


### PR DESCRIPTION
## Purpose
  - When using GUI the player would move/interact when not supposed to, for instance when typing in the console. This pull request will add InputMode to solve this issue.

## Changes
  - InputMode is added to most input functions to tell the input system if the caller want to care about GUI or GAME inputs.
  - Pop/Push functions to tell the input system which InputMode should be used for the time being.
  - KEY_END is now possible to use to lock cursor on screen (for non-numpad users)

## Example
  - ConsoleWindow is opened - Input::PushInputMode(InputMode::GUI) is called - the system is now in GUI mode.
  - ConsoleWindow is closed  - Input::PopInputMode() is called - the system is now in the previous used inputMode.