### PR TITLE
Fixed Skipping Lobby State when pressing multiplayer

### DIFF
--- a/CrazyCanvas/Include/ECS/Systems/Player/WeaponSystem.h
+++ b/CrazyCanvas/Include/ECS/Systems/Player/WeaponSystem.h
@@ -8,8 +8,8 @@
 
 #include "Math/Math.h"
 
-#include "Multiplayer/Packet/PlayerAction.h"
-#include "Multiplayer/Packet/PlayerActionResponse.h"
+#include "Multiplayer/Packet/PacketPlayerAction.h"
+#include "Multiplayer/Packet/PacketPlayerActionResponse.h"
 
 namespace LambdaEngine
 {
@@ -79,12 +79,12 @@ private:
 	void TryFire(
 		EAmmoType ammoType,
 		WeaponComponent& weaponComponent,
-		PacketComponent<PlayerAction>& packets,
+		PacketComponent<PacketPlayerAction>& packets,
 		const glm::vec3& startPos,
 		const glm::quat& direction,
 		const glm::vec3& playerVelocity);
 
-	void StartReload(WeaponComponent& weaponComponent, PacketComponent<PlayerAction>& packets);
+	void StartReload(WeaponComponent& weaponComponent, PacketComponent<PacketPlayerAction>& packets);
 	void AbortReload(WeaponComponent& weaponComponent);
 
 	void OnProjectileHit(const LambdaEngine::EntityCollisionInfo& collisionInfo0, const LambdaEngine::EntityCollisionInfo& collisionInfo1);

--- a/CrazyCanvas/Include/Match/MatchClient.h
+++ b/CrazyCanvas/Include/Match/MatchClient.h
@@ -3,7 +3,7 @@
 #include "Match/MatchBase.h"
 
 #include "Multiplayer/Packet/MultiplayerEvents.h"
-#include "Multiplayer/Packet/CreateLevelObject.h"
+#include "Multiplayer/Packet/PacketCreateLevelObject.h"
 #include "Multiplayer/Packet/PacketTeamScored.h"
 #include "Multiplayer/Packet/PacketGameOver.h"
 
@@ -20,7 +20,7 @@ protected:
 	virtual bool OnWeaponFired(const WeaponFiredEvent& event) override final;
 	virtual bool OnPlayerDied(const PlayerDiedEvent& event) override final;
 
-	bool OnPacketCreateLevelObjectReceived(const PacketReceivedEvent<CreateLevelObject>& event);
+	bool OnPacketCreateLevelObjectReceived(const PacketReceivedEvent<PacketCreateLevelObject>& event);
 	bool OnPacketTeamScoredReceived(const PacketReceivedEvent<PacketTeamScored>& event);
 	bool OnPacketGameOverReceived(const PacketReceivedEvent<PacketGameOver>& event);
 };

--- a/CrazyCanvas/Include/Multiplayer/Packet/PacketConfigureServer.h
+++ b/CrazyCanvas/Include/Multiplayer/Packet/PacketConfigureServer.h
@@ -3,12 +3,12 @@
 #include "Multiplayer/Packet/Packet.h"
 
 #pragma pack(push, 1)
-struct PacketHostServer
+struct PacketConfigureServer
 {
-	DECL_PACKET(PacketHostServer);
+	DECL_PACKET(PacketConfigureServer);
 
-	int8 PlayersNumber = -1;
-	int8 MapNumber = -1;
 	int32 AuthenticationID = -1;
+	uint8 Players = 0;
+	uint8 MapID = 0;
 };
 #pragma pack(pop)

--- a/CrazyCanvas/Include/Multiplayer/Packet/PacketCreateLevelObject.h
+++ b/CrazyCanvas/Include/Multiplayer/Packet/PacketCreateLevelObject.h
@@ -24,9 +24,9 @@ namespace Obj
 }
 
 #pragma pack(push, 1)
