### PR TITLE
Fix crashing benchmarks

### DIFF
--- a/.github/workflows/benchmark.py
+++ b/.github/workflows/benchmark.py
@@ -85,9 +85,6 @@ def main(argv):
 	run_benchmark(bin_path, original_engine_config, ray_tracing_enabled=True)
 	os.rename(BENCHMARK_RESULTS_PATH, BENCHMARK_RESULTS_PATH_RT_ON)
 
-	run_benchmark(bin_path, original_engine_config, ray_tracing_enabled=False)
-	os.rename(BENCHMARK_RESULTS_PATH, BENCHMARK_RESULTS_PATH_RT_OFF)
-
 	# Restore original engine config
 	os.remove(ENGINE_CONFIG_PATH)
 	os.rename(TEMP_ENGINE_CONFIG_PATH, ENGINE_CONFIG_PATH)

--- a/.github/workflows/update-charts.py
+++ b/.github/workflows/update-charts.py
@@ -60,10 +60,6 @@ def update_charts(commit_ID, repo_dir):
         rt_on_results = json.load(benchmarkFile)
         benchmarkFile.close()
 
-    with open(BENCHMARK_RESULTS_PATH_RT_OFF, 'r') as benchmarkFile:
-        rt_off_results = json.load(benchmarkFile)
-        benchmarkFile.close()
-
     with open(f'{repo_dir}/_data/charts.json', 'r+') as chartsFile:
         chartsData = json.load(chartsFile)
         update_commit_data(chartsData, commit_ID)
@@ -72,7 +68,6 @@ def update_charts(commit_ID, repo_dir):
             chartData = chartsData[chartName]
             chartData['commitIDs'].append(commit_ID)
             chartData['rtOn'].append(rt_on_results[chartName])
-            chartData['rtOff'].append(rt_off_results[chartName])
 
         chartsFile.seek(0)
         json.dump(chartsData, chartsFile, indent=4)

--- a/CrazyCanvas/Include/ECS/Systems/Player/WeaponSystem.h
+++ b/CrazyCanvas/Include/ECS/Systems/Player/WeaponSystem.h
@@ -55,11 +55,11 @@ public:
 		UNREFERENCED_VARIABLE(deltaTime);
 	}
 
-	void TryFire(
+	void Fire(
 		EAmmoType ammoType,
-		WeaponComponent& weaponComponent,
-		const glm::vec3& startPos, 
-		const glm::quat& direction, 
+		LambdaEngine::Entity weaponOwner,
+		const glm::vec3& playerPos,
+		const glm::quat& direction,
 		const glm::vec3& playerVelocity);
 
 public:
@@ -68,13 +68,6 @@ public:
 private:
 	WeaponSystem() = default;
 	~WeaponSystem() = default;
-
-	void Fire(
-		EAmmoType ammoType,
-		LambdaEngine::Entity weaponOwner,
-		const glm::vec3& playerPos,
-		const glm::quat& direction,
-		const glm::vec3& playerVelocity);
 
 	void TryFire(
 		EAmmoType ammoType,

--- a/CrazyCanvas/Include/States/BenchmarkState.h
+++ b/CrazyCanvas/Include/States/BenchmarkState.h
@@ -10,6 +10,7 @@
 #include "World/Level.h"
 
 class Level;
+struct WeaponFiredEvent;
 
 class BenchmarkState : public LambdaEngine::State
 {
@@ -29,6 +30,7 @@ private:
 
 private:
 	bool OnPacketReceived(const LambdaEngine::NetworkSegmentReceivedEvent& event);
+	bool OnWeaponFired(const WeaponFiredEvent& event);
 
 private:
 	LambdaEngine::Entity m_Camera;

--- a/CrazyCanvas/Source/ECS/Systems/Player/BenchmarkSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Player/BenchmarkSystem.cpp
@@ -97,19 +97,6 @@ void BenchmarkSystem::Tick(LambdaEngine::Timestamp deltaTime)
 			continue;
 		}
 
-		if (weaponComponent.ReloadClock > 0.0f)
-		{
-			weaponComponent.ReloadClock -= dt;
-			if (weaponComponent.ReloadClock <= 0.0f)
-			{
-				weaponComponent.CurrentAmmunition = AMMO_CAPACITY;
-			}
-			else
-			{
-				continue;
-			}
-		}
-
 		weaponSystem.Fire(
 			EAmmoType::AMMO_TYPE_PAINT,
 			playerEntity,
@@ -119,10 +106,5 @@ void BenchmarkSystem::Tick(LambdaEngine::Timestamp deltaTime)
 		);
 
 		weaponComponent.CurrentCooldown = 1.0f / weaponComponent.FireRate;
-
-		if (--weaponComponent.CurrentAmmunition == 0)
-		{
-			weaponComponent.ReloadClock = weaponComponent.ReloadTime;
-		}
 	}
 }

--- a/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Player/WeaponSystem.cpp
@@ -22,7 +22,7 @@
 static const glm::vec3 PROJECTILE_OFFSET = glm::vec3(0.0f, 1.0f, 0.0f);
 
 /*
-* WeaponSystem 
+* WeaponSystem
 */
 
 WeaponSystem WeaponSystem::s_Instance;
@@ -163,7 +163,7 @@ void WeaponSystem::FixedTick(LambdaEngine::Timestamp deltaTime)
 
 			TQueue<PlayerActionResponse>& packetsToSend = responsesToSend.GetPacketsToSend();
 			const TArray<PlayerAction>& packetsRecived = actionsRecived.GetPacketsReceived();
-			
+
 			const uint32 packetCount = packetsRecived.GetSize();
 			for (uint32 i = 0; i < packetCount; i++)
 			{
@@ -247,7 +247,7 @@ void WeaponSystem::FixedTick(LambdaEngine::Timestamp deltaTime)
 			const PositionComponent& playerPositionComp	= pPositionComponents->GetConstData(playerEntity);
 			const RotationComponent& playerRotationComp	= pRotationComponents->GetConstData(playerEntity);
 			const OffsetComponent& weaponOffsetComp		= pOffsetComponents->GetConstData(weaponEntity);
-			
+
 			glm::vec3 weaponPosition;
 			//if (playerRotationComp.Dirty || playerPositionComp.Dirty)
 			//{
@@ -350,9 +350,9 @@ void WeaponSystem::Fire(
 	// Fire event
 	WeaponFiredEvent firedEvent(
 		weaponOwner,
-		ammoType, 
+		ammoType,
 		startPos,
-		initialVelocity, 
+		initialVelocity,
 		direction,
 		playerTeam);
 	firedEvent.Callback = std::bind_front(&WeaponSystem::OnProjectileHit, this);
@@ -401,40 +401,6 @@ void WeaponSystem::TryFire(
 		}
 
 		// For creating entity
-		Fire(ammoType, weaponComponent.WeaponOwner, startPos, direction, playerVelocity);
-	}
-	else
-	{
-		// Play out of ammo
-		ISoundEffect3D* m_pSound = ResourceManager::GetSoundEffect(m_OutOfAmmoGUID);
-		m_pSound->PlayOnceAt(startPos, playerVelocity, 1.0f, 1.0f);
-	}
-}
-
-void WeaponSystem::TryFire(
-	EAmmoType ammoType,
-	WeaponComponent& weaponComponent,
-	const glm::vec3& startPos,
-	const glm::quat& direction,
-	const glm::vec3& playerVelocity)
-{
-	using namespace LambdaEngine;
-
-	// Add cooldown
-	weaponComponent.CurrentCooldown = 1.0f / weaponComponent.FireRate;
-
-	const bool hasAmmo = weaponComponent.CurrentAmmunition > 0;
-	if (hasAmmo)
-	{
-		// If we try to shoot when reloading we abort the reload
-		const bool isReloading = weaponComponent.ReloadClock > 0.0f;
-		if (isReloading)
-		{
-			AbortReload(weaponComponent);
-		}
-
-		// Fire the gun
-		weaponComponent.CurrentAmmunition--;
 		Fire(ammoType, weaponComponent.WeaponOwner, startPos, direction, playerVelocity);
 	}
 	else

--- a/CrazyCanvas/Source/Match/MatchBase.cpp
+++ b/CrazyCanvas/Source/Match/MatchBase.cpp
@@ -22,7 +22,7 @@ bool MatchBase::Init(const MatchDescription* pDesc)
 
 	// Register eventhandlers
 	EventQueue::RegisterEventHandler<WeaponFiredEvent>(this, &MatchBase::OnWeaponFired);
-	
+
 	m_pLevel = LevelManager::LoadLevel(pDesc->LevelHash);
 	m_MatchDesc = *pDesc;
 

--- a/CrazyCanvas/Source/Match/MatchClient.cpp
+++ b/CrazyCanvas/Source/Match/MatchClient.cpp
@@ -126,6 +126,7 @@ bool MatchClient::OnPacketGameOverReceived(const PacketReceivedEvent<PacketGameO
 
 	return true;
 }
+
 bool MatchClient::OnWeaponFired(const WeaponFiredEvent& event)
 {
 	using namespace LambdaEngine;

--- a/CrazyCanvas/Source/World/Level.cpp
+++ b/CrazyCanvas/Source/World/Level.cpp
@@ -40,7 +40,7 @@ bool Level::Init(const LevelCreateDesc* pDesc)
 	m_Name = pDesc->Name;
 
 	using namespace LambdaEngine;
-	
+
 	std::scoped_lock<SpinLock> lock(m_SpinLock);
 
 	for (LevelModule* pModule : pDesc->LevelModules)

--- a/CrazyCanvas/Source/World/LevelObjectCreator.cpp
+++ b/CrazyCanvas/Source/World/LevelObjectCreator.cpp
@@ -229,8 +229,8 @@ LambdaEngine::Entity LevelObjectCreator::CreateStaticGeometry(const LambdaEngine
 }
 
 ELevelObjectType LevelObjectCreator::CreateLevelObjectFromPrefix(
-	const LambdaEngine::LevelObjectOnLoad& levelObject, 
-	LambdaEngine::TArray<LambdaEngine::Entity>& createdEntities, 
+	const LambdaEngine::LevelObjectOnLoad& levelObject,
+	LambdaEngine::TArray<LambdaEngine::Entity>& createdEntities,
 	const glm::vec3& translation)
 {
 	auto createFuncIt = s_LevelObjectByPrefixCreateFunctions.find(levelObject.Prefix);
@@ -267,8 +267,8 @@ bool LevelObjectCreator::CreateLevelObjectOfType(
 }
 
 ELevelObjectType LevelObjectCreator::CreatePlayerSpawn(
-	const LambdaEngine::LevelObjectOnLoad& levelObject, 
-	LambdaEngine::TArray<LambdaEngine::Entity>& createdEntities, 
+	const LambdaEngine::LevelObjectOnLoad& levelObject,
+	LambdaEngine::TArray<LambdaEngine::Entity>& createdEntities,
 	const glm::vec3& translation)
 {
 	using namespace LambdaEngine;
@@ -329,8 +329,8 @@ ELevelObjectType LevelObjectCreator::CreatePlayerSpawn(
 }
 
 ELevelObjectType LevelObjectCreator::CreateFlagSpawn(
-	const LambdaEngine::LevelObjectOnLoad& levelObject, 
-	LambdaEngine::TArray<LambdaEngine::Entity>& createdEntities, 
+	const LambdaEngine::LevelObjectOnLoad& levelObject,
+	LambdaEngine::TArray<LambdaEngine::Entity>& createdEntities,
 	const glm::vec3& translation)
 {
 	using namespace LambdaEngine;
@@ -546,7 +546,7 @@ bool LevelObjectCreator::CreateFlag(
 			},
 			/* Velocity */			pECS->AddComponent<VelocityComponent>(entity, { glm::vec3(0.0f) })
 		};
-		
+
 		DynamicCollisionComponent collisionComponent = pPhysicsSystem->CreateDynamicActor(collisionCreateInfo);
 		collisionComponent.pActor->setRigidBodyFlag(PxRigidBodyFlag::eKINEMATIC, true);
 		pECS->AddComponent<DynamicCollisionComponent>(entity, collisionComponent);
@@ -576,23 +576,23 @@ bool LevelObjectCreator::CreatePlayer(
 	const CreatePlayerDesc* pPlayerDesc = reinterpret_cast<const CreatePlayerDesc*>(pData);
 
 	ECSCore* pECS = ECSCore::GetInstance();
-	Entity playerEntity = pECS->CreateEntity();
+	const Entity playerEntity = pECS->CreateEntity();
 	createdEntities.PushBack(playerEntity);
 	TArray<Entity>& childEntities = createdChildEntities.PushBack({});
 
-	glm::quat lookDirQuat = glm::quatLookAt(pPlayerDesc->Forward, g_DefaultUp);
+	const glm::quat lookDirQuat = glm::quatLookAt(pPlayerDesc->Forward, g_DefaultUp);
 
 	pECS->AddComponent<PlayerBaseComponent>(playerEntity,		PlayerBaseComponent());
 	EntityMaskManager::AddExtensionToEntity(playerEntity,		PlayerBaseComponent::Type(), nullptr);
 
 	pECS->AddComponent<PositionComponent>(playerEntity,			PositionComponent{ .Position = pPlayerDesc->Position });
-	pECS->AddComponent<NetworkPositionComponent>(playerEntity,	
+	pECS->AddComponent<NetworkPositionComponent>(playerEntity,
 		NetworkPositionComponent
-		{ 
-		.Position		= pPlayerDesc->Position, 
-		.PositionLast	= pPlayerDesc->Position, 
-		.TimestampStart = EngineLoop::GetTimeSinceStart(), 
-		.Duration		= EngineLoop::GetFixedTimestep() 
+		{
+		.Position		= pPlayerDesc->Position,
+		.PositionLast	= pPlayerDesc->Position,
+		.TimestampStart = EngineLoop::GetTimeSinceStart(),
+		.Duration		= EngineLoop::GetFixedTimestep()
 		});
 
 	pECS->AddComponent<RotationComponent>(playerEntity,			RotationComponent{ .Quaternion = lookDirQuat });
@@ -601,7 +601,7 @@ bool LevelObjectCreator::CreatePlayer(
 	pECS->AddComponent<TeamComponent>(playerEntity,				TeamComponent{ .TeamIndex = pPlayerDesc->TeamIndex });
 	pECS->AddComponent<PacketComponent<PlayerAction>>(playerEntity, { });
 	pECS->AddComponent<PacketComponent<PlayerActionResponse>>(playerEntity, { });
-	
+
 	const CharacterColliderCreateInfo colliderInfo =
 	{
 		.Entity			= playerEntity,
@@ -616,8 +616,8 @@ bool LevelObjectCreator::CreatePlayer(
 
 	PhysicsSystem* pPhysicsSystem = PhysicsSystem::GetInstance();
 	CharacterColliderComponent characterColliderComponent = pPhysicsSystem->CreateCharacterCapsule(
-		colliderInfo, 
-		std::max(0.0f, PLAYER_CAPSULE_HEIGHT - 2.0f * PLAYER_CAPSULE_RADIUS), 
+		colliderInfo,
+		std::max(0.0f, PLAYER_CAPSULE_HEIGHT - 2.0f * PLAYER_CAPSULE_RADIUS),
 		PLAYER_CAPSULE_RADIUS);
 
 	pECS->AddComponent<CharacterColliderComponent>(playerEntity, characterColliderComponent);
@@ -853,7 +853,7 @@ bool LevelObjectCreator::CreatePlayer(
 	pECS->AddComponent<NetworkComponent>(weaponEntity, { weaponNetworkUID });
 	D_LOG_INFO("Created Player with EntityID %d and NetworkID %d", playerEntity, playerNetworkUID);
 	D_LOG_INFO("Created Weapon with EntityID %d and NetworkID %d", weaponEntity, weaponNetworkUID);
-	
+
 	return true;
 }
 

--- a/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
@@ -55,16 +55,10 @@ namespace LambdaEngine
 			{
 				SAFERELEASE(m_ppRenderCommandLists[b]);
 				SAFERELEASE(m_ppRenderCommandAllocators[b]);
-
-				for (TSharedRef<DeviceChild> pDeviceChild : m_pDeviceResourcesToDestroy[b])
-				{
-					SAFERELEASE(pDeviceChild);
-				}
 			}
 
 			SAFEDELETE_ARRAY(m_ppRenderCommandLists);
 			SAFEDELETE_ARRAY(m_ppRenderCommandAllocators);
-			m_pDeviceResourcesToDestroy.Clear();
 		}
 	}
 


### PR DESCRIPTION
## Purpose
- Benchmarks no longer crash
- The characters in the benchmarks no longer run out of ammo after emptying one magazine

## Changes
- Crash fixes:
  - Added `WeaponNetworkUID` to `CreatePlayerDesc` in `BenchmarkState`
  - Fixed shared pointers being deleted twice in `~PaintMaskRenderer`
- `BenchmarkSystem` takes care of weapon-firing logic (very simplified version of the logic in `WeaponSystem`)