### PR TITLE
Normal mapping paint

### DIFF
--- a/Assets/Shaders/Geometry/GeomMeshPaint.frag
+++ b/Assets/Shaders/Geometry/GeomMeshPaint.frag
@@ -7,6 +7,7 @@
 #include "../Defines.glsl"
 #include "../Helpers.glsl"
 #include "../Noise.glsl"
+#include "../Paint.glsl"
 
 struct SPaintDescription
 {
@@ -87,15 +88,11 @@ SPaintDescription InterpolatePaint(in mat3 TBN, in vec3 position, in vec3 tangen
 	float paintAmountHor1	= mix(paintSample01.PaintAmount, paintSample11.PaintAmount, subTexel.x);
 	float paintAmountFinal	= mix(paintAmountHor0, paintAmountHor1, subTexel.y);
 
-	float noiseScale			= 8.0f;
-	float deltaNoise			= 0.001f;
-	float h0 					= snoise(noiseScale * (position));
-	float h_u 					= snoise(noiseScale * (position + deltaNoise * tangent));
-	float h_v 					= snoise(noiseScale * (position + deltaNoise * tangent));
-	float dh_u					= (h0 - h_u);
-	float dh_v					= (h0 - h_v);
-	vec3 grad_h					= vec3(dh_u, dh_v, sqrt(1.0f - (dh_u * dh_u) - (dh_v * dh_v)));
-	vec3 paintNormal			= normalize(grad_h);
+	float h0 					= snoise(PAINT_NOISE_SCALE * (position));
+	float h_u 					= snoise(PAINT_NOISE_SCALE * (position + PAINT_DELTA_NOISE * tangent));
+	float h_v 					= snoise(PAINT_NOISE_SCALE * (position + PAINT_DELTA_NOISE * tangent));
+	vec2 grad_h					= vec2(h0 - h_u, h0 - h_v);
+	vec3 paintNormal			= normalize(vec3(PAINT_BUMPINESS * grad_h, sqrt(1.0f - (grad_h.x * grad_h.x) - (grad_h.y * grad_h.y))));
 	vec3 noPaintNormal00		= normalize(vec3(-1.0f,  1.0f, 1.0f));
 	vec3 noPaintNormal10		= normalize(vec3( 1.0f,  1.0f, 1.0f));
 	vec3 noPaintNormal01		= normalize(vec3(-1.0f, -1.0f, 1.0f));
@@ -112,7 +109,7 @@ SPaintDescription InterpolatePaint(in mat3 TBN, in vec3 position, in vec3 tangen
 
 	paintDescription.Normal			= combinedNormal;
 	paintDescription.Albedo 		= paintColorFinal;
-	paintDescription.Roughness 		= 0.01f;
+	paintDescription.Roughness 		= PAINT_ROUGHNESS;
 	paintDescription.Interpolation	= paintAmountFinal;
 
 	return paintDescription;

--- a/Assets/Shaders/Geometry/GeomMeshPaint.frag
+++ b/Assets/Shaders/Geometry/GeomMeshPaint.frag
@@ -6,6 +6,21 @@
 
 #include "../Defines.glsl"
 #include "../Helpers.glsl"
+#include "../Noise.glsl"
+
+struct SPaintDescription
+{
+	vec3 	Normal;
+	vec3 	Albedo;
+	float 	Roughness;
+	float 	Interpolation;
+};
+
+struct SPaintSample
+{
+	float PaintAmount;
+	uint Team;
+};
 
 layout(location = 0) in flat uint	in_MaterialSlot;
 layout(location = 1) in vec3		in_WorldPosition;
@@ -32,6 +47,77 @@ layout(location = 2) out vec4 out_AO_Rough_Metal_Valid;
 layout(location = 3) out vec3 out_Compact_Normal;
 layout(location = 4) out vec2 out_Velocity;
 
+SPaintSample SamplePaint(in ivec2 p, in uint paintMaskIndex)
+{
+	uvec2 paintData = floatBitsToUint(texelFetch(u_PaintMaskTextures[paintMaskIndex], p, 0).rg);
+
+	uint clientTeam				= (paintData.g >> 1) & 0x7F;
+	uint serverTeam				= (paintData.r >> 1) & 0x7F;
+	uint clientPainting			= paintData.g & 0x1;
+
+	SPaintSample paintSample;
+	paintSample.PaintAmount		= float((paintData.r & 0x1) | (paintData.g & 0x1));
+	paintSample.Team 			= clientPainting * clientTeam + (1 - clientPainting) * serverTeam;
+	return paintSample;
+}
+
+SPaintDescription InterpolatePaint(in mat3 TBN, in vec3 position, in vec3 tangent, in vec3 bitangent, in vec2 texCoord, in uint paintMaskIndex)
+{
+	ivec2 paintMaskSize 		= textureSize(u_PaintMaskTextures[paintMaskIndex], 0);
+	vec2 texelPos				= (texCoord * vec2(paintMaskSize));
+	vec2 texelCenter;
+	vec2 subTexel				= modf(texelPos, texelCenter);
+	ivec2 iTexelCenter			= ivec2(texelCenter);
+
+	SPaintSample paintSample00		= SamplePaint(iTexelCenter + ivec2(0, 0), 	paintMaskIndex);
+	SPaintSample paintSample10		= SamplePaint(iTexelCenter + ivec2(1, 0), 	paintMaskIndex);
+	SPaintSample paintSample01		= SamplePaint(iTexelCenter + ivec2(0, 1), 	paintMaskIndex);
+	SPaintSample paintSample11		= SamplePaint(iTexelCenter + ivec2(1, 1), 	paintMaskIndex);
+
+	vec3 paintColor00		= b_PaintMaskColor.val[paintSample00.Team].rgb;
+	vec3 paintColor10 		= b_PaintMaskColor.val[paintSample10.Team].rgb;
+	vec3 paintColor01 		= b_PaintMaskColor.val[paintSample01.Team].rgb;
+	vec3 paintColor11 		= b_PaintMaskColor.val[paintSample11.Team].rgb;
+	
+	vec3 paintColorHor0 	= mix(paintColor00, paintColor10, subTexel.x);
+	vec3 paintColorHor1 	= mix(paintColor01, paintColor11, subTexel.x);
+	vec3 paintColorFinal	= mix(paintColorHor0, paintColorHor1, subTexel.y);
+
+	float paintAmountHor0	= mix(paintSample00.PaintAmount, paintSample10.PaintAmount, subTexel.x);
+	float paintAmountHor1	= mix(paintSample01.PaintAmount, paintSample11.PaintAmount, subTexel.x);
+	float paintAmountFinal	= mix(paintAmountHor0, paintAmountHor1, subTexel.y);
+
+	float noiseScale			= 8.0f;
+	float deltaNoise			= 0.001f;
+	float h0 					= snoise(noiseScale * (position));
+	float h_u 					= snoise(noiseScale * (position + deltaNoise * tangent));
+	float h_v 					= snoise(noiseScale * (position + deltaNoise * tangent));
+	float dh_u					= (h0 - h_u);
+	float dh_v					= (h0 - h_v);
+	vec3 grad_h					= vec3(dh_u, dh_v, sqrt(1.0f - (dh_u * dh_u) - (dh_v * dh_v)));
+	vec3 paintNormal			= normalize(grad_h);
+	vec3 noPaintNormal00		= normalize(vec3(-1.0f,  1.0f, 1.0f));
+	vec3 noPaintNormal10		= normalize(vec3( 1.0f,  1.0f, 1.0f));
+	vec3 noPaintNormal01		= normalize(vec3(-1.0f, -1.0f, 1.0f));
+	vec3 noPaintNormal11		= normalize(vec3( 1.0f, -1.0f, 1.0f));
+	vec3 combinedNormal			= TBN * normalize(
+		paintNormal + 
+		(1.0f - paintSample00.PaintAmount) * noPaintNormal00 +
+		(1.0f - paintSample10.PaintAmount) * noPaintNormal10 +
+		(1.0f - paintSample01.PaintAmount) * noPaintNormal01 +
+		(1.0f - paintSample11.PaintAmount) * noPaintNormal11
+	);
+
+	SPaintDescription paintDescription;
+
+	paintDescription.Normal			= combinedNormal;
+	paintDescription.Albedo 		= paintColorFinal;
+	paintDescription.Roughness 		= 0.01f;
+	paintDescription.Interpolation	= paintAmountFinal;
+
+	return paintDescription;
+}
+
 void main()
 {
 	vec3 normal		= normalize(in_Normal);
@@ -40,55 +126,36 @@ void main()
 	vec2 texCoord	= in_TexCoord;
 
 	mat3 TBN = mat3(tangent, bitangent, normal);
-
+	
 	vec3 sampledAlbedo				= texture(u_AlbedoMaps[in_MaterialSlot],			texCoord).rgb;
 	vec3 sampledNormal				= texture(u_NormalMaps[in_MaterialSlot],			texCoord).rgb;
 	vec3 sampledCombinedMaterial	= texture(u_CombinedMaterialMaps[in_MaterialSlot],	texCoord).rgb;
-	
-	vec3 shadingNormal			= normalize((sampledNormal * 2.0f) - 1.0f);
-	shadingNormal				= normalize(TBN * normalize(shadingNormal));
 
 	SMaterialParameters materialParameters = b_MaterialParameters.val[in_MaterialSlot];
-
-	vec2 currentNDC				= (in_ClipPosition.xy / in_ClipPosition.w) * 0.5f + 0.5f;
-	vec2 prevNDC				= (in_PrevClipPosition.xy / in_PrevClipPosition.w) * 0.5f + 0.5f;
-	
-	uint serverData				= floatBitsToUint(texture(u_PaintMaskTextures[in_ExtensionIndex], texCoord).r);
-	uint clientData				= floatBitsToUint(texture(u_PaintMaskTextures[in_ExtensionIndex], texCoord).g);
-	float shouldPaint 			= float((serverData & 0x1) | (clientData & 0x1));
+	SPaintDescription paintDescription = InterpolatePaint(TBN, in_WorldPosition, tangent, bitangent, in_TexCoord, in_ExtensionIndex);
 
 	//0
 	out_Position				= vec4(in_WorldPosition, 0.0f);
 
 	//1
 	vec3 storedAlbedo			= pow(materialParameters.Albedo.rgb * sampledAlbedo, vec3(GAMMA));
-	out_Albedo					= storedAlbedo;
+	out_Albedo					= mix(storedAlbedo, paintDescription.Albedo, paintDescription.Interpolation);
 
 	//2
 	vec3 storedMaterial			= vec3(
 									materialParameters.AO * sampledCombinedMaterial.b, 
-									mix(materialParameters.Roughness * sampledCombinedMaterial.r, 1.0f, shouldPaint), 
+									mix(materialParameters.Roughness * sampledCombinedMaterial.r, paintDescription.Roughness, paintDescription.Interpolation), 
 									materialParameters.Metallic * sampledCombinedMaterial.g);
 	out_AO_Rough_Metal_Valid	= vec4(storedMaterial, 1.0f);
 
 	//3
-	out_Compact_Normal			= PackNormal(shadingNormal);
+	vec3 shadingNormal			= normalize((sampledNormal * 2.0f) - 1.0f);
+	shadingNormal				= normalize(TBN * normalize(shadingNormal));
+	out_Compact_Normal			= PackNormal(mix(shadingNormal, paintDescription.Normal, paintDescription.Interpolation));
 
 	//4
+	vec2 currentNDC				= (in_ClipPosition.xy / in_ClipPosition.w) * 0.5f + 0.5f;
+	vec2 prevNDC				= (in_PrevClipPosition.xy / in_PrevClipPosition.w) * 0.5f + 0.5f;
 	vec2 screenVelocity			= (prevNDC - currentNDC);
 	out_Velocity				= vec2(screenVelocity);
-
-	// 5
-	uint clientTeam				= (clientData >> 1) & 0x7F;
-	uint serverTeam				= (serverData >> 1) & 0x7F;
-	uint clientPainting			= clientData & 0x1;
-	uint team = serverTeam;
-	if (clientPainting > 0)
-		team = clientTeam;
-
-	// Assume the correct amount of colors have been sent in
-	vec4 color = b_PaintMaskColor.val[team];
-
-	// Mix team color
-	out_Albedo					= mix(out_Albedo, color.rgb, shouldPaint);
 }

--- a/Assets/Shaders/Noise.glsl
+++ b/Assets/Shaders/Noise.glsl
@@ -1,0 +1,70 @@
+#include "Defines.glsl"
+
+//	Simplex 3D Noise 
+//	by Ian McEwan, Ashima Arts
+//
+vec4 permute(vec4 x)
+{
+    return mod(((x*34.0)+1.0)*x, 289.0);
+}
+
+vec4 taylorInvSqrt(vec4 r)
+{
+    return 1.79284291400159 - 0.85373472095314 * r;
+}
+
+float snoise(vec3 v)
+{ 
+    const vec2  C = vec2(1.0/6.0, 1.0/3.0);
+    const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);   
+    // First corner
+    vec3 i  = floor(v + dot(v, C.yyy) );
+    vec3 x0 =   v - i + dot(i, C.xxx) ; 
+    // Other corners
+    vec3 g = step(x0.yzx, x0.xyz);
+    vec3 l = 1.0 - g;
+    vec3 i1 = min( g.xyz, l.zxy );
+    vec3 i2 = max( g.xyz, l.zxy );  
+    //  x0 = x0 - 0. + 0.0 * C 
+    vec3 x1 = x0 - i1 + 1.0 * C.xxx;
+    vec3 x2 = x0 - i2 + 2.0 * C.xxx;
+    vec3 x3 = x0 - 1. + 3.0 * C.xxx;    
+    // Permutations
+    i = mod(i, 289.0 ); 
+    vec4 p = permute( permute( permute( 
+                i.z + vec4(0.0, i1.z, i2.z, 1.0 ))
+            + i.y + vec4(0.0, i1.y, i2.y, 1.0 )) 
+            + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));   
+    // Gradients
+    // ( N*N points uniformly over a square, mapped onto an octahedron.)
+    float n_ = 1.0/7.0; // N=7
+    vec3  ns = n_ * D.wyz - D.xzx;  
+    vec4 j = p - 49.0 * floor(p * ns.z *ns.z);  //  mod(p,N*N)  
+    vec4 x_ = floor(j * ns.z);
+    vec4 y_ = floor(j - 7.0 * x_ );    // mod(j,N)  
+    vec4 x = x_ *ns.x + ns.yyyy;
+    vec4 y = y_ *ns.x + ns.yyyy;
+    vec4 h = 1.0 - abs(x) - abs(y); 
+    vec4 b0 = vec4( x.xy, y.xy );
+    vec4 b1 = vec4( x.zw, y.zw );   
+    vec4 s0 = floor(b0)*2.0 + 1.0;
+    vec4 s1 = floor(b1)*2.0 + 1.0;
+    vec4 sh = -step(h, vec4(0.0));  
+    vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
+    vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;   
+    vec3 p0 = vec3(a0.xy,h.x);
+    vec3 p1 = vec3(a0.zw,h.y);
+    vec3 p2 = vec3(a1.xy,h.z);
+    vec3 p3 = vec3(a1.zw,h.w);  
+    //Normalise gradients
+    vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
+    p0 *= norm.x;
+    p1 *= norm.y;
+    p2 *= norm.z;
+    p3 *= norm.w;   
+    // Mix final noise value
+    vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+    m = m * m;
+    return 42.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1), 
+                                    dot(p2,x2), dot(p3,x3) ) );
+}

--- a/Assets/Shaders/Paint.glsl
+++ b/Assets/Shaders/Paint.glsl
@@ -1,0 +1,4 @@
+#define PAINT_NOISE_SCALE		8.0f
+#define PAINT_DELTA_NOISE		0.001f
+#define PAINT_BUMPINESS	        2.0f
+#define PAINT_ROUGHNESS	        0.05f

--- a/Assets/Shaders/RayTracing/PrimaryClosestHit.rchit
+++ b/Assets/Shaders/RayTracing/PrimaryClosestHit.rchit
@@ -7,14 +7,32 @@
 #include "RayTracingInclude.glsl"
 #include "../Helpers.glsl"
 #include "../Defines.glsl"
+#include "../Noise.glsl"
 
 struct SRayHitDescription
 {
 	vec3	Position;
 	vec3	Normal;
+	vec3	Tangent;
+	vec3	Bitangent;
+	mat3 	TBN;
 	vec2	TexCoord;
 	uint	MaterialIndex;
 	uint	PaintMaskIndex;
+};
+
+struct SPaintDescription
+{
+	vec3 	Normal;
+	vec3 	Albedo;
+	float 	Roughness;
+	float 	Interpolation;
+};
+
+struct SPaintSample
+{
+	float PaintAmount;
+	uint Team;
 };
 
 layout(buffer_reference, buffer_reference_align = 16) buffer VertexBuffer 
@@ -68,24 +86,96 @@ SRayHitDescription CalculateHitData()
 	SRayHitDescription hitDescription;
 	hitDescription.Position			= gl_WorldRayOriginEXT + normalize(gl_WorldRayDirectionEXT) * gl_HitTEXT;
 	hitDescription.Normal			= shadingNormal;
+	hitDescription.Tangent			= T;
+	hitDescription.Bitangent		= B;
+	hitDescription.TBN				= TBN;
 	hitDescription.TexCoord			= texCoord;
 	hitDescription.MaterialIndex	= materialIndex;
 	hitDescription.PaintMaskIndex	= paintMaskIndex;
-
+	
 	return hitDescription;
+}
+
+SPaintSample SamplePaint(in ivec2 p, in uint paintMaskIndex)
+{
+	uvec2 paintData = floatBitsToUint(texelFetch(u_PaintMaskTextures[paintMaskIndex], p, 0).rg);
+
+	uint clientTeam				= (paintData.g >> 1) & 0x7F;
+	uint serverTeam				= (paintData.r >> 1) & 0x7F;
+	uint clientPainting			= paintData.g & 0x1;
+
+	SPaintSample paintSample;
+	paintSample.PaintAmount		= float((paintData.r & 0x1) | (paintData.g & 0x1));
+	paintSample.Team 			= clientPainting * clientTeam + (1 - clientPainting) * serverTeam;
+	return paintSample;
+}
+
+SPaintDescription InterpolatePaint(in mat3 TBN, in vec3 position, in vec3 tangent, in vec3 bitangent, in vec2 texCoord, in uint paintMaskIndex)
+{
+	ivec2 paintMaskSize 		= textureSize(u_PaintMaskTextures[paintMaskIndex], 0);
+	vec2 texelPos				= (texCoord * vec2(paintMaskSize));
+	vec2 texelCenter;
+	vec2 subTexel				= modf(texelPos, texelCenter);
+	ivec2 iTexelCenter			= ivec2(texelCenter);
+
+	SPaintSample paintSample00		= SamplePaint(iTexelCenter + ivec2(0, 0), 	paintMaskIndex);
+	SPaintSample paintSample10		= SamplePaint(iTexelCenter + ivec2(1, 0), 	paintMaskIndex);
+	SPaintSample paintSample01		= SamplePaint(iTexelCenter + ivec2(0, 1), 	paintMaskIndex);
+	SPaintSample paintSample11		= SamplePaint(iTexelCenter + ivec2(1, 1), 	paintMaskIndex);
+
+	vec3 paintColor00		= b_PaintMaskColor.val[paintSample00.Team].rgb;
+	vec3 paintColor10 		= b_PaintMaskColor.val[paintSample10.Team].rgb;
+	vec3 paintColor01 		= b_PaintMaskColor.val[paintSample01.Team].rgb;
+	vec3 paintColor11 		= b_PaintMaskColor.val[paintSample11.Team].rgb;
+	
+	vec3 paintColorHor0 	= mix(paintColor00, paintColor10, subTexel.x);
+	vec3 paintColorHor1 	= mix(paintColor01, paintColor11, subTexel.x);
+	vec3 paintColorFinal	= mix(paintColorHor0, paintColorHor1, subTexel.y);
+
+	float paintAmountHor0	= mix(paintSample00.PaintAmount, paintSample10.PaintAmount, subTexel.x);
+	float paintAmountHor1	= mix(paintSample01.PaintAmount, paintSample11.PaintAmount, subTexel.x);
+	float paintAmountFinal	= mix(paintAmountHor0, paintAmountHor1, subTexel.y);
+
+	float noiseScale			= 8.0f;
+	float deltaNoise			= 0.001f;
+	float h0 					= snoise(noiseScale * (position));
+	float h_u 					= snoise(noiseScale * (position + deltaNoise * tangent));
+	float h_v 					= snoise(noiseScale * (position + deltaNoise * tangent));
+	float dh_u					= (h0 - h_u);
+	float dh_v					= (h0 - h_v);
+	vec3 grad_h					= vec3(dh_u, dh_v, sqrt(1.0f - (dh_u * dh_u) - (dh_v * dh_v)));
+	vec3 paintNormal			= normalize(grad_h);
+	vec3 noPaintNormal00		= normalize(vec3(-1.0f,  1.0f, 1.0f));
+	vec3 noPaintNormal10		= normalize(vec3( 1.0f,  1.0f, 1.0f));
+	vec3 noPaintNormal01		= normalize(vec3(-1.0f, -1.0f, 1.0f));
+	vec3 noPaintNormal11		= normalize(vec3( 1.0f, -1.0f, 1.0f));
+	vec3 combinedNormal			= TBN * normalize(
+		paintNormal + 
+		(1.0f - paintSample00.PaintAmount) * noPaintNormal00 +
+		(1.0f - paintSample10.PaintAmount) * noPaintNormal10 +
+		(1.0f - paintSample01.PaintAmount) * noPaintNormal01 +
+		(1.0f - paintSample11.PaintAmount) * noPaintNormal11
+	);
+
+	SPaintDescription paintDescription;
+
+	paintDescription.Normal			= combinedNormal;
+	paintDescription.Albedo 		= paintColorFinal;
+	paintDescription.Roughness 		= 0.01f;
+	paintDescription.Interpolation	= paintAmountFinal;
+
+	return paintDescription;
 }
 
 void main() 
 {
 	SRayHitDescription hitDescription = CalculateHitData();
-
+	SPaintDescription paintDescription = InterpolatePaint(hitDescription.TBN, hitDescription.Position, hitDescription.Tangent, hitDescription.Bitangent, hitDescription.TexCoord, hitDescription.PaintMaskIndex);
+	
 	SMaterialParameters materialParameters = u_MaterialParameters.val[hitDescription.MaterialIndex];
 
 	vec3 sampledAlbedo 		= texture(u_AlbedoMaps[hitDescription.MaterialIndex],			hitDescription.TexCoord).rgb;
 	vec3 sampledMaterial	= texture(u_CombinedMaterialMaps[hitDescription.MaterialIndex],	hitDescription.TexCoord).rgb;
-	uint serverData				= floatBitsToUint(texture(u_PaintMaskTextures[hitDescription.PaintMaskIndex], hitDescription.TexCoord).r);
-	uint clientData				= floatBitsToUint(texture(u_PaintMaskTextures[hitDescription.PaintMaskIndex], hitDescription.TexCoord).g);
-	float shouldPaint 			= float((serverData & 0x1) | (clientData & 0x1));
 
 	vec3 albedo				= pow(  materialParameters.Albedo.rgb * sampledAlbedo, vec3(GAMMA));
 	float ao				= 		materialParameters.AO * sampledMaterial.b;
@@ -93,21 +183,10 @@ void main()
 	float metallic			= 		materialParameters.Metallic * sampledMaterial.g;
 
 	s_PrimaryPayload.HitPosition		= hitDescription.Position;
-	s_PrimaryPayload.Normal				= hitDescription.Normal;
+	s_PrimaryPayload.Normal				= mix(hitDescription.Normal, paintDescription.Normal, paintDescription.Interpolation);
+	s_PrimaryPayload.Albedo				= mix(albedo, paintDescription.Albedo, paintDescription.Interpolation);
 	s_PrimaryPayload.AO					= ao;
+	s_PrimaryPayload.Roughness			= mix(roughness, paintDescription.Roughness, paintDescription.Interpolation);
 	s_PrimaryPayload.Metallic			= metallic;
 	s_PrimaryPayload.Distance			= gl_HitTEXT;
-
-	uint clientTeam				= (clientData >> 1) & 0x7F;
-	uint serverTeam				= (serverData >> 1) & 0x7F;
-	uint clientPainting			= clientData & 0x1;
-	uint team = serverTeam;
-	if (clientPainting > 0)
-		team = clientTeam;
-
-	// Assume the correct amount of colors have been sent in
-	vec4 color = b_PaintMaskColor.val[team];
-
-	s_PrimaryPayload.Albedo				= mix(albedo, color.rgb, shouldPaint);
-	s_PrimaryPayload.Roughness			= mix(roughness, 1.0f, shouldPaint);
 }

--- a/Assets/Shaders/RayTracing/PrimaryClosestHit.rchit
+++ b/Assets/Shaders/RayTracing/PrimaryClosestHit.rchit
@@ -8,6 +8,7 @@
 #include "../Helpers.glsl"
 #include "../Defines.glsl"
 #include "../Noise.glsl"
+#include "../Paint.glsl"
 
 struct SRayHitDescription
 {
@@ -136,15 +137,11 @@ SPaintDescription InterpolatePaint(in mat3 TBN, in vec3 position, in vec3 tangen
 	float paintAmountHor1	= mix(paintSample01.PaintAmount, paintSample11.PaintAmount, subTexel.x);
 	float paintAmountFinal	= mix(paintAmountHor0, paintAmountHor1, subTexel.y);
 
-	float noiseScale			= 8.0f;
-	float deltaNoise			= 0.001f;
-	float h0 					= snoise(noiseScale * (position));
-	float h_u 					= snoise(noiseScale * (position + deltaNoise * tangent));
-	float h_v 					= snoise(noiseScale * (position + deltaNoise * tangent));
-	float dh_u					= (h0 - h_u);
-	float dh_v					= (h0 - h_v);
-	vec3 grad_h					= vec3(dh_u, dh_v, sqrt(1.0f - (dh_u * dh_u) - (dh_v * dh_v)));
-	vec3 paintNormal			= normalize(grad_h);
+	float h0 					= snoise(PAINT_NOISE_SCALE * (position));
+	float h_u 					= snoise(PAINT_NOISE_SCALE * (position + PAINT_DELTA_NOISE * tangent));
+	float h_v 					= snoise(PAINT_NOISE_SCALE * (position + PAINT_DELTA_NOISE * tangent));
+	vec2 grad_h					= vec2(h0 - h_u, h0 - h_v);
+	vec3 paintNormal			= normalize(vec3(PAINT_BUMPINESS * grad_h, sqrt(1.0f - (grad_h.x * grad_h.x) - (grad_h.y * grad_h.y))));
 	vec3 noPaintNormal00		= normalize(vec3(-1.0f,  1.0f, 1.0f));
 	vec3 noPaintNormal10		= normalize(vec3( 1.0f,  1.0f, 1.0f));
 	vec3 noPaintNormal01		= normalize(vec3(-1.0f, -1.0f, 1.0f));
@@ -161,7 +158,7 @@ SPaintDescription InterpolatePaint(in mat3 TBN, in vec3 position, in vec3 tangen
 
 	paintDescription.Normal			= combinedNormal;
 	paintDescription.Albedo 		= paintColorFinal;
-	paintDescription.Roughness 		= 0.01f;
+	paintDescription.Roughness 		= PAINT_ROUGHNESS;
 	paintDescription.Interpolation	= paintAmountFinal;
 
 	return paintDescription;

--- a/Assets/Shaders/RayTracing/Raygen.rgen
+++ b/Assets/Shaders/RayTracing/Raygen.rgen
@@ -99,8 +99,7 @@ void main()
     {
         imageStore(u_RadianceOut, pixelCoords, vec4(0.0f));
     }
-
-    if (shadeOutput)
+    else if (shadeOutput)
     {
         SLightsBuffer lightBuffer = b_LightsBuffer.val;
 

--- a/Assets/Shaders/Sampling.glsl
+++ b/Assets/Shaders/Sampling.glsl
@@ -1,0 +1,143 @@
+#include "Defines.glsl"
+
+/*
+    Non-Uniform Sample Generators
+*/
+
+float RadicalInverse_VdC(uint bits)
+{
+	bits = (bits << 16u) | (bits >> 16u);
+	bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+	bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+	bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+	bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+	return float(bits) * 2.3283064365386963e-10; // / 0x100000000
+}
+
+vec2 Hammersley(uint i, uint N)
+{
+	return vec2(float(i) / float(N), RadicalInverse_VdC(i));
+}
+
+/*
+    Shape Sample Functions
+*/
+
+float SphereSurfaceArea(float radius)
+{
+	return FOUR_PI * radius * radius;
+}
+
+float DiskSurfaceArea(float radius)
+{
+	return PI * radius * radius;
+}
+
+float QuadSurfaceArea(float radiusX, float radiusY)
+{
+	return 4 * radiusX * radiusY;
+}
+
+vec2 ConcentricSampleDisk(vec2 u)
+{
+	vec2 uOffset = u * 2.0f - 1.0f;
+	if (dot(uOffset, uOffset) == 0.0f) return vec2(0.0f);
+
+	float r     = 0.0f;
+	float theta = 0.0f;
+
+	if (abs(uOffset.x) > abs(uOffset.y))
+	{
+		r = uOffset.x;
+		theta = PI_OVER_FOUR * uOffset.y / uOffset.x;
+	}
+	else
+	{
+		r = uOffset.y;
+		theta = PI_OVER_TWO - PI_OVER_FOUR * uOffset.x / uOffset.y;
+	}
+
+	return r * vec2(cos(theta), sin(theta));
+}
+
+//These functions assume that the untransformed quad lies in the xz-plane with normal pointing in positive y direction and has a radius of 1 (side length of 2)
+float QuadPDF(mat4 transform)
+{
+	return 1.0f / QuadSurfaceArea(length(transform[0].xyz), length(transform[2].xyz));
+}
+
+vec3 QuadNormal(mat4 transform)
+{
+	return (transform * vec4(0.0f, 1.0f, 0.0f, 0.0f)).xyz;
+}
+
+SShapeSample SampleQuad(mat4 transform, vec2 u)
+{
+	SShapeSample shapeSample;
+
+	u = u * 2.0f - 1.0f;
+	shapeSample.Position 	= (transform * vec4(u.x, 0.0f, u.y, 1.0f)).xyz; //Assume quad thickiness of 0.0f
+	shapeSample.Normal		= QuadNormal(transform);
+	shapeSample.PDF			= QuadPDF(transform);
+
+	return shapeSample;
+}
+
+SShapeSample SampleQuad(vec3 position, vec3 direction, float radius, vec2 u)
+{
+	SShapeSample shapeSample;
+
+	direction = normalize(direction);
+
+	vec3 tangent;
+	vec3 bitangent;
+	CreateCoordinateSystem(direction, tangent, bitangent);
+
+	u = u * 2.0f - 1.0f;
+	shapeSample.Position 	= position + radius * (u.x * tangent + u.y * bitangent); //Assume quad thickiness of 0.0f
+	shapeSample.Normal		= direction;
+	shapeSample.PDF			= 1.0f / QuadSurfaceArea(radius, radius);
+
+	return shapeSample;
+}
+
+SShapeSample SampleDisk(vec3 position, vec3 direction, float radius, vec2 u)
+{
+	SShapeSample shapeSample;
+
+	direction = normalize(direction);
+
+	vec3 tangent;
+	vec3 bitangent;
+	CreateCoordinateSystem(direction, tangent, bitangent);
+
+	vec2 pd = ConcentricSampleDisk(u);
+	shapeSample.Position 	= position + radius * (pd.x * tangent + pd.y * bitangent); //Assume disk thickiness of 0.0f
+	shapeSample.Normal		= direction;
+	shapeSample.PDF			= 1.0f / DiskSurfaceArea(radius);
+
+	return shapeSample;
+}
+
+SShapeSample UniformSampleUnitSphere(vec2 u)
+{
+	SShapeSample shapeSample;
+
+	float z 	= 1.0f - 2.0f * u.x;
+	float r 	= sqrt(max(0.0f, 1.0f - z * z));
+	float phi 	= 2.0f * PI * u.y;
+
+	shapeSample.Position 	= vec3(r * cos(phi), r * sin(phi), z);
+	shapeSample.Normal	 	= normalize(shapeSample.Position);
+	shapeSample.PDF 		= 1.0f / FOUR_PI;
+	return shapeSample;
+}
+
+SShapeSample UniformSampleSphereSurface(vec3 position, float radius, vec2 u)
+{
+	SShapeSample shapeSample = UniformSampleUnitSphere(u);
+
+	shapeSample.Position	 = position + radius * shapeSample.Normal; //The normal as returned from UniformSampleUnitSphere can be interpreted as a point on the surface
+	shapeSample.PDF 		 /= (radius * radius);
+	return shapeSample;
+}

--- a/CrazyCanvas/Source/World/LevelObjectCreator.cpp
+++ b/CrazyCanvas/Source/World/LevelObjectCreator.cpp
@@ -197,13 +197,21 @@ LambdaEngine::Entity LevelObjectCreator::CreateStaticGeometry(const LambdaEngine
 {
 	using namespace LambdaEngine;
 
-	const Mesh* pMesh = ResourceManager::GetMesh(meshComponent.MeshGUID);
+	Mesh* pMesh = ResourceManager::GetMesh(meshComponent.MeshGUID);
+
+	float32 maxDim = glm::max<float32>(
+		pMesh->DefaultScale.x * pMesh->BoundingBox.Dimensions.x,
+		glm::max<float32>(
+			pMesh->DefaultScale.y * pMesh->BoundingBox.Dimensions.y,
+			pMesh->DefaultScale.z * pMesh->BoundingBox.Dimensions.z));
+
+	uint32 meshPaintSize = uint32(maxDim * 384.0f);
 
 	ECSCore* pECS					= ECSCore::GetInstance();
 	PhysicsSystem* pPhysicsSystem	= PhysicsSystem::GetInstance();
 
 	Entity entity = pECS->CreateEntity();
-	pECS->AddComponent<MeshPaintComponent>(entity, MeshPaint::CreateComponent(entity, "GeometryUnwrappedTexture", 4096, 4096));
+	pECS->AddComponent<MeshPaintComponent>(entity, MeshPaint::CreateComponent(entity, "GeometryUnwrappedTexture", meshPaintSize, meshPaintSize));
 	pECS->AddComponent<MeshComponent>(entity, meshComponent);
 	const CollisionCreateInfo collisionCreateInfo =
 	{
@@ -216,7 +224,7 @@ LambdaEngine::Entity LevelObjectCreator::CreateStaticGeometry(const LambdaEngine
 			{
 				/* ShapeType */			EShapeType::SIMULATION,
 				/* GeometryType */		EGeometryType::MESH,
-				/* Geometry */			{ .pMesh = ResourceManager::GetMesh(meshComponent.MeshGUID) },
+				/* Geometry */			{ .pMesh = pMesh },
 				/* CollisionGroup */	FCollisionGroup::COLLISION_GROUP_STATIC,
 				/* CollisionMask */		~FCollisionGroup::COLLISION_GROUP_STATIC, // Collide with any non-static object
 			},


### PR DESCRIPTION
## Purpose
  - Paint has previously looked very flat.
  - The edges of paint has also been very pixelated and flat.

## Changes
 - Changes have been made to GeomMeshPaint.frag and PrimaryClosestHit.rchit, a Paint.glsl file has also been added for Paint settings.
 - Normals are calculated by approximating the gradient of a Noise function based on World position (currently Simplex noise).
 - The paint edges are handled with bilinear interpolation by sampling the corners around each paint texel.