-struct CreateLevelObject
+struct PacketCreateLevelObject
 {
-	DECL_PACKET(CreateLevelObject);
+	DECL_PACKET(PacketCreateLevelObject);
 
 	ELevelObjectType LevelObjectType;
 	int32 NetworkUID;

--- a/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerAction.h
+++ b/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerAction.h
@@ -6,9 +6,9 @@
 #include "ECS/Components/Player/ProjectileComponent.h"
 
 #pragma pack(push, 1)
-struct PlayerAction : Packet
+struct PacketPlayerAction : Packet
 {
-	DECL_PACKET(PlayerAction);
+	DECL_PACKET(PacketPlayerAction);
 
 	glm::quat Rotation;
 	int8 DeltaForward	= 0;

--- a/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerActionResponse.h
+++ b/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerActionResponse.h
@@ -6,9 +6,9 @@
 #include "ECS/Components/Player/ProjectileComponent.h"
 
 #pragma pack(push, 1)
-struct PlayerActionResponse : Packet
+struct PacketPlayerActionResponse : Packet
 {
-	DECL_PACKET(PlayerActionResponse);
+	DECL_PACKET(PacketPlayerActionResponse);
 
 	glm::vec3 Position;
 	glm::vec3 Velocity;

--- a/CrazyCanvas/Include/Multiplayer/Packet/PacketType.h
+++ b/CrazyCanvas/Include/Multiplayer/Packet/PacketType.h
@@ -27,7 +27,7 @@ public:
 	static uint16 FLAG_EDITED;
 	static uint16 TEAM_SCORED;
 	static uint16 GAME_OVER;
-	static uint16 HOST_SERVER;
+	static uint16 CONFIGURE_SERVER;
 
 public:
 	static IPacketReceivedEvent* GetPacketReceivedEventPointer(uint16 packetType);

--- a/CrazyCanvas/Include/Multiplayer/ServerHelper.h
+++ b/CrazyCanvas/Include/Multiplayer/ServerHelper.h
@@ -15,6 +15,9 @@ public:
 
 	template<class T>
 	static bool SendBroadcast(const T& packet, LambdaEngine::IPacketListener* pListener = nullptr, LambdaEngine::IClient* pExcludeClient = nullptr);
+
+	static void SetMaxClients(uint8 clients);
+	static void SetIgnoreNewClients(bool ignore);
 };
 
 template<class T>

--- a/CrazyCanvas/Include/Multiplayer/ServerHostHelper.h
+++ b/CrazyCanvas/Include/Multiplayer/ServerHostHelper.h
@@ -4,8 +4,9 @@
 
 class ServerHostHelper
 {
-public:
+	friend class CrazyCanvas;
 
+public:
 	static void SetClientHostID(int32 serverHostID);
 	static void SetAuthenticationID(int32 clientHostID);
 
@@ -13,6 +14,9 @@ public:
 	static int32 GetAuthenticationHostID();
 
 private:
-	static int32 m_sClientHostID;
-	static int32 m_sAuthenticationID;
+	static void Init();
+
+private:
+	static int32 s_ClientHostID;
+	static int32 s_AuthenticationID;
 };

--- a/CrazyCanvas/Include/States/ServerState.h
+++ b/CrazyCanvas/Include/States/ServerState.h
@@ -10,7 +10,7 @@
 
 #include "Multiplayer/MultiplayerServer.h"
 #include "Multiplayer/Packet/MultiplayerEvents.h"
-#include "Multiplayer/Packet/PacketHostServer.h"
+#include "Multiplayer/Packet/PacketConfigureServer.h"
 
 class Level;
 
@@ -18,7 +18,6 @@ class ServerState :
 	public LambdaEngine::State
 {
 public:
-	ServerState();
 	ServerState(const std::string& clientHostID, const std::string& authenticationID);
 	
 	~ServerState();
@@ -31,7 +30,7 @@ public:
 	void Tick(LambdaEngine::Timestamp delta) override final;
 	void FixedTick(LambdaEngine::Timestamp delta) override final;
 
-	bool OnPacketHostServerReceived(const PacketReceivedEvent<PacketHostServer>& event);
+	bool OnPacketConfigureServerReceived(const PacketReceivedEvent<PacketConfigureServer>& event);
 
 	bool OnKeyPressed(const LambdaEngine::KeyPressedEvent& event);
 

--- a/CrazyCanvas/Include/World/Player/Client/PlayerLocalSystem.h
+++ b/CrazyCanvas/Include/World/Player/Client/PlayerLocalSystem.h
@@ -7,7 +7,7 @@
 
 #include "World/Player/PlayerGameState.h"
 
-#include "Multiplayer/Packet/PlayerActionResponse.h"
+#include "Multiplayer/Packet/PacketPlayerActionResponse.h"
 
 class PlayerLocalSystem : public LambdaEngine::System
 {
@@ -33,8 +33,8 @@ private:
 
 	void SendGameState(const PlayerGameState& gameState, LambdaEngine::Entity entityPlayer);
 	void Reconcile(LambdaEngine::Entity entityPlayer);
-	void ReplayGameStatesBasedOnServerGameState(LambdaEngine::Entity entityPlayer, PlayerGameState* pGameStates, uint32 count, const PlayerActionResponse& gameStateServer);
-	bool CompareGameStates(const PlayerGameState& gameStateLocal, const PlayerActionResponse& gameStateServer);
+	void ReplayGameStatesBasedOnServerGameState(LambdaEngine::Entity entityPlayer, PlayerGameState* pGameStates, uint32 count, const PacketPlayerActionResponse& gameStateServer);
+	bool CompareGameStates(const PlayerGameState& gameStateLocal, const PacketPlayerActionResponse& gameStateServer);
 
 private:
 	LambdaEngine::IDVector m_Entities;

--- a/CrazyCanvas/Include/World/Player/Server/PlayerRemoteSystem.h
+++ b/CrazyCanvas/Include/World/Player/Server/PlayerRemoteSystem.h
@@ -5,7 +5,7 @@
 
 #include "ECS/Components/Multiplayer/PacketComponent.h"
 
-#include "Multiplayer/Packet/PlayerAction.h"
+#include "Multiplayer/Packet/PacketPlayerAction.h"
 
 class PlayerRemoteSystem : public LambdaEngine::System
 {
@@ -22,5 +22,5 @@ private:
 
 private:
 	LambdaEngine::IDVector m_Entities;
-	LambdaEngine::THashTable<LambdaEngine::Entity, PlayerAction> m_CurrentGameStates;
+	LambdaEngine::THashTable<LambdaEngine::Entity, PacketPlayerAction> m_CurrentGameStates;
 };

--- a/CrazyCanvas/Source/CrazyCanvas.cpp
+++ b/CrazyCanvas/Source/CrazyCanvas.cpp
@@ -19,10 +19,10 @@
 
 #include "Teams/TeamHelper.h"
 
+#include "Multiplayer/ServerHostHelper.h"
+
 #include "Game/Multiplayer/Client/ClientSystem.h"
 #include "Game/Multiplayer/Server/ServerSystem.h"
-
-
 
 #include <rapidjson/document.h>
 #include <rapidjson/filewritestream.h>
@@ -35,6 +35,8 @@ constexpr const uint32 NUM_BLUE_NOISE_LUTS = 128;
 CrazyCanvas::CrazyCanvas(const argh::parser& flagParser)
 {
 	using namespace LambdaEngine;
+
+	ServerHostHelper::Init();
 
 	GraphicsDeviceFeatureDesc deviceFeatures = {};
 	RenderAPI::GetDevice()->QueryDeviceFeatures(&deviceFeatures);
@@ -56,7 +58,7 @@ CrazyCanvas::CrazyCanvas(const argh::parser& flagParser)
 
 	constexpr const char* pGameName = "Crazy Canvas";
 	constexpr const char* pDefaultStateStr = "crazycanvas";
-	constexpr const char* pDefaultIsHostStr = "-1";
+	constexpr const char* pDefaultIsHostStr = "";
 	State* pStartingState = nullptr;
 	String stateStr;
 

--- a/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
@@ -81,7 +81,7 @@ bool WeaponSystem::Init()
 				.ComponentAccesses =
 				{
 					{ NDA, PlayerForeignComponent::Type() },
-					{ RW, PacketComponent<PlayerActionResponse>::Type() }
+					{ RW, PacketComponent<PacketPlayerActionResponse>::Type() }
 				}
 			},
 			{
@@ -89,7 +89,7 @@ bool WeaponSystem::Init()
 				.ComponentAccesses =
 				{
 					{ NDA, PlayerLocalComponent::Type() },
-					{ RW, PacketComponent<PlayerAction>::Type() }
+					{ RW, PacketComponent<PacketPlayerAction>::Type() }
 				},
 				.ComponentGroups = { &playerGroup }
 			},
@@ -98,8 +98,8 @@ bool WeaponSystem::Init()
 				.ComponentAccesses =
 				{
 					{ NDA, PlayerBaseComponent::Type() },
-					{ R, PacketComponent<PlayerAction>::Type() },
-					{ RW, PacketComponent<PlayerActionResponse>::Type() },
+					{ R, PacketComponent<PacketPlayerAction>::Type() },
+					{ RW, PacketComponent<PacketPlayerActionResponse>::Type() },
 				},
 				.ComponentGroups = { &playerGroup }
 			}
@@ -172,8 +172,8 @@ void WeaponSystem::FixedTick(LambdaEngine::Timestamp deltaTime)
 	const float32 dt = (float32)deltaTime.AsSeconds();
 
 	ECSCore* pECS = ECSCore::GetInstance();
-	ComponentArray<PacketComponent<PlayerAction>>* pPlayerActionPackets = pECS->GetComponentArray<PacketComponent<PlayerAction>>();
-	ComponentArray<PacketComponent<PlayerActionResponse>>* pPlayerResponsePackets = pECS->GetComponentArray<PacketComponent<PlayerActionResponse>>();
+	ComponentArray<PacketComponent<PacketPlayerAction>>* pPlayerActionPackets = pECS->GetComponentArray<PacketComponent<PacketPlayerAction>>();
+	ComponentArray<PacketComponent<PacketPlayerActionResponse>>* pPlayerResponsePackets = pECS->GetComponentArray<PacketComponent<PacketPlayerActionResponse>>();
 	ComponentArray<WeaponComponent>* pWeaponComponents = pECS->GetComponentArray<WeaponComponent>();
 	ComponentArray<PositionComponent>* pPositionComponents = pECS->GetComponentArray<PositionComponent>();
 	ComponentArray<RotationComponent>* pRotationComponents = pECS->GetComponentArray<RotationComponent>();
@@ -208,10 +208,10 @@ void WeaponSystem::FixedTick(LambdaEngine::Timestamp deltaTime)
 				}
 			}
 
-			PacketComponent<PlayerAction>& actionsRecived = pPlayerActionPackets->GetData(remotePlayerEntity);
-			PacketComponent<PlayerActionResponse>& responsesToSend = pPlayerResponsePackets->GetData(remotePlayerEntity);
-			TQueue<PlayerActionResponse>& packetsToSend = responsesToSend.GetPacketsToSend();
-			const TArray<PlayerAction>& packetsRecived	= actionsRecived.GetPacketsReceived();
+			PacketComponent<PacketPlayerAction>& actionsRecived = pPlayerActionPackets->GetData(remotePlayerEntity);
+			PacketComponent<PacketPlayerActionResponse>& responsesToSend = pPlayerResponsePackets->GetData(remotePlayerEntity);
+			TQueue<PacketPlayerActionResponse>& packetsToSend = responsesToSend.GetPacketsToSend();
+			const TArray<PacketPlayerAction>& packetsRecived	= actionsRecived.GetPacketsReceived();
 
 			// Handle packets
 			const uint32 packetCount = packetsRecived.GetSize();
@@ -274,9 +274,9 @@ void WeaponSystem::FixedTick(LambdaEngine::Timestamp deltaTime)
 			// Foreign Players
 			if (!m_LocalPlayerEntities.HasElement(playerEntity))
 			{
-				PacketComponent<PlayerActionResponse>& packets = pPlayerResponsePackets->GetData(playerEntity);
-				const TArray<PlayerActionResponse>& receivedPackets = packets.GetPacketsReceived();
-				for (const PlayerActionResponse& response : receivedPackets)
+				PacketComponent<PacketPlayerActionResponse>& packets = pPlayerResponsePackets->GetData(playerEntity);
+				const TArray<PacketPlayerActionResponse>& receivedPackets = packets.GetPacketsReceived();
+				for (const PacketPlayerActionResponse& response : receivedPackets)
 				{
 					if (response.FiredAmmo != EAmmoType::AMMO_TYPE_NONE)
 					{
@@ -298,7 +298,7 @@ void WeaponSystem::FixedTick(LambdaEngine::Timestamp deltaTime)
 			}
 
 			// LocalPlayers
-			PacketComponent<PlayerAction>& playerActions = pPlayerActionPackets->GetData(playerEntity);
+			PacketComponent<PacketPlayerAction>& playerActions = pPlayerActionPackets->GetData(playerEntity);
 			const bool hasAmmo		= weaponComponent.CurrentAmmunition > 0;
 			const bool isReloading	= weaponComponent.ReloadClock > 0.0f;
 			if (!hasAmmo && !isReloading)
@@ -432,7 +432,7 @@ void WeaponSystem::Fire(
 void WeaponSystem::TryFire(
 	EAmmoType ammoType,
 	WeaponComponent& weaponComponent,
-	PacketComponent<PlayerAction>& packets,
+	PacketComponent<PacketPlayerAction>& packets,
 	const glm::vec3& startPos,
 	const glm::quat& direction,
 	const glm::vec3& playerVelocity)
@@ -456,7 +456,7 @@ void WeaponSystem::TryFire(
 		weaponComponent.CurrentAmmunition--;
 
 		// Send action to server
-		TQueue<PlayerAction>& actions = packets.GetPacketsToSend();
+		TQueue<PacketPlayerAction>& actions = packets.GetPacketsToSend();
 		if (!actions.empty())
 		{
 			actions.back().FiredAmmo = ammoType;
@@ -569,12 +569,12 @@ void WeaponSystem::OnProjectileHit(const LambdaEngine::EntityCollisionInfo& coll
 	}
 }
 
-void WeaponSystem::StartReload(WeaponComponent& weaponComponent, PacketComponent<PlayerAction>& packets)
+void WeaponSystem::StartReload(WeaponComponent& weaponComponent, PacketComponent<PacketPlayerAction>& packets)
 {
 	using namespace LambdaEngine;
 
 	// Send action to server
-	TQueue<PlayerAction>& actions = packets.GetPacketsToSend();
+	TQueue<PacketPlayerAction>& actions = packets.GetPacketsToSend();
 	if (!actions.empty())
 	{
 		actions.back().StartedReload = true;

--- a/CrazyCanvas/Source/GUI/LobbyGUI.cpp
+++ b/CrazyCanvas/Source/GUI/LobbyGUI.cpp
@@ -137,10 +137,10 @@ bool LobbyGUI::OnClientConnected(const LambdaEngine::ClientConnectedEvent& event
 {
 	if (m_HasHostedServer)
 	{
-		PacketHostServer packet;
-		packet.AuthenticationID = ServerHostHelper::GetAuthenticationHostID();
-		packet.MapNumber = m_HostGameDesc.MapNumber;
-		packet.PlayersNumber = m_HostGameDesc.PlayersNumber;
+		PacketConfigureServer packet;
+		packet.AuthenticationID	= ServerHostHelper::GetAuthenticationHostID();
+		packet.MapID			= m_HostGameDesc.MapNumber;
+		packet.Players			= m_HostGameDesc.PlayersNumber;
 
 		ClientHelper::Send(packet);
 	}

--- a/CrazyCanvas/Source/GUI/LobbyGUI.cpp
+++ b/CrazyCanvas/Source/GUI/LobbyGUI.cpp
@@ -135,7 +135,7 @@ bool LobbyGUI::OnLANServerFound(const LambdaEngine::ServerDiscoveredEvent& event
 
 bool LobbyGUI::OnClientConnected(const LambdaEngine::ClientConnectedEvent& event)
 {
-	if (ServerHostHelper::GetAuthenticationHostID() != -1)
+	if (m_HasHostedServer)
 	{
 		PacketHostServer packet;
 		packet.AuthenticationID = ServerHostHelper::GetAuthenticationHostID();

--- a/CrazyCanvas/Source/Match/MatchClient.cpp
+++ b/CrazyCanvas/Source/Match/MatchClient.cpp
@@ -26,14 +26,14 @@ using namespace LambdaEngine;
 
 MatchClient::~MatchClient()
 {
-	EventQueue::UnregisterEventHandler<PacketReceivedEvent<CreateLevelObject>>(this, &MatchClient::OnPacketCreateLevelObjectReceived);
+	EventQueue::UnregisterEventHandler<PacketReceivedEvent<PacketCreateLevelObject>>(this, &MatchClient::OnPacketCreateLevelObjectReceived);
 	EventQueue::UnregisterEventHandler<PacketReceivedEvent<PacketTeamScored>>(this, &MatchClient::OnPacketTeamScoredReceived);
 	EventQueue::UnregisterEventHandler<PacketReceivedEvent<PacketGameOver>>(this, &MatchClient::OnPacketGameOverReceived);
 }
 
 bool MatchClient::InitInternal()
 {
-	EventQueue::RegisterEventHandler<PacketReceivedEvent<CreateLevelObject>>(this, &MatchClient::OnPacketCreateLevelObjectReceived);
+	EventQueue::RegisterEventHandler<PacketReceivedEvent<PacketCreateLevelObject>>(this, &MatchClient::OnPacketCreateLevelObjectReceived);
 	EventQueue::RegisterEventHandler<PacketReceivedEvent<PacketTeamScored>>(this, &MatchClient::OnPacketTeamScoredReceived);
 	EventQueue::RegisterEventHandler<PacketReceivedEvent<PacketGameOver>>(this, &MatchClient::OnPacketGameOverReceived);
 	return true;
@@ -44,9 +44,9 @@ void MatchClient::TickInternal(LambdaEngine::Timestamp deltaTime)
 	UNREFERENCED_VARIABLE(deltaTime);
 }
 
-bool MatchClient::OnPacketCreateLevelObjectReceived(const PacketReceivedEvent<CreateLevelObject>& event)
+bool MatchClient::OnPacketCreateLevelObjectReceived(const PacketReceivedEvent<PacketCreateLevelObject>& event)
 {
-	const CreateLevelObject& packet = event.Packet;
+	const PacketCreateLevelObject& packet = event.Packet;
 	IClient* pClient = event.pClient;
 
 	switch (packet.LevelObjectType)

--- a/CrazyCanvas/Source/Match/MatchServer.cpp
+++ b/CrazyCanvas/Source/Match/MatchServer.cpp
@@ -31,7 +31,7 @@
 
 #include "Rendering/ImGuiRenderer.h"
 
-#include "Multiplayer/Packet/CreateLevelObject.h"
+#include "Multiplayer/Packet/PacketCreateLevelObject.h"
 
 #include "Multiplayer/ServerHelper.h"
 #include "Multiplayer/Packet/PacketTeamScored.h"
@@ -142,7 +142,7 @@ void MatchServer::SpawnFlag()
 		{
 			VALIDATE(createdFlagEntities.GetSize() == 1);
 
-			CreateLevelObject packet;
+			PacketCreateLevelObject packet;
 			packet.LevelObjectType			= ELevelObjectType::LEVEL_OBJECT_TYPE_FLAG;
 			packet.Position					= createDesc.Position;
 			packet.Forward					= GetForward(createDesc.Rotation);
@@ -238,7 +238,7 @@ void MatchServer::SpawnPlayer(LambdaEngine::ClientRemoteBase* pClient)
 	{
 		VALIDATE(createdPlayerEntities.GetSize() == 1);
 
-		CreateLevelObject packet;
+		PacketCreateLevelObject packet;
 		packet.LevelObjectType	= ELevelObjectType::LEVEL_OBJECT_TYPE_PLAYER;
 		packet.Position			= position;
 		packet.Forward			= forward;
@@ -285,7 +285,7 @@ bool MatchServer::OnClientConnected(const LambdaEngine::ClientConnectedEvent& ev
 		uint32 otherPlayerCount = 0;
 		Entity* pOtherPlayerEntities = m_pLevel->GetEntities(ELevelObjectType::LEVEL_OBJECT_TYPE_PLAYER, otherPlayerCount);
 
-		CreateLevelObject packet;
+		PacketCreateLevelObject packet;
 		packet.LevelObjectType	= ELevelObjectType::LEVEL_OBJECT_TYPE_PLAYER;
 		packet.Player.IsMySelf	= false;
 
@@ -316,7 +316,7 @@ bool MatchServer::OnClientConnected(const LambdaEngine::ClientConnectedEvent& ev
 		uint32 flagCount = 0;
 		Entity* pFlagEntities = m_pLevel->GetEntities(ELevelObjectType::LEVEL_OBJECT_TYPE_FLAG, flagCount);
 
-		CreateLevelObject packet;
+		PacketCreateLevelObject packet;
 		packet.LevelObjectType = ELevelObjectType::LEVEL_OBJECT_TYPE_FLAG;
 
 		for (uint32 i = 0; i < flagCount; i++)

--- a/CrazyCanvas/Source/Multiplayer/PacketType.cpp
+++ b/CrazyCanvas/Source/Multiplayer/PacketType.cpp
@@ -3,12 +3,12 @@
 #include "ECS/Components/Multiplayer/PacketComponent.h"
 #include "ECS/Components/Match/FlagComponent.h"
 
-#include "Multiplayer/Packet/PlayerAction.h"
-#include "Multiplayer/Packet/PlayerActionResponse.h"
-#include "Multiplayer/Packet/CreateLevelObject.h"
+#include "Multiplayer/Packet/PacketPlayerAction.h"
+#include "Multiplayer/Packet/PacketPlayerActionResponse.h"
+#include "Multiplayer/Packet/PacketCreateLevelObject.h"
 #include "Multiplayer/Packet/PacketTeamScored.h"
 #include "Multiplayer/Packet/PacketGameOver.h"
-#include "Multiplayer/Packet/PacketHostServer.h"
+#include "Multiplayer/Packet/PacketConfigureServer.h"
 
 #include "ECS/Components/Player/WeaponComponent.h"
 #include "ECS/Components/Player/HealthComponent.h"
@@ -25,20 +25,20 @@ uint16 PacketType::HEALTH_CHANGED			= 0;
 uint16 PacketType::FLAG_EDITED				= 0;
 uint16 PacketType::TEAM_SCORED				= 0;
 uint16 PacketType::GAME_OVER				= 0;
-uint16 PacketType::HOST_SERVER				= 0;
+uint16 PacketType::CONFIGURE_SERVER			= 0;
 
 void PacketType::Init()
 {
-	CREATE_LEVEL_OBJECT		= RegisterPacketType<CreateLevelObject>();
+	CREATE_LEVEL_OBJECT		= RegisterPacketType<PacketCreateLevelObject>();
 	DELETE_LEVEL_OBJECT		= RegisterPacketTypeRaw();
-	PLAYER_ACTION			= RegisterPacketTypeWithComponent<PlayerAction>();
-	PLAYER_ACTION_RESPONSE	= RegisterPacketTypeWithComponent<PlayerActionResponse>();
+	PLAYER_ACTION			= RegisterPacketTypeWithComponent<PacketPlayerAction>();
+	PLAYER_ACTION_RESPONSE	= RegisterPacketTypeWithComponent<PacketPlayerActionResponse>();
 	WEAPON_FIRE				= RegisterPacketTypeWithComponent<WeaponFiredPacket>();
 	HEALTH_CHANGED			= RegisterPacketTypeWithComponent<HealthChangedPacket>();
 	FLAG_EDITED				= RegisterPacketTypeWithComponent<FlagEditedPacket>();
 	TEAM_SCORED				= RegisterPacketType<PacketTeamScored>();
 	GAME_OVER				= RegisterPacketType<PacketGameOver>();
-	HOST_SERVER				= RegisterPacketType<PacketHostServer>();
+	CONFIGURE_SERVER		= RegisterPacketType<PacketConfigureServer>();
 }
 
 uint16 PacketType::RegisterPacketTypeRaw()

--- a/CrazyCanvas/Source/Multiplayer/ServerHelper.cpp
+++ b/CrazyCanvas/Source/Multiplayer/ServerHelper.cpp
@@ -1,0 +1,13 @@
+#include "Multiplayer/ServerHelper.h"
+
+using namespace LambdaEngine;
+
+void ServerHelper::SetMaxClients(uint8 clients)
+{
+	ServerSystem::GetInstance().GetServer()->SetMaxClients(clients);
+}
+
+void ServerHelper::SetIgnoreNewClients(bool ignore)
+{
+	ServerSystem::GetInstance().GetServer()->SetAcceptingConnections(!ignore);
+}

--- a/CrazyCanvas/Source/Multiplayer/ServerHostHelper.cpp
+++ b/CrazyCanvas/Source/Multiplayer/ServerHostHelper.cpp
@@ -1,8 +1,11 @@
 #include "Multiplayer/ServerHostHelper.h"
 
+#include "Math/Random.h"
 
-int32 ServerHostHelper::m_sClientHostID = -1;
-int32 ServerHostHelper::m_sAuthenticationID = -1;
+using namespace LambdaEngine;
+
+int32 ServerHostHelper::m_sClientHostID = Random::Int32();
+int32 ServerHostHelper::m_sAuthenticationID = Random::Int32();
 
 void ServerHostHelper::SetClientHostID(int32 serverHostID)
 {

--- a/CrazyCanvas/Source/Multiplayer/ServerHostHelper.cpp
+++ b/CrazyCanvas/Source/Multiplayer/ServerHostHelper.cpp
@@ -4,25 +4,31 @@
 
 using namespace LambdaEngine;
 
-int32 ServerHostHelper::m_sClientHostID = Random::Int32();
-int32 ServerHostHelper::m_sAuthenticationID = Random::Int32();
+int32 ServerHostHelper::s_ClientHostID = -1;
+int32 ServerHostHelper::s_AuthenticationID = -1;
 
 void ServerHostHelper::SetClientHostID(int32 serverHostID)
 {
-	m_sClientHostID = serverHostID;
+	s_ClientHostID = serverHostID;
 }
 
 void ServerHostHelper::SetAuthenticationID(int32 clientHostID)
 {
-	m_sAuthenticationID = clientHostID;
+	s_AuthenticationID = clientHostID;
 }
 
 int32 ServerHostHelper::GetClientHostID()
 {
-	return m_sClientHostID;
+	return s_ClientHostID;
 }
 
 int32 ServerHostHelper::GetAuthenticationHostID()
 {
-	return m_sAuthenticationID;
+	return s_AuthenticationID;
+}
+
+void ServerHostHelper::Init()
+{
+	s_ClientHostID = Random::Int32();
+	s_AuthenticationID = Random::Int32();
 }

--- a/CrazyCanvas/Source/Multiplayer/SingleplayerInitializer.cpp
+++ b/CrazyCanvas/Source/Multiplayer/SingleplayerInitializer.cpp
@@ -3,7 +3,7 @@
 #include "Game/Multiplayer/MultiplayerUtils.h"
 #include "Game/Multiplayer/Client/ClientSystem.h"
 
-#include "Multiplayer/Packet/CreateLevelObject.h"
+#include "Multiplayer/Packet/PacketCreateLevelObject.h"
 
 #include "Multiplayer/Packet/PacketType.h"
 
@@ -17,7 +17,7 @@ namespace LambdaEngine
 	{
 		using namespace LambdaEngine;
 
-		CreateLevelObject packet;
+		PacketCreateLevelObject packet;
 		packet.LevelObjectType = ELevelObjectType::LEVEL_OBJECT_TYPE_PLAYER;
 		packet.Position = glm::vec3(0.0f, 2.0f, 0.0f);
 		packet.Forward = glm::vec3(1.0f, 0.0f, 0.0f);

--- a/CrazyCanvas/Source/States/BenchmarkState.cpp
+++ b/CrazyCanvas/Source/States/BenchmarkState.cpp
@@ -38,7 +38,7 @@
 #include "World/LevelManager.h"
 #include "World/Level.h"
 
-#include "Multiplayer/Packet/CreateLevelObject.h"
+#include "Multiplayer/Packet/PacketCreateLevelObject.h"
 #include "Multiplayer/Packet/PacketType.h"
 #include "Multiplayer/SingleplayerInitializer.h"
 
@@ -270,7 +270,7 @@ bool BenchmarkState::OnPacketReceived(const LambdaEngine::NetworkSegmentReceived
 
 	if (event.Type == PacketType::CREATE_LEVEL_OBJECT)
 	{
-		CreateLevelObject packet;
+		PacketCreateLevelObject packet;
 		event.pPacket->Read(&packet);
 
 		// Create player characters that a benchmark system controls

--- a/CrazyCanvas/Source/States/ServerState.cpp
+++ b/CrazyCanvas/Source/States/ServerState.cpp
@@ -35,6 +35,9 @@
 
 #include "ECS/Systems/Match/ServerFlagSystem.h"
 
+#include <windows.h>
+#include <Lmcons.h>
+
 using namespace LambdaEngine;
 
 ServerState::ServerState(const std::string& clientHostID, const std::string& authenticationID) :
@@ -47,7 +50,9 @@ ServerState::ServerState(const std::string& clientHostID, const std::string& aut
 ServerState::ServerState() : 
 	m_MultiplayerServer()
 {
-
+	m_ServerName.reserve(UNLEN + 1);
+	DWORD length = m_ServerName.capacity();
+	GetUserNameA(m_ServerName.data(), &length);
 }
 
 ServerState::~ServerState()
@@ -69,7 +74,6 @@ void ServerState::Init()
 
 	m_MultiplayerServer.InitInternal();
 
-	m_ServerName = "Crazy Canvas Server";
 
 	// Load Match
 	{

--- a/CrazyCanvas/Source/World/LevelObjectCreator.cpp
+++ b/CrazyCanvas/Source/World/LevelObjectCreator.cpp
@@ -42,8 +42,8 @@
 #include "Rendering/EntityMaskManager.h"
 
 #include "Multiplayer/Packet/PacketType.h"
-#include "Multiplayer/Packet/PlayerAction.h"
-#include "Multiplayer/Packet/PlayerActionResponse.h"
+#include "Multiplayer/Packet/PacketPlayerAction.h"
+#include "Multiplayer/Packet/PacketPlayerActionResponse.h"
 
 #include "Physics/CollisionGroups.h"
 
@@ -599,8 +599,8 @@ bool LevelObjectCreator::CreatePlayer(
 	pECS->AddComponent<ScaleComponent>(playerEntity,			ScaleComponent{ .Scale = pPlayerDesc->Scale });
 	pECS->AddComponent<VelocityComponent>(playerEntity,			VelocityComponent());
 	pECS->AddComponent<TeamComponent>(playerEntity,				TeamComponent{ .TeamIndex = pPlayerDesc->TeamIndex });
-	pECS->AddComponent<PacketComponent<PlayerAction>>(playerEntity, { });
-	pECS->AddComponent<PacketComponent<PlayerActionResponse>>(playerEntity, { });
+	pECS->AddComponent<PacketComponent<PacketPlayerAction>>(playerEntity, { });
+	pECS->AddComponent<PacketComponent<PacketPlayerActionResponse>>(playerEntity, { });
 	
 	const CharacterColliderCreateInfo colliderInfo =
 	{

--- a/CrazyCanvas/Source/World/Player/Client/PlayerForeignSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/Client/PlayerForeignSystem.cpp
@@ -10,7 +10,7 @@
 
 #include "ECS/Components/Multiplayer/PacketComponent.h"
 
-#include "Multiplayer/Packet/PlayerActionResponse.h"
+#include "Multiplayer/Packet/PacketPlayerActionResponse.h"
 
 using namespace LambdaEngine;
 
@@ -37,7 +37,7 @@ void PlayerForeignSystem::Init()
 				{R , PositionComponent::Type()},
 				{RW, VelocityComponent::Type()},
 				{RW, RotationComponent::Type()},
-				{R, PacketComponent<PlayerActionResponse>::Type()},
+				{R, PacketComponent<PacketPlayerActionResponse>::Type()},
 			}
 		}
 	};
@@ -56,20 +56,20 @@ void PlayerForeignSystem::FixedTickMainThread(LambdaEngine::Timestamp deltaTime)
 	ComponentArray<VelocityComponent>* pVelocityComponents = pECS->GetComponentArray<VelocityComponent>();
 	const ComponentArray<PositionComponent>* pPositionComponents = pECS->GetComponentArray<PositionComponent>();
 	ComponentArray<RotationComponent>* pRotationComponents = pECS->GetComponentArray<RotationComponent>();
-	const ComponentArray<PacketComponent<PlayerActionResponse>>* pPacketComponents = pECS->GetComponentArray<PacketComponent<PlayerActionResponse>>();
+	const ComponentArray<PacketComponent<PacketPlayerActionResponse>>* pPacketComponents = pECS->GetComponentArray<PacketComponent<PacketPlayerActionResponse>>();
 
 	for (Entity entity : m_Entities)
 	{
 		const NetworkPositionComponent& constNetPosComponent = pNetPosComponents->GetConstData(entity);
 		const PositionComponent& positionComponent = pPositionComponents->GetConstData(entity);
 		VelocityComponent& velocityComponent = pVelocityComponents->GetData(entity);
-		const PacketComponent<PlayerActionResponse>& packetComponent = pPacketComponents->GetConstData(entity);
+		const PacketComponent<PacketPlayerActionResponse>& packetComponent = pPacketComponents->GetConstData(entity);
 
-		const TArray<PlayerActionResponse>& gameStates = packetComponent.GetPacketsReceived();
+		const TArray<PacketPlayerActionResponse>& gameStates = packetComponent.GetPacketsReceived();
 
 		if (!gameStates.IsEmpty())
 		{
-			for (const PlayerActionResponse& gameState : gameStates)
+			for (const PacketPlayerActionResponse& gameState : gameStates)
 			{
 				const RotationComponent& constRotationComponent = pRotationComponents->GetConstData(entity);
 

--- a/CrazyCanvas/Source/World/Player/Client/PlayerLocalSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/Client/PlayerLocalSystem.cpp
@@ -26,7 +26,7 @@
 #include "Input/API/InputActionSystem.h"
 
 #include "Multiplayer/Packet/PacketType.h"
-#include "Multiplayer/Packet/PlayerAction.h"
+#include "Multiplayer/Packet/PacketPlayerAction.h"
 
 #define EPSILON 0.01f
 
@@ -55,8 +55,8 @@ void PlayerLocalSystem::Init()
 				{R , PositionComponent::Type()},
 				{RW, VelocityComponent::Type()},
 				{RW, RotationComponent::Type()},
-				{RW, PacketComponent<PlayerAction>::Type()},
-				{R, PacketComponent<PlayerActionResponse>::Type()},
+				{RW, PacketComponent<PacketPlayerAction>::Type()},
+				{R, PacketComponent<PacketPlayerActionResponse>::Type()},
 			}
 		}
 	};
@@ -96,9 +96,9 @@ void PlayerLocalSystem::FixedTickMainThread(Timestamp deltaTime)
 void PlayerLocalSystem::SendGameState(const PlayerGameState& gameState, Entity entityPlayer)
 {
 	ECSCore* pECS = ECSCore::GetInstance();
-	PacketComponent<PlayerAction>& pPacketComponent = pECS->GetComponent<PacketComponent<PlayerAction>>(entityPlayer);
+	PacketComponent<PacketPlayerAction>& pPacketComponent = pECS->GetComponent<PacketComponent<PacketPlayerAction>>(entityPlayer);
 
-	PlayerAction packet		= {};
+	PacketPlayerAction packet		= {};
 	packet.SimulationTick	= gameState.SimulationTick;
 	packet.Rotation			= gameState.Rotation;
 	packet.DeltaForward		= gameState.DeltaForward;
@@ -163,8 +163,8 @@ void PlayerLocalSystem::DoAction(Timestamp deltaTime, Entity entityPlayer, Playe
 void PlayerLocalSystem::Reconcile(Entity entityPlayer)
 {
 	ECSCore* pECS = ECSCore::GetInstance();
-	const PacketComponent<PlayerActionResponse>& pPacketComponent = pECS->GetComponent<PacketComponent<PlayerActionResponse>>(entityPlayer);
-	const TArray<PlayerActionResponse>& m_FramesProcessedByServer = pPacketComponent.GetPacketsReceived();
+	const PacketComponent<PacketPlayerActionResponse>& pPacketComponent = pECS->GetComponent<PacketComponent<PacketPlayerActionResponse>>(entityPlayer);
+	const TArray<PacketPlayerActionResponse>& m_FramesProcessedByServer = pPacketComponent.GetPacketsReceived();
 
 	for (uint32 i = 0; i < m_FramesProcessedByServer.GetSize(); i++)
 	{
@@ -179,7 +179,7 @@ void PlayerLocalSystem::Reconcile(Entity entityPlayer)
 	}
 }
 
-void PlayerLocalSystem::ReplayGameStatesBasedOnServerGameState(Entity entityPlayer, PlayerGameState* pGameStates, uint32 count, const PlayerActionResponse& gameStateServer)
+void PlayerLocalSystem::ReplayGameStatesBasedOnServerGameState(Entity entityPlayer, PlayerGameState* pGameStates, uint32 count, const PacketPlayerActionResponse& gameStateServer)
 {
 	ECSCore* pECS = ECSCore::GetInstance();
 
@@ -222,7 +222,7 @@ void PlayerLocalSystem::ReplayGameStatesBasedOnServerGameState(Entity entityPlay
 	}
 }
 
-bool PlayerLocalSystem::CompareGameStates(const PlayerGameState& gameStateLocal, const PlayerActionResponse& gameStateServer)
+bool PlayerLocalSystem::CompareGameStates(const PlayerGameState& gameStateLocal, const PacketPlayerActionResponse& gameStateServer)
 {
 	bool result = true;
 	if (glm::distance(gameStateLocal.Position, gameStateServer.Position) > EPSILON)

--- a/CrazyCanvas/Source/World/Player/Server/PlayerRemoteSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/Server/PlayerRemoteSystem.cpp
@@ -8,8 +8,8 @@
 
 #include "ECS/ECSCore.h"
 
-#include "Multiplayer/Packet/PlayerAction.h"
-#include "Multiplayer/Packet/PlayerActionResponse.h"
+#include "Multiplayer/Packet/PacketPlayerAction.h"
+#include "Multiplayer/Packet/PacketPlayerActionResponse.h"
 
 using namespace LambdaEngine;
 
@@ -38,8 +38,8 @@ void PlayerRemoteSystem::Init()
 				{R , PositionComponent::Type()},
 				{RW, VelocityComponent::Type()},
 				{RW, RotationComponent::Type()},
-				{R, PacketComponent<PlayerAction>::Type()},
-				{RW, PacketComponent<PlayerActionResponse>::Type()},
+				{R, PacketComponent<PacketPlayerAction>::Type()},
+				{RW, PacketComponent<PacketPlayerActionResponse>::Type()},
 			}
 		}
 	};
@@ -51,8 +51,8 @@ void PlayerRemoteSystem::Init()
 void PlayerRemoteSystem::FixedTickMainThread(LambdaEngine::Timestamp deltaTime)
 {
 	ECSCore* pECS = ECSCore::GetInstance();
-	auto* pPlayerActionComponents = pECS->GetComponentArray<PacketComponent<PlayerAction>>();
-	auto* pPlayerActionResponseComponents = pECS->GetComponentArray<PacketComponent<PlayerActionResponse>>();
+	auto* pPlayerActionComponents = pECS->GetComponentArray<PacketComponent<PacketPlayerAction>>();
+	auto* pPlayerActionResponseComponents = pECS->GetComponentArray<PacketComponent<PacketPlayerActionResponse>>();
 	auto* pCharacterColliderComponents = pECS->GetComponentArray<CharacterColliderComponent>();
 	auto* pPositionComponents = pECS->GetComponentArray<PositionComponent>();
 	auto* pNetPosComponents = pECS->GetComponentArray<NetworkPositionComponent>();
@@ -63,18 +63,18 @@ void PlayerRemoteSystem::FixedTickMainThread(LambdaEngine::Timestamp deltaTime)
 
 	for(Entity entityPlayer : m_Entities)
 	{
-		const PacketComponent<PlayerAction>& playerActionComponent = pPlayerActionComponents->GetConstData(entityPlayer);
-		PacketComponent<PlayerActionResponse>& playerActionResponseComponent = pPlayerActionResponseComponents->GetData(entityPlayer);
+		const PacketComponent<PacketPlayerAction>& playerActionComponent = pPlayerActionComponents->GetConstData(entityPlayer);
+		PacketComponent<PacketPlayerActionResponse>& playerActionResponseComponent = pPlayerActionResponseComponents->GetData(entityPlayer);
 		const NetworkPositionComponent& netPosComponent = pNetPosComponents->GetConstData(entityPlayer);
 		const PositionComponent& constPositionComponent = pPositionComponents->GetConstData(entityPlayer);
 		VelocityComponent& velocityComponent = pVelocityComponents->GetData(entityPlayer);
 		const RotationComponent& constRotationComponent = pRotationComponents->GetConstData(entityPlayer);
 
-		const TArray<PlayerAction>& gameStates = playerActionComponent.GetPacketsReceived();
+		const TArray<PacketPlayerAction>& gameStates = playerActionComponent.GetPacketsReceived();
 
-		for (const PlayerAction& gameState : gameStates)
+		for (const PacketPlayerAction& gameState : gameStates)
 		{
-			PlayerAction& currentGameState = m_CurrentGameStates[entityPlayer];
+			PacketPlayerAction& currentGameState = m_CurrentGameStates[entityPlayer];
 			ASSERT(gameState.SimulationTick - 1 == currentGameState.SimulationTick);
 			currentGameState = gameState;
 
@@ -89,7 +89,7 @@ void PlayerRemoteSystem::FixedTickMainThread(LambdaEngine::Timestamp deltaTime)
 			CharacterControllerHelper::TickCharacterController(dt, entityPlayer, pCharacterColliderComponents, pNetPosComponents, pVelocityComponents);
 
 
-			PlayerActionResponse packet;
+			PacketPlayerActionResponse packet;
 			packet.SimulationTick	= gameState.SimulationTick;
 			packet.Position			= netPosComponent.Position;
 			packet.Velocity			= velocityComponent.Velocity;

--- a/LambdaEngine/Include/Game/Multiplayer/Server/ClientRemoteSystem.h
+++ b/LambdaEngine/Include/Game/Multiplayer/Server/ClientRemoteSystem.h
@@ -13,8 +13,6 @@ namespace LambdaEngine
 		virtual ~ClientRemoteSystem();
 
 	protected:
-		virtual void TickMainThread(Timestamp deltaTime);
-
 		virtual void OnConnecting(IClient* pClient) override;
 		virtual void OnConnected(IClient* pClient) override;
 		virtual void OnDisconnecting(IClient* pClient) override;

--- a/LambdaEngine/Include/Math/Random.h
+++ b/LambdaEngine/Include/Math/Random.h
@@ -13,6 +13,7 @@ namespace LambdaEngine
 {
 	class LAMBDA_API Random
 	{
+		friend class EngineLoop;
 	public:
 		DECL_STATIC_CLASS(Random);
 
@@ -23,6 +24,9 @@ namespace LambdaEngine
 		static uint64  UInt64(uint64 min = 0, uint64 max = UINT64_MAX);
 		static float32 Float32();
 		static bool    Bool();
+
+	private:
+		static void PreInit();
 
 	private:
 		static std::default_random_engine s_Generator;

--- a/LambdaEngine/Include/Math/Random.h
+++ b/LambdaEngine/Include/Math/Random.h
@@ -16,13 +16,11 @@ namespace LambdaEngine
 	public:
 		DECL_STATIC_CLASS(Random);
 
-		static void PreInit();
-
-		static int32   Int32(int32 min, int32 max);
-		static uint32  UInt32(uint32 min, uint32 max);
+		static int32   Int32(int32 min = INT32_MIN, int32 max = INT32_MAX);
+		static uint32  UInt32(uint32 min = 0, uint32 max = UINT32_MAX);
 		static float32 Float32(float32 min, float32 max);
 
-		static uint64  UInt64();
+		static uint64  UInt64(uint64 min = 0, uint64 max = UINT64_MAX);
 		static float32 Float32();
 		static bool    Bool();
 

--- a/LambdaEngine/Include/Networking/API/ServerBase.h
+++ b/LambdaEngine/Include/Networking/API/ServerBase.h
@@ -48,8 +48,9 @@ namespace LambdaEngine
         bool IsRunning();
         const IPEndPoint& GetEndPoint() const;
         void SetAcceptingConnections(bool accepting);
-        bool IsAcceptingConnections();
-        uint8 GetClientCount();
+        bool IsAcceptingConnections() const;
+        void SetMaxClients(uint8 clients);
+        uint8 GetClientCount() const;
         const ServerDesc& GetDescription() const;
         const ClientMap& GetClients() const;
         

--- a/LambdaEngine/Source/Engine/EngineLoop.cpp
+++ b/LambdaEngine/Source/Engine/EngineLoop.cpp
@@ -5,8 +5,6 @@
 #include "Time/API/PlatformTime.h"
 #include "Time/API/Clock.h"
 
-#include "Math/Random.h"
-
 #include "Application/API/PlatformMisc.h"
 #include "Application/API/PlatformConsole.h"
 #include "Application/API/CommonApplication.h"
@@ -279,8 +277,6 @@ namespace LambdaEngine
 		}
 
 		PlatformTime::PreInit();
-
-		Random::PreInit();
 
 		return true;
 	}

--- a/LambdaEngine/Source/Engine/EngineLoop.cpp
+++ b/LambdaEngine/Source/Engine/EngineLoop.cpp
@@ -11,6 +11,8 @@
 
 #include "Application/API/Events/EventQueue.h"
 
+#include "Math/Random.h"
+
 #include "ECS/ECSCore.h"
 
 #include "Engine/EngineConfig.h"
@@ -254,6 +256,9 @@ namespace LambdaEngine
 		Malloc::SetDebugFlags(MEMORY_DEBUG_FLAGS_OVERFLOW_PROTECT | MEMORY_DEBUG_FLAGS_LEAK_CHECK);
 #endif
 
+		PlatformTime::PreInit();
+		Random::PreInit();
+
 		if (!EngineConfig::LoadFromFile(flagParser))
 		{
 			return false;
@@ -275,8 +280,6 @@ namespace LambdaEngine
 		{
 			return false;
 		}
-
-		PlatformTime::PreInit();
 
 		return true;
 	}

--- a/LambdaEngine/Source/Game/Multiplayer/Server/ClientRemoteSystem.cpp
+++ b/LambdaEngine/Source/Game/Multiplayer/Server/ClientRemoteSystem.cpp
@@ -17,11 +17,6 @@ namespace LambdaEngine
 
 	}
 
-	void ClientRemoteSystem::TickMainThread(Timestamp deltaTime)
-	{
-		UNREFERENCED_VARIABLE(deltaTime);
-	}
-
 	void ClientRemoteSystem::OnConnecting(IClient* pClient)
 	{
 		m_pClient = (ClientRemoteBase*)pClient;

--- a/LambdaEngine/Source/Game/Multiplayer/Server/ServerSystem.cpp
+++ b/LambdaEngine/Source/Game/Multiplayer/Server/ServerSystem.cpp
@@ -59,14 +59,8 @@ namespace LambdaEngine
 
 	void ServerSystem::TickMainThread(Timestamp deltaTime)
 	{
+		UNREFERENCED_VARIABLE(deltaTime);
 		NetworkDebugger::RenderStatistics(m_pServer);
-
-		const ClientMap& pClients = m_pServer->GetClients();
-		for (auto& pair : pClients)
-		{
-			ClientRemoteSystem* pClientSystem = (ClientRemoteSystem*)pair.second->GetHandler();
-			pClientSystem->TickMainThread(deltaTime);
-		}
 	}
 
 	ServerBase* ServerSystem::GetServer()

--- a/LambdaEngine/Source/Math/Random.cpp
+++ b/LambdaEngine/Source/Math/Random.cpp
@@ -4,12 +4,7 @@
 
 namespace LambdaEngine
 {
-	std::default_random_engine Random::s_Generator((uint32)0);
-
-	void Random::PreInit()
-	{
-		s_Generator = std::default_random_engine((uint32)PlatformTime::GetPerformanceCounter());
-	}
+	std::default_random_engine Random::s_Generator((uint32)PlatformTime::GetPerformanceCounter());
 
 	int32 Random::Int32(int32 min, int32 max)
 	{
@@ -31,13 +26,13 @@ namespace LambdaEngine
 
 	float32 Random::Float32()
 	{
-		std::uniform_real_distribution<float32> dist(0, 1.0F);
+		std::uniform_real_distribution<float32> dist(0.0F, 1.0F);
 		return dist(s_Generator);
 	}
 
-	uint64 Random::UInt64()
+	uint64 Random::UInt64(uint64 min, uint64 max)
 	{
-		std::uniform_int_distribution<uint64> dist(0, UINT64_MAX);
+		std::uniform_int_distribution<uint64> dist(min, max);
 		return dist(s_Generator);
 	}
 

--- a/LambdaEngine/Source/Math/Random.cpp
+++ b/LambdaEngine/Source/Math/Random.cpp
@@ -4,7 +4,12 @@
 
 namespace LambdaEngine
 {
-	std::default_random_engine Random::s_Generator((uint32)PlatformTime::GetPerformanceCounter());
+	std::default_random_engine Random::s_Generator(0);
+
+	void Random::PreInit()
+	{
+		s_Generator = std::default_random_engine((uint32)PlatformTime::GetPerformanceCounter());
+	}
 
 	int32 Random::Int32(int32 min, int32 max)
 	{

--- a/LambdaEngine/Source/Networking/API/NetworkSegment.cpp
+++ b/LambdaEngine/Source/Networking/API/NetworkSegment.cpp
@@ -58,7 +58,6 @@ namespace LambdaEngine
 
 	NetworkSegment* NetworkSegment::Write(const void* pBuffer, uint16 bytes)
 	{
-		ASSERT(bytes > 0);
 		ASSERT(m_SizeOfBuffer + bytes <= MAXIMUM_SEGMENT_SIZE);
 		memcpy(m_pBuffer + m_SizeOfBuffer, pBuffer, bytes);
 		m_SizeOfBuffer += bytes;
@@ -67,7 +66,6 @@ namespace LambdaEngine
 
 	NetworkSegment* NetworkSegment::Read(void* pBuffer, uint16 bytes)
 	{
-		ASSERT(bytes > 0);
 		ASSERT(m_ReadHead + bytes <= m_SizeOfBuffer);
 		memcpy(pBuffer, m_pBuffer + m_ReadHead, bytes);
 		m_ReadHead += bytes;

--- a/LambdaEngine/Source/Networking/API/ServerBase.cpp
+++ b/LambdaEngine/Source/Networking/API/ServerBase.cpp
@@ -90,12 +90,17 @@ namespace LambdaEngine
 		m_Accepting = accepting;
 	}
 
-	bool ServerBase::IsAcceptingConnections()
+	void ServerBase::SetMaxClients(uint8 clients)
+	{
+		m_Description.MaxClients = clients;
+	}
+
+	bool ServerBase::IsAcceptingConnections() const
 	{
 		return m_Accepting;
 	}
 
-	uint8 ServerBase::GetClientCount()
+	uint8 ServerBase::GetClientCount() const
 	{
 		return (uint8)m_Clients.size();
 	}


### PR DESCRIPTION
-When starting the Server and CrazyCanvas projects, clicking multiplayer causes the game to skip the Lobby state.
This is because the default host id was set to -1 for both the client and the server. This means they are both the same and the client automatically connects to the server. This is solved by making sure the default id is different on the server and the client.
-I have also made sure the client only sends the host packet if actually hosting the game.
-Renamed all packet classes to have the prefix of Packet.
-The default name of a hosted server is now set to the Username used in the OS, while waiting for a textfield in the GUI