### PR TITLE
Rebuild SBT Optimizations

### DIFF
--- a/LambdaEngine/Include/Rendering/Core/API/GraphicsDevice.h
+++ b/LambdaEngine/Include/Rendering/Core/API/GraphicsDevice.h
@@ -142,7 +142,7 @@ namespace LambdaEngine
 		virtual PipelineState*	CreateComputePipelineState(const ComputePipelineStateDesc* pDesc) 		const = 0;
 		virtual PipelineState*	CreateRayTracingPipelineState(const RayTracingPipelineStateDesc* pDesc)	const = 0;
 
-		virtual SBT* CreateSBT(CommandQueue* pCommandQueue, const SBTDesc* pDesc) const = 0;
+		virtual SBT* CreateSBT(CommandList* pCommandList, const SBTDesc* pDesc) const = 0;
 		
 		virtual AccelerationStructure*	CreateAccelerationStructure(const AccelerationStructureDesc* pDesc) const = 0;
 		

--- a/LambdaEngine/Include/Rendering/Core/API/SBT.h
+++ b/LambdaEngine/Include/Rendering/Core/API/SBT.h
@@ -18,6 +18,8 @@ namespace LambdaEngine
 	public:
 		DECL_INTERFACE(SBT);
 
+		virtual bool Build(CommandList* pCommandList, TArray<DeviceChild*>& removedDeviceResources, const SBTDesc* pDesc) = 0;
+
 	protected:
 		String m_DebugName;
 	};

--- a/LambdaEngine/Include/Rendering/Core/Vulkan/GraphicsDeviceVK.h
+++ b/LambdaEngine/Include/Rendering/Core/Vulkan/GraphicsDeviceVK.h
@@ -115,7 +115,7 @@ namespace LambdaEngine
 		virtual PipelineState* CreateComputePipelineState(const ComputePipelineStateDesc* pDesc) const override final;
 		virtual PipelineState* CreateRayTracingPipelineState(const RayTracingPipelineStateDesc* pDesc) const override final;
 
-		virtual SBT* CreateSBT(CommandQueue* pCommandQueue, const SBTDesc* pDesc) const override final;
+		virtual SBT* CreateSBT(CommandList* pCommandList, const SBTDesc* pDesc) const override final;
 
 		virtual AccelerationStructure* CreateAccelerationStructure(const AccelerationStructureDesc* pDesc) const override final;
 

--- a/LambdaEngine/Include/Rendering/Core/Vulkan/SBTVK.h
+++ b/LambdaEngine/Include/Rendering/Core/Vulkan/SBTVK.h
@@ -17,11 +17,13 @@ namespace LambdaEngine
 		SBTVK(const GraphicsDeviceVK* pDevice);
 		~SBTVK();
 
-		bool Init(CommandQueue* pCommandQueue, const SBTDesc* pDesc);
+		bool Init(CommandList* pCommandList, const SBTDesc* pDesc);
+
+		virtual bool Build(CommandList* pCommandList, TArray<DeviceChild*>& removedDeviceResources, const SBTDesc* pDesc) override;
 
 		FORCEINLINE BufferVK* GetSBT()
 		{
-			return m_SBTBuffer.Get();
+			return m_pSBTBuffer;
 		}
 		
 		FORCEINLINE const VkStridedBufferRegionKHR* GetRaygenBufferRegion() const
@@ -48,10 +50,10 @@ namespace LambdaEngine
 		virtual void SetName(const String& debugName) override final;
 
 	private:
-		TSharedRef<BufferVK>	m_ShaderHandleStorageBuffer = nullptr;
-		TSharedRef<BufferVK>	m_SBTBuffer					= nullptr;
-		TSharedRef<BufferVK>	m_ShaderRecordsBuffer		= nullptr;
-		uint32					m_NumShaderRecords			= 0;
+		BufferVK*				m_pShaderHandleStorageBuffer	= nullptr;
+		BufferVK*				m_pSBTBuffer					= nullptr;
+		BufferVK*				m_pShaderRecordsBuffer			= nullptr;
+		uint32					m_NumShaderRecords				= 0;
 
 		VkStridedBufferRegionKHR m_RaygenBufferRegion	= {};
 		VkStridedBufferRegionKHR m_HitBufferRegion		= {};

--- a/LambdaEngine/Include/Rendering/RenderGraph.h
+++ b/LambdaEngine/Include/Rendering/RenderGraph.h
@@ -353,7 +353,7 @@ namespace LambdaEngine
 		/*
 		* Updates the global SBT which is used for all Ray Tracing calls, each SBTRecord should contain addresses to valid Buffers
 		*/
-		void UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords);
+		void UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*> removedDeviceResources);
 		/*
 		* Updates the dimensions of a RenderStage, will only set the dimensions which are set to EXTERNAL
 		*/

--- a/LambdaEngine/Include/Rendering/RenderGraph.h
+++ b/LambdaEngine/Include/Rendering/RenderGraph.h
@@ -353,7 +353,7 @@ namespace LambdaEngine
 		/*
 		* Updates the global SBT which is used for all Ray Tracing calls, each SBTRecord should contain addresses to valid Buffers
 		*/
-		void UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*> removedDeviceResources);
+		void UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*>& removedDeviceResources);
 		/*
 		* Updates the dimensions of a RenderStage, will only set the dimensions which are set to EXTERNAL
 		*/

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -2334,7 +2334,7 @@ namespace LambdaEngine
 		{
 			if (!m_SBTRecords.IsEmpty())
 			{
-				m_pRenderGraph->UpdateGlobalSBT(m_SBTRecords);
+				m_pRenderGraph->UpdateGlobalSBT(m_SBTRecords, m_ResourcesToRemove[m_ModFrameIndex]);
 			}
 
 			m_RenderGraphSBTRecordsDirty = false;

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/GraphicsDeviceVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/GraphicsDeviceVK.cpp
@@ -624,12 +624,12 @@ namespace LambdaEngine
 		}
 	}
 
-	SBT* GraphicsDeviceVK::CreateSBT(CommandQueue* pCommandQueue, const SBTDesc* pDesc) const
+	SBT* GraphicsDeviceVK::CreateSBT(CommandList* pCommandList, const SBTDesc* pDesc) const
 	{
 		VALIDATE(pDesc != nullptr);
 
 		SBTVK* pSBT = DBG_NEW SBTVK(this);
-		if (!pSBT->Init(pCommandQueue, pDesc))
+		if (!pSBT->Init(pCommandList, pDesc))
 		{
 			pSBT->Release();
 			return nullptr;

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/SBTVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/SBTVK.cpp
@@ -18,33 +18,73 @@ namespace LambdaEngine
 
 	SBTVK::~SBTVK()
 	{
+		SAFERELEASE(m_pShaderHandleStorageBuffer);
+		SAFERELEASE(m_pSBTBuffer);
+		SAFERELEASE(m_pShaderRecordsBuffer);
+
 		m_RaygenBufferRegion	= {};
 		m_HitBufferRegion		= {};
 		m_MissBufferRegion		= {};
 		m_CallableBufferRegion	= {};
 	}
 
-	bool SBTVK::Init(CommandQueue* pCommandQueue, const SBTDesc* pDesc)
+	bool SBTVK::Init(CommandList* pCommandList, const SBTDesc* pDesc)
+	{
+		VALIDATE(pDesc != nullptr);
+
+		TArray<DeviceChild*> removedDeviceChildren;
+		if (!Build(pCommandList, removedDeviceChildren, pDesc))
+		{
+			LOG_ERROR("[SBTVK]: Failed to build SBT");
+			return false;
+		}
+
+		for (DeviceChild* pDeviceChild : removedDeviceChildren)
+		{
+			SAFERELEASE(pDeviceChild);
+		}
+
+		if (!pDesc->DebugName.empty())
+		{
+			D_LOG_MESSAGE("[SBTVK]: Created SBT %s", pDesc->DebugName.c_str());
+		}
+		else
+		{
+			D_LOG_MESSAGE("[SBTVK]: Created SBT");
+		}
+
+		return true;
+	}
+
+	bool SBTVK::Build(CommandList* pCommandList, TArray<DeviceChild*>& removedDeviceResources, const SBTDesc* pDesc)
 	{
 		VALIDATE(pDesc != nullptr);
 		VALIDATE(pDesc->pPipelineState != nullptr);
 		VALIDATE(pDesc->pPipelineState->GetType() == EPipelineStateType::PIPELINE_STATE_TYPE_RAY_TRACING);
 
+		constexpr const uint64 OVER_ALLOCATION_MULT = 2;
+
 		void* pMapped;
 		m_NumShaderRecords = pDesc->SBTRecords.GetSize();
+		
+		uint64 newShaderRecordsBufferSize = m_NumShaderRecords * sizeof(SBTRecord);
 
-		BufferDesc shaderRecordsBufferDesc = {};
-		shaderRecordsBufferDesc.DebugName		= "Shader Records Storage";
-		shaderRecordsBufferDesc.Flags			= BUFFER_FLAG_COPY_SRC;
-		shaderRecordsBufferDesc.MemoryType		= EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
-		shaderRecordsBufferDesc.SizeInBytes		= m_NumShaderRecords * sizeof(SBTRecord);
+		if (m_pShaderRecordsBuffer == nullptr || newShaderRecordsBufferSize > m_pShaderRecordsBuffer->GetDesc().SizeInBytes)
+		{
+			if (m_pShaderRecordsBuffer != nullptr) removedDeviceResources.PushBack(m_pShaderRecordsBuffer);
 
-		m_ShaderRecordsBuffer		= reinterpret_cast<BufferVK*>(m_pDevice->CreateBuffer(&shaderRecordsBufferDesc));
+			BufferDesc shaderRecordsBufferDesc = {};
+			shaderRecordsBufferDesc.DebugName		= "Shader Records Storage";
+			shaderRecordsBufferDesc.Flags			= BUFFER_FLAG_COPY_SRC;
+			shaderRecordsBufferDesc.MemoryType		= EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
+			shaderRecordsBufferDesc.SizeInBytes		= OVER_ALLOCATION_MULT * newShaderRecordsBufferSize;
 
-		pMapped = m_ShaderRecordsBuffer->Map();
-		//memcpy(pMapped, pDesc->SBTRecords.GetData(), shaderRecordsBufferDesc.SizeInBytes);
-		memcpy(pMapped, pDesc->SBTRecords.GetData(), shaderRecordsBufferDesc.SizeInBytes);
-		m_ShaderRecordsBuffer->Unmap();
+			m_pShaderRecordsBuffer = reinterpret_cast<BufferVK*>(m_pDevice->CreateBuffer(&shaderRecordsBufferDesc));
+		}
+
+		pMapped = m_pShaderRecordsBuffer->Map();
+		memcpy(pMapped, pDesc->SBTRecords.GetData(), newShaderRecordsBufferSize);
+		m_pShaderRecordsBuffer->Unmap();
 
 		const RayTracingPipelineStateVK* pRayTracingPipelineVK = reinterpret_cast<const RayTracingPipelineStateVK*>(pDesc->pPipelineState);
 
@@ -72,15 +112,20 @@ namespace LambdaEngine
 		uint64 sbtSize						= missSBTOffset + missSize;
 		uint32 shaderGroupCount				= 1 + pRayTracingPipelineVK->HitShaderCount() + pRayTracingPipelineVK->MissShaderCount();
 
-		BufferDesc shaderHandleStorageDesc = {};
-		shaderHandleStorageDesc.DebugName		= "Shader Handle Storage";
-		shaderHandleStorageDesc.Flags			= BUFFER_FLAG_COPY_SRC;
-		shaderHandleStorageDesc.MemoryType		= EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
-		shaderHandleStorageDesc.SizeInBytes		= shaderHandleStorageSize;
+		if (m_pShaderHandleStorageBuffer == nullptr || shaderHandleStorageSize > m_pShaderHandleStorageBuffer->GetDesc().SizeInBytes)
+		{
+			if (m_pShaderHandleStorageBuffer != nullptr) removedDeviceResources.PushBack(m_pShaderHandleStorageBuffer);
 
-		m_ShaderHandleStorageBuffer = reinterpret_cast<BufferVK*>(m_pDevice->CreateBuffer(&shaderHandleStorageDesc));
+			BufferDesc shaderHandleStorageDesc = {};
+			shaderHandleStorageDesc.DebugName		= "Shader Handle Storage";
+			shaderHandleStorageDesc.Flags			= BUFFER_FLAG_COPY_SRC;
+			shaderHandleStorageDesc.MemoryType		= EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
+			shaderHandleStorageDesc.SizeInBytes		= OVER_ALLOCATION_MULT * shaderHandleStorageSize;
 
-		pMapped = m_ShaderHandleStorageBuffer->Map();
+			m_pShaderHandleStorageBuffer = reinterpret_cast<BufferVK*>(m_pDevice->CreateBuffer(&shaderHandleStorageDesc));
+		}
+
+		pMapped = m_pShaderHandleStorageBuffer->Map();
 		VkResult result = m_pDevice->vkGetRayTracingShaderGroupHandlesKHR(m_pDevice->Device, pRayTracingPipelineVK->GetPipeline(), 0, shaderGroupCount, shaderHandleStorageSize, pMapped);
 		if (result!= VK_SUCCESS)
 		{
@@ -95,41 +140,33 @@ namespace LambdaEngine
 			
 			return false;
 		}
-		m_ShaderHandleStorageBuffer->Unmap();
+		m_pShaderHandleStorageBuffer->Unmap();
 
-		CommandAllocator* pCommandAllocator = m_pDevice->CreateCommandAllocator("Ray Tracing Pipeline SBT Copy", ECommandQueueType::COMMAND_QUEUE_TYPE_COMPUTE);
-		CommandListDesc commandListDesc = {};
-		commandListDesc.DebugName		= "Ray Tracing Pipeline Command List";
-		commandListDesc.CommandListType	= ECommandListType::COMMAND_LIST_TYPE_PRIMARY;
-		commandListDesc.Flags			= FCommandListFlag::COMMAND_LIST_FLAG_ONE_TIME_SUBMIT;
+		if (m_pSBTBuffer == nullptr || sbtSize > m_pSBTBuffer->GetDesc().SizeInBytes)
+		{
+			if (m_pSBTBuffer != nullptr) removedDeviceResources.PushBack(m_pSBTBuffer);
 
-		CommandList* pCommandList = m_pDevice->CreateCommandList(pCommandAllocator, &commandListDesc);
+			BufferDesc sbtDesc = {};
+			sbtDesc.DebugName	= "Shader Binding Table";
+			sbtDesc.Flags		= BUFFER_FLAG_COPY_DST | BUFFER_FLAG_RAY_TRACING;
+			sbtDesc.MemoryType	= EMemoryType::MEMORY_TYPE_GPU;
+			sbtDesc.SizeInBytes	= OVER_ALLOCATION_MULT * sbtSize;
 
-		BufferDesc sbtDesc = {};
-		sbtDesc.DebugName	= "Shader Binding Table";
-		sbtDesc.Flags		= BUFFER_FLAG_COPY_DST | BUFFER_FLAG_RAY_TRACING;
-		sbtDesc.MemoryType	= EMemoryType::MEMORY_TYPE_GPU;
-		sbtDesc.SizeInBytes	= sbtSize;
+			m_pSBTBuffer = reinterpret_cast<BufferVK*>(m_pDevice->CreateBuffer(&sbtDesc));
+		}
 
-		m_SBTBuffer = reinterpret_cast<BufferVK*>(m_pDevice->CreateBuffer(&sbtDesc));
-		pCommandAllocator->Reset();
-
-		pCommandList->Begin(nullptr);
-		pCommandList->CopyBuffer(m_ShaderHandleStorageBuffer.Get(), raygenUnalignedOffset,	m_SBTBuffer.Get(), raygenAlignedOffset,	raygenSize);
+		pCommandList->CopyBuffer(m_pShaderHandleStorageBuffer, raygenUnalignedOffset, m_pSBTBuffer, raygenAlignedOffset,	raygenSize);
 
 		for (VkDeviceSize s = 0; s < m_NumShaderRecords; s++)
 		{
 			VkDeviceSize baseOffset = hitSBTOffset + s * hitSBTStride;
-			pCommandList->CopyBuffer(m_ShaderHandleStorageBuffer.Get(), hitGroupHandleOffset,	m_SBTBuffer.Get(), baseOffset,							shaderGroupHandleSize);
-			pCommandList->CopyBuffer(m_ShaderRecordsBuffer.Get(),		s * sizeof(SBTRecord),	m_SBTBuffer.Get(), baseOffset + shaderGroupHandleSize,	sizeof(SBTRecord));
+			pCommandList->CopyBuffer(m_pShaderHandleStorageBuffer, hitGroupHandleOffset,	m_pSBTBuffer, baseOffset,							shaderGroupHandleSize);
+			pCommandList->CopyBuffer(m_pShaderRecordsBuffer,		s * sizeof(SBTRecord),	m_pSBTBuffer, baseOffset + shaderGroupHandleSize,	sizeof(SBTRecord));
 		}
 
-		pCommandList->CopyBuffer(m_ShaderHandleStorageBuffer.Get(), missGroupHandleOffset,	m_SBTBuffer.Get(), missSBTOffset, missSize);
-		pCommandList->End();
+		pCommandList->CopyBuffer(m_pShaderHandleStorageBuffer, missGroupHandleOffset, m_pSBTBuffer, missSBTOffset, missSize);
 
-		pCommandQueue->ExecuteCommandLists(&pCommandList, 1, FPipelineStageFlag::PIPELINE_STAGE_FLAG_UNKNOWN , nullptr, 0, nullptr, 0);
-
-		VkBuffer sbtBuffer = m_SBTBuffer->GetBuffer();
+		VkBuffer sbtBuffer = m_pSBTBuffer->GetBuffer();
 		m_RaygenBufferRegion.buffer	= sbtBuffer;
 		m_RaygenBufferRegion.offset	= raygenAlignedOffset;
 		m_RaygenBufferRegion.size	= raygenSize;
@@ -145,27 +182,14 @@ namespace LambdaEngine
 		m_MissBufferRegion.size		= missSize;
 		m_MissBufferRegion.stride	= missStride;
 
-		pCommandQueue->Flush();
-		SAFERELEASE(pCommandAllocator);
-		SAFERELEASE(pCommandList);
-
-		if (!pDesc->DebugName.empty())
-		{
-			D_LOG_MESSAGE("[SBTVK]: Created SBT %s", pDesc->DebugName.c_str());
-		}
-		else
-		{
-			D_LOG_MESSAGE("[SBTVK]: Created SBT");
-		}
-
 		return true;
 	}
 
 	void SBTVK::SetName(const String& debugName)
 	{
-		m_pDevice->SetVulkanObjectName((debugName + " Handle Storage"), reinterpret_cast<uint64>(m_ShaderHandleStorageBuffer->GetBuffer()), VK_OBJECT_TYPE_BUFFER);
-		m_pDevice->SetVulkanObjectName((debugName + " SBT Buffer"), reinterpret_cast<uint64>(m_SBTBuffer->GetBuffer()), VK_OBJECT_TYPE_BUFFER);
-		m_pDevice->SetVulkanObjectName((debugName + " Records Buffer"), reinterpret_cast<uint64>(m_ShaderRecordsBuffer->GetBuffer()), VK_OBJECT_TYPE_BUFFER);
+		m_pDevice->SetVulkanObjectName((debugName + " Handle Storage"), reinterpret_cast<uint64>(m_pShaderHandleStorageBuffer->GetBuffer()), VK_OBJECT_TYPE_BUFFER);
+		m_pDevice->SetVulkanObjectName((debugName + " SBT Buffer"), reinterpret_cast<uint64>(m_pSBTBuffer->GetBuffer()), VK_OBJECT_TYPE_BUFFER);
+		m_pDevice->SetVulkanObjectName((debugName + " Records Buffer"), reinterpret_cast<uint64>(m_pShaderRecordsBuffer->GetBuffer()), VK_OBJECT_TYPE_BUFFER);
 		m_DebugName = debugName;
 	}
 }

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -350,7 +350,7 @@ namespace LambdaEngine
 		}
 	}
 
-	void RenderGraph::UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*> removedDeviceResources)
+	void RenderGraph::UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*>& removedDeviceResources)
 	{
 		m_GlobalShaderRecords = shaderRecords;
 

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -350,7 +350,7 @@ namespace LambdaEngine
 		}
 	}
 
-	void RenderGraph::UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords)
+	void RenderGraph::UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*> removedDeviceResources)
 	{
 		m_GlobalShaderRecords = shaderRecords;
 
@@ -360,14 +360,19 @@ namespace LambdaEngine
 
 			if (pRenderStage->pPipelineState != nullptr && pRenderStage->pPipelineState->GetType() == EPipelineStateType::PIPELINE_STATE_TYPE_RAY_TRACING)
 			{
-				m_pDeviceResourcesToDestroy[m_ModFrameIndex].PushBack(pRenderStage->pSBT);
-
 				SBTDesc sbtDesc = {};
 				sbtDesc.DebugName		= "Render Graph Global SBT";
 				sbtDesc.pPipelineState	= pRenderStage->pPipelineState;
 				sbtDesc.SBTRecords		= m_GlobalShaderRecords;
 
-				pRenderStage->pSBT = RenderAPI::GetDevice()->CreateSBT(RenderAPI::GetComputeQueue(), &sbtDesc);
+				if (pRenderStage->pSBT == nullptr)
+				{
+					pRenderStage->pSBT = RenderAPI::GetDevice()->CreateSBT(AcquireComputeCopyCommandList(), &sbtDesc);
+				}
+				else
+				{
+					pRenderStage->pSBT->Build(AcquireComputeCopyCommandList(), removedDeviceResources, &sbtDesc);
+				}
 			}
 		}
 	}
@@ -1268,7 +1273,7 @@ namespace LambdaEngine
 					sbtDesc.pPipelineState = pRenderStage->pPipelineState;
 					sbtDesc.SBTRecords = m_GlobalShaderRecords;
 
-					pRenderStage->pSBT = RenderAPI::GetDevice()->CreateSBT(RenderAPI::GetComputeQueue(), &sbtDesc);
+					pRenderStage->pSBT = RenderAPI::GetDevice()->CreateSBT(AcquireComputeCopyCommandList(), &sbtDesc);
 				}
 			}
 		}


### PR DESCRIPTION
## Purpose
  - Lag spikes that occur when shooting seem  to have multiple causes, this however seems to fix the primary one.
  - Basically, for ray tracing, we use something called a SBT (Shader Binding Table) to access Vertex Data in the Ray Tracing stage. This SBT needs to be rebuilt every time we add/remove an Instance and this rebuilding process was completely terribly implemented before, the rebuild could therefore take 1-6ms in Debug. This fixes that, the rebuild should now take <0.1ms even in Debug.
  - This doesn't completely solve the lag spikes that occur in Debug, but it does help quite alot.