### PR TITLE
Moving AS(S) building

### DIFF
--- a/Assets/RenderGraphs/RT_DEFERRED_PBR.lrg
+++ b/Assets/RenderGraphs/RT_DEFERRED_PBR.lrg
@@ -828,6 +828,54 @@
             ]
         },
         {
+            "name": "FXAA",
+            "type": "GRAPHICS",
+            "custom_renderer": false,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "EVERY",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "RELATIVE",
+            "y_dim_type": "RELATIVE",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 1.0,
+            "y_dim_var": 1.0,
+            "z_dim_var": 1.0,
+            "draw_type": "FULLSCREEN_QUAD",
+            "depth_test_enabled": false,
+            "alpha_blend_enabled": false,
+            "cull_mode": "CULL_MODE_NONE",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
+            "shaders": {
+                "task_shader": "",
+                "mesh_shader": "",
+                "vertex_shader": "/Helpers\\FullscreenQuad.vert",
+                "geometry_shader": "",
+                "hull_shader": "",
+                "domain_shader": "",
+                "pixel_shader": "/PostProcess\\FXAA.frag"
+            },
+            "resource_states": [
+                {
+                    "name": "INTERMEDIATE_OUTPUT_IMAGE",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "COMBINED_SAMPLER",
+                    "src_stage": "PARTICLE_COMBINE_PASS"
+                },
+                {
+                    "name": "BACK_BUFFER_TEXTURE",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": ""
+                }
+            ]
+        },
+        {
             "name": "DIRL_SHADOWMAP",
             "type": "GRAPHICS",
             "custom_renderer": false,
@@ -944,54 +992,6 @@
                     "draw_args_exclude_mask": 0,
                     "binding_type": "ATTACHMENT",
                     "src_stage": "PLAYER_PASS"
-                }
-            ]
-        },
-        {
-            "name": "FXAA",
-            "type": "GRAPHICS",
-            "custom_renderer": false,
-            "allow_overriding_of_binding_types": false,
-            "trigger_type": "EVERY",
-            "frame_delay": 0,
-            "frame_offset": 0,
-            "x_dim_type": "RELATIVE",
-            "y_dim_type": "RELATIVE",
-            "z_dim_type": "CONSTANT",
-            "x_dim_var": 1.0,
-            "y_dim_var": 1.0,
-            "z_dim_var": 1.0,
-            "draw_type": "FULLSCREEN_QUAD",
-            "depth_test_enabled": false,
-            "alpha_blend_enabled": false,
-            "cull_mode": "CULL_MODE_NONE",
-            "polygon_mode": "POLYGON_MODE_FILL",
-            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
-            "shaders": {
-                "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "/Helpers\\FullscreenQuad.vert",
-                "geometry_shader": "",
-                "hull_shader": "",
-                "domain_shader": "",
-                "pixel_shader": "/PostProcess\\FXAA.frag"
-            },
-            "resource_states": [
-                {
-                    "name": "INTERMEDIATE_OUTPUT_IMAGE",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "COMBINED_SAMPLER",
-                    "src_stage": "PARTICLE_COMBINE_PASS"
-                },
-                {
-                    "name": "BACK_BUFFER_TEXTURE",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": ""
                 }
             ]
         },
@@ -1201,7 +1201,7 @@
                     "draw_args_include_mask": 1,
                     "draw_args_exclude_mask": 0,
                     "binding_type": "ACCELERATION_STRUCTURE",
-                    "src_stage": "EXTERNAL_RESOURCES"
+                    "src_stage": "AS_BUILDER"
                 },
                 {
                     "name": "PER_FRAME_BUFFER",
@@ -1446,118 +1446,6 @@
             ]
         },
         {
-            "name": "RENDER_STAGE_PARTICLE_RENDER",
-            "type": "GRAPHICS",
-            "custom_renderer": true,
-            "allow_overriding_of_binding_types": false,
-            "trigger_type": "EVERY",
-            "frame_delay": 0,
-            "frame_offset": 0,
-            "x_dim_type": "RELATIVE",
-            "y_dim_type": "RELATIVE",
-            "z_dim_type": "CONSTANT",
-            "x_dim_var": 1.0,
-            "y_dim_var": 1.0,
-            "z_dim_var": 1.0,
-            "draw_type": "FULLSCREEN_QUAD",
-            "depth_test_enabled": true,
-            "alpha_blend_enabled": false,
-            "cull_mode": "CULL_MODE_BACK",
-            "polygon_mode": "POLYGON_MODE_FILL",
-            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
-            "shaders": {
-                "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "",
-                "geometry_shader": "",
-                "hull_shader": "",
-                "domain_shader": "",
-                "pixel_shader": ""
-            },
-            "resource_states": [
-                {
-                    "name": "SCENE_PARTICLE_INDIRECT_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_INDEX_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "PER_FRAME_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "CONSTANT_BUFFER",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_VERTEX_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_INSTANCE_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "RENDER_STAGE_PARTICLE_UPDATE"
-                },
-                {
-                    "name": "SCENE_EMITTER_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_EMITTER_INDEX_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_ATLAS_INFO_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "CONSTANT_BUFFER",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "PARTICLE_IMAGE",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": ""
-                },
-                {
-                    "name": "G_BUFFER_DEPTH_STENCIL",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": "PLAYER_PASS"
-                }
-            ]
-        },
-        {
             "name": "DEFERRED_GEOMETRY_PASS_MESH_PAINT",
             "type": "GRAPHICS",
             "custom_renderer": false,
@@ -1694,6 +1582,118 @@
             ]
         },
         {
+            "name": "RENDER_STAGE_PARTICLE_RENDER",
+            "type": "GRAPHICS",
+            "custom_renderer": true,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "EVERY",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "RELATIVE",
+            "y_dim_type": "RELATIVE",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 1.0,
+            "y_dim_var": 1.0,
+            "z_dim_var": 1.0,
+            "draw_type": "FULLSCREEN_QUAD",
+            "depth_test_enabled": true,
+            "alpha_blend_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
+            "shaders": {
+                "task_shader": "",
+                "mesh_shader": "",
+                "vertex_shader": "",
+                "geometry_shader": "",
+                "hull_shader": "",
+                "domain_shader": "",
+                "pixel_shader": ""
+            },
+            "resource_states": [
+                {
+                    "name": "SCENE_PARTICLE_INDIRECT_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_INDEX_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "PER_FRAME_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "CONSTANT_BUFFER",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_VERTEX_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_INSTANCE_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "RENDER_STAGE_PARTICLE_UPDATE"
+                },
+                {
+                    "name": "SCENE_EMITTER_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_EMITTER_INDEX_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_ATLAS_INFO_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "CONSTANT_BUFFER",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "PARTICLE_IMAGE",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": ""
+                },
+                {
+                    "name": "G_BUFFER_DEPTH_STENCIL",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": "PLAYER_PASS"
+                }
+            ]
+        },
+        {
             "name": "PLAYER_PASS",
             "type": "GRAPHICS",
             "custom_renderer": true,
@@ -1793,6 +1793,34 @@
                     "draw_args_include_mask": 1,
                     "draw_args_exclude_mask": 0,
                     "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                }
+            ]
+        },
+        {
+            "name": "AS_BUILDER",
+            "type": "COMPUTE",
+            "custom_renderer": true,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "EVERY",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "RELATIVE",
+            "y_dim_type": "RELATIVE",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 1.0,
+            "y_dim_var": 1.0,
+            "z_dim_var": 1.0,
+            "shaders": {
+                "shader": ""
+            },
+            "resource_states": [
+                {
+                    "name": "SCENE_TLAS",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_RW",
                     "src_stage": "EXTERNAL_RESOURCES"
                 }
             ]

--- a/Assets/RenderGraphs/RT_DEFERRED_PBR_MESH.lrg
+++ b/Assets/RenderGraphs/RT_DEFERRED_PBR_MESH.lrg
@@ -828,6 +828,54 @@
             ]
         },
         {
+            "name": "FXAA",
+            "type": "GRAPHICS",
+            "custom_renderer": false,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "EVERY",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "RELATIVE",
+            "y_dim_type": "RELATIVE",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 1.0,
+            "y_dim_var": 1.0,
+            "z_dim_var": 1.0,
+            "draw_type": "FULLSCREEN_QUAD",
+            "depth_test_enabled": false,
+            "alpha_blend_enabled": false,
+            "cull_mode": "CULL_MODE_NONE",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
+            "shaders": {
+                "task_shader": "",
+                "mesh_shader": "",
+                "vertex_shader": "/Helpers\\FullscreenQuad.vert",
+                "geometry_shader": "",
+                "hull_shader": "",
+                "domain_shader": "",
+                "pixel_shader": "/PostProcess\\FXAA.frag"
+            },
+            "resource_states": [
+                {
+                    "name": "INTERMEDIATE_OUTPUT_IMAGE",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "COMBINED_SAMPLER",
+                    "src_stage": "PARTICLE_COMBINE_PASS"
+                },
+                {
+                    "name": "BACK_BUFFER_TEXTURE",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": ""
+                }
+            ]
+        },
+        {
             "name": "SKYBOX_PASS",
             "type": "GRAPHICS",
             "custom_renderer": false,
@@ -939,54 +987,6 @@
                 },
                 {
                     "name": "DIRL_SHADOWMAP",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": ""
-                }
-            ]
-        },
-        {
-            "name": "FXAA",
-            "type": "GRAPHICS",
-            "custom_renderer": false,
-            "allow_overriding_of_binding_types": false,
-            "trigger_type": "EVERY",
-            "frame_delay": 0,
-            "frame_offset": 0,
-            "x_dim_type": "RELATIVE",
-            "y_dim_type": "RELATIVE",
-            "z_dim_type": "CONSTANT",
-            "x_dim_var": 1.0,
-            "y_dim_var": 1.0,
-            "z_dim_var": 1.0,
-            "draw_type": "FULLSCREEN_QUAD",
-            "depth_test_enabled": false,
-            "alpha_blend_enabled": false,
-            "cull_mode": "CULL_MODE_NONE",
-            "polygon_mode": "POLYGON_MODE_FILL",
-            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
-            "shaders": {
-                "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "/Helpers\\FullscreenQuad.vert",
-                "geometry_shader": "",
-                "hull_shader": "",
-                "domain_shader": "",
-                "pixel_shader": "/PostProcess\\FXAA.frag"
-            },
-            "resource_states": [
-                {
-                    "name": "INTERMEDIATE_OUTPUT_IMAGE",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "COMBINED_SAMPLER",
-                    "src_stage": "PARTICLE_COMBINE_PASS"
-                },
-                {
-                    "name": "BACK_BUFFER_TEXTURE",
                     "removable": true,
                     "draw_args_include_mask": 1,
                     "draw_args_exclude_mask": 0,
@@ -1201,7 +1201,7 @@
                     "draw_args_include_mask": 1,
                     "draw_args_exclude_mask": 0,
                     "binding_type": "ACCELERATION_STRUCTURE",
-                    "src_stage": "EXTERNAL_RESOURCES"
+                    "src_stage": "AS_BUILDER"
                 },
                 {
                     "name": "PER_FRAME_BUFFER",
@@ -1446,6 +1446,118 @@
             ]
         },
         {
+            "name": "RENDER_STAGE_PARTICLE_RENDER",
+            "type": "GRAPHICS",
+            "custom_renderer": true,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "EVERY",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "RELATIVE",
+            "y_dim_type": "RELATIVE",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 1.0,
+            "y_dim_var": 1.0,
+            "z_dim_var": 1.0,
+            "draw_type": "FULLSCREEN_QUAD",
+            "depth_test_enabled": true,
+            "alpha_blend_enabled": false,
+            "cull_mode": "CULL_MODE_BACK",
+            "polygon_mode": "POLYGON_MODE_FILL",
+            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
+            "shaders": {
+                "task_shader": "",
+                "mesh_shader": "",
+                "vertex_shader": "",
+                "geometry_shader": "",
+                "hull_shader": "",
+                "domain_shader": "",
+                "pixel_shader": ""
+            },
+            "resource_states": [
+                {
+                    "name": "SCENE_PARTICLE_INDIRECT_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_INDEX_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "PER_FRAME_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "CONSTANT_BUFFER",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_VERTEX_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_INSTANCE_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "RENDER_STAGE_PARTICLE_UPDATE"
+                },
+                {
+                    "name": "SCENE_EMITTER_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_EMITTER_INDEX_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_R",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "SCENE_PARTICLE_ATLAS_INFO_BUFFER",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "CONSTANT_BUFFER",
+                    "src_stage": "EXTERNAL_RESOURCES"
+                },
+                {
+                    "name": "PARTICLE_IMAGE",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": ""
+                },
+                {
+                    "name": "G_BUFFER_DEPTH_STENCIL",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "ATTACHMENT",
+                    "src_stage": "PLAYER_PASS"
+                }
+            ]
+        },
+        {
             "name": "DEFERRED_GEOMETRY_PASS_MESH_PAINT",
             "type": "GRAPHICS",
             "custom_renderer": false,
@@ -1578,118 +1690,6 @@
                     "draw_args_exclude_mask": 0,
                     "binding_type": "ATTACHMENT",
                     "src_stage": "DEFERRED_GEOMETRY_PASS"
-                }
-            ]
-        },
-        {
-            "name": "RENDER_STAGE_PARTICLE_RENDER",
-            "type": "GRAPHICS",
-            "custom_renderer": true,
-            "allow_overriding_of_binding_types": false,
-            "trigger_type": "EVERY",
-            "frame_delay": 0,
-            "frame_offset": 0,
-            "x_dim_type": "RELATIVE",
-            "y_dim_type": "RELATIVE",
-            "z_dim_type": "CONSTANT",
-            "x_dim_var": 1.0,
-            "y_dim_var": 1.0,
-            "z_dim_var": 1.0,
-            "draw_type": "FULLSCREEN_QUAD",
-            "depth_test_enabled": true,
-            "alpha_blend_enabled": false,
-            "cull_mode": "CULL_MODE_BACK",
-            "polygon_mode": "POLYGON_MODE_FILL",
-            "primitive_topology": "PRIMITIVE_TOPOLOGY_TRIANGLE_LIST",
-            "shaders": {
-                "task_shader": "",
-                "mesh_shader": "",
-                "vertex_shader": "",
-                "geometry_shader": "",
-                "hull_shader": "",
-                "domain_shader": "",
-                "pixel_shader": ""
-            },
-            "resource_states": [
-                {
-                    "name": "SCENE_PARTICLE_INDIRECT_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_INDEX_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "PER_FRAME_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "CONSTANT_BUFFER",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_VERTEX_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_INSTANCE_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "RENDER_STAGE_PARTICLE_UPDATE"
-                },
-                {
-                    "name": "SCENE_EMITTER_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_EMITTER_INDEX_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "UNORDERED_ACCESS_R",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "SCENE_PARTICLE_ATLAS_INFO_BUFFER",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "CONSTANT_BUFFER",
-                    "src_stage": "EXTERNAL_RESOURCES"
-                },
-                {
-                    "name": "PARTICLE_IMAGE",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": ""
-                },
-                {
-                    "name": "G_BUFFER_DEPTH_STENCIL",
-                    "removable": true,
-                    "draw_args_include_mask": 1,
-                    "draw_args_exclude_mask": 0,
-                    "binding_type": "ATTACHMENT",
-                    "src_stage": "PLAYER_PASS"
                 }
             ]
         },
@@ -1926,6 +1926,34 @@
                     "draw_args_exclude_mask": 0,
                     "binding_type": "ATTACHMENT",
                     "src_stage": "SKYBOX_PASS"
+                }
+            ]
+        },
+        {
+            "name": "AS_BUILDER",
+            "type": "COMPUTE",
+            "custom_renderer": true,
+            "allow_overriding_of_binding_types": false,
+            "trigger_type": "EVERY",
+            "frame_delay": 0,
+            "frame_offset": 0,
+            "x_dim_type": "RELATIVE",
+            "y_dim_type": "RELATIVE",
+            "z_dim_type": "CONSTANT",
+            "x_dim_var": 1.0,
+            "y_dim_var": 1.0,
+            "z_dim_var": 1.0,
+            "shaders": {
+                "shader": ""
+            },
+            "resource_states": [
+                {
+                    "name": "SCENE_TLAS",
+                    "removable": true,
+                    "draw_args_include_mask": 1,
+                    "draw_args_exclude_mask": 0,
+                    "binding_type": "UNORDERED_ACCESS_RW",
+                    "src_stage": "EXTERNAL_RESOURCES"
                 }
             ]
         }

--- a/CrazyCanvas/Include/ECS/Systems/Player/WeaponSystem.h
+++ b/CrazyCanvas/Include/ECS/Systems/Player/WeaponSystem.h
@@ -34,9 +34,16 @@ inline LambdaEngine::TArray<LambdaEngine::ComponentAccess> GetFireProjectileComp
 	using namespace LambdaEngine;
 	return
 	{
-		{ RW, PositionComponent::Type()}, { RW, ScaleComponent::Type()}, { RW, RotationComponent::Type() },
-		{ RW, VelocityComponent::Type()}, { RW, WeaponComponent::Type()}, { RW, TeamComponent::Type() },
-		{ RW, ProjectileComponent::Type()}, { RW, DynamicCollisionComponent::Type() }, { RW, MeshComponent::Type() }
+		{ RW, PositionComponent::Type()},
+		{ RW, ScaleComponent::Type()},
+		{ RW, RotationComponent::Type() },
+		{ RW, VelocityComponent::Type()},
+		{ RW, WeaponComponent::Type()},
+		{ RW, TeamComponent::Type() },
+		{ RW, ProjectileComponent::Type()},
+		{ RW, DynamicCollisionComponent::Type() },
+		{ RW, MeshComponent::Type() },
+		{ RW, ParticleEmitterComponent::Type() },
 	};
 }
 

--- a/CrazyCanvas/Include/RenderStages/PlayerRenderer.h
+++ b/CrazyCanvas/Include/RenderStages/PlayerRenderer.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Rendering/RenderGraphTypes.h"
-#include "Rendering/ICustomRenderer.h"
+#include "Rendering/CustomRenderer.h"
 #include "Rendering/Core/API/DescriptorCache.h"
 
 #define MAX_PLAYERS_IN_MATCH 10
@@ -30,7 +30,7 @@ namespace LambdaEngine
 	using ReleaseFrame = uint32;
 	using DescriptorSetIndex = uint32;
 
-	class PlayerRenderer : public ICustomRenderer
+	class PlayerRenderer : public CustomRenderer
 	{
 	public:
 		DECL_REMOVE_COPY(PlayerRenderer);
@@ -43,16 +43,9 @@ namespace LambdaEngine
 
 		virtual bool RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc) override final;
 
-		void PrepareTextureUpdates(const TArray<UpdateData>& textureIndices);
-
-		virtual void PreBuffersDescriptorSetWrite()		override final;
-		virtual void PreTexturesDescriptorSetWrite()	override final;
-
-
 		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const* ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
 		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
 		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)  override final;
 
 		virtual void Render(
@@ -62,8 +55,8 @@ namespace LambdaEngine
 			CommandList** ppSecondaryExecutionStage,
 			bool Sleeping)	override final;
 
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
 
 		virtual const String& GetName() const override final
 		{

--- a/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
+++ b/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
@@ -105,21 +105,6 @@ namespace LambdaEngine
 		return true;
 	}
 
-	void PlayerRenderer::PrepareTextureUpdates(const TArray<UpdateData>& textureIndices)
-	{
-		UNREFERENCED_VARIABLE(textureIndices);
-
-	}
-
-	void PlayerRenderer::PreBuffersDescriptorSetWrite()
-	{
-		// called before removing
-	}
-
-	void PlayerRenderer::PreTexturesDescriptorSetWrite()
-	{
-	}
-
 	void PlayerRenderer::Update(LambdaEngine::Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
 	{
 		UNREFERENCED_VARIABLE(delta);
@@ -278,12 +263,6 @@ namespace LambdaEngine
 			}
 		}
 
-	}
-
-	void PlayerRenderer::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
 	}
 
 	void PlayerRenderer::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)

--- a/LambdaEngine/Include/GUI/Core/GUIRenderer.h
+++ b/LambdaEngine/Include/GUI/Core/GUIRenderer.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Rendering/ICustomRenderer.h"
+#include "Rendering/CustomRenderer.h"
 #include "Rendering/RenderGraphTypes.h"
 
 #include "Rendering/Core/API/CommandList.h"
@@ -15,7 +15,7 @@ namespace LambdaEngine
 	class GUIRenderTarget;
 	class GUITexture;
 
-	class GUIRenderer : public Noesis::RenderDevice, public ICustomRenderer
+	class GUIRenderer : public Noesis::RenderDevice, public CustomRenderer
 	{
 		struct GUIParamsData
 		{
@@ -92,13 +92,7 @@ namespace LambdaEngine
 		//ICustomRenderer
 		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
 
-		virtual void PreBuffersDescriptorSetWrite()		override final;
-		virtual void PreTexturesDescriptorSetWrite()	override final;
-
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const* ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
-		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const * ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
-		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count) override final;
 
 		virtual void Render(
 			uint32 modFrameIndex, 
@@ -119,8 +113,8 @@ namespace LambdaEngine
 			return deviceCaps;
 		}
 
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; };
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; };
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; };
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; };
 
 		FORCEINLINE virtual const String& GetName() const override final 
 		{ 

--- a/LambdaEngine/Include/Rendering/Core/API/AccelerationStructure.h
+++ b/LambdaEngine/Include/Rendering/Core/API/AccelerationStructure.h
@@ -51,7 +51,7 @@ namespace LambdaEngine
 		*	return -	Returns a valid 64-bit address on success, otherwise zero. Returns zero on systems that
 		*				does not support deviceaddresses.
 		*/
-		virtual uint64 GetDeviceAdress() const
+		virtual uint64 GetDeviceAddress() const
 		{
 			return 0ULL;
 		}

--- a/LambdaEngine/Include/Rendering/Core/API/AccelerationStructure.h
+++ b/LambdaEngine/Include/Rendering/Core/API/AccelerationStructure.h
@@ -30,12 +30,12 @@ namespace LambdaEngine
 
 	struct AccelerationStructureInstance
 	{
-		glm::mat3x4						Transform;
-		uint32							CustomIndex			: 24;
-		uint32							Mask				: 8;
-		uint32							SBTRecordOffset		: 24;
-		FAccelerationStructureFlags		Flags				: 8;
-		uint64							AccelerationStructureAddress;
+		glm::mat3x4								Transform;
+		uint32									CustomIndex			: 24;
+		uint32									Mask				: 8;
+		uint32									SBTRecordOffset		: 24;
+		FAccelerationStructureInstanceFlags		Flags				: 8;
+		uint64									AccelerationStructureAddress;
 	};
 
 	/*

--- a/LambdaEngine/Include/Rendering/Core/API/Buffer.h
+++ b/LambdaEngine/Include/Rendering/Core/API/Buffer.h
@@ -38,7 +38,7 @@ namespace LambdaEngine
 		* Returns this resource's address on the device
 		*	return -  Returns a valid 64-bit address on success, otherwise zero. Returns zero on systems that does not support deviceaddresses.
 		*/
-		virtual uint64 GetDeviceAdress() const
+		virtual uint64 GetDeviceAddress() const
 		{
 			return 0;
 		}

--- a/LambdaEngine/Include/Rendering/Core/Vulkan/AccelerationStructureVK.h
+++ b/LambdaEngine/Include/Rendering/Core/Vulkan/AccelerationStructureVK.h
@@ -36,7 +36,7 @@ namespace LambdaEngine
 		virtual void SetName(const String& name) override final;
 
 		// AccelerationStructure interface
-		FORCEINLINE virtual uint64 GetDeviceAdress() const override final
+		FORCEINLINE virtual uint64 GetDeviceAddress() const override final
 		{
 			return m_AccelerationStructureDeviceAddress;
 		}

--- a/LambdaEngine/Include/Rendering/Core/Vulkan/BufferVK.h
+++ b/LambdaEngine/Include/Rendering/Core/Vulkan/BufferVK.h
@@ -33,7 +33,7 @@ namespace LambdaEngine
 		virtual void* Map() override final;
 		virtual void Unmap() override final;
 		
-		virtual uint64 GetDeviceAdress() const override final;
+		virtual uint64 GetDeviceAddress() const override final;
 		virtual uint64 GetAlignmentRequirement() const override final;
 
 		inline virtual uint64 GetHandle() const override final

--- a/LambdaEngine/Include/Rendering/CustomRenderer.h
+++ b/LambdaEngine/Include/Rendering/CustomRenderer.h
@@ -9,6 +9,7 @@ namespace LambdaEngine
 {
 	struct RenderPassAttachmentDesc;
 
+	class RenderGraph;
 	class CommandAllocator;
 	class CommandList;
 	class TextureView;
@@ -18,16 +19,17 @@ namespace LambdaEngine
 
 	struct CustomRendererRenderGraphInitDesc
 	{
+		RenderGraph*				pRenderGraph					= nullptr;
 		uint32						BackBufferCount					= 0;
 		RenderPassAttachmentDesc*	pColorAttachmentDesc			= nullptr;
 		uint32						ColorAttachmentCount			= 0;
 		RenderPassAttachmentDesc*	pDepthStencilAttachmentDesc		= nullptr;
 	};
 
-	class ICustomRenderer
+	class CustomRenderer
 	{
 	public:
-		DECL_INTERFACE(ICustomRenderer);
+		DECL_INTERFACE(CustomRenderer);
 
 		/*
 		* Called once by RenderSystem, required arguments which be passed in constructor.
@@ -40,26 +42,23 @@ namespace LambdaEngine
 		/*
 		* Called every frame, can be used for internal resource handling in custom renderers
 		*/
-		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) = 0;
+		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
+		{
+			UNREFERENCED_VARIABLE(delta);
+			UNREFERENCED_VARIABLE(modFrameIndex);
+			UNREFERENCED_VARIABLE(backBufferIndex);
+		}
 
 		/*
 		* Called before when a/multiple buffer descriptor write(s) are discovered.
 		* Allows the callee to recreate Descriptor Sets if needed.
 		*/
-		virtual void PreBuffersDescriptorSetWrite()		= 0;
+		virtual void PreBuffersDescriptorSetWrite() {}
 		/*
 		* Called before when a/multiple texture descriptor write(s) are discovered.
 		* Allows the callee to recreate Descriptor Sets if needed.
 		*/
-		virtual void PreTexturesDescriptorSetWrite()	= 0;
-
-		/*
-		* Called when the Render Graph discovers a parameter update for the custom renderer.
-		*	pData - The data passed to RenderGraph::UpdateRenderStageParameters
-		*/
-		//virtual void UpdateParameters(void* pData)		= 0;
-
-		//virtual void UpdatePushConstants(void* pData, uint32 dataSize)	= 0;
+		virtual void PreTexturesDescriptorSetWrite() {}
 
 		/*
 		* Called when a ResourceUpdate is scheduled in the RenderGraph for the given texture
@@ -70,7 +69,21 @@ namespace LambdaEngine
 		*	subImageCount - Size of ppPerSubImageTextureViews, guaranteed to be an integer multiple of imageCount
 		*	backBufferBound - Describes if subresources are bound in array or 1 / Back buffer
 		*/
-		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const * ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound)	= 0;
+		virtual void UpdateTextureResource(
+			const String& resourceName,
+			const TextureView* const* ppPerImageTextureViews,
+			const TextureView* const* ppPerSubImageTextureViews,
+			uint32 imageCount,
+			uint32 subImageCount,
+			bool backBufferBound)
+		{
+			UNREFERENCED_VARIABLE(resourceName);
+			UNREFERENCED_VARIABLE(ppPerImageTextureViews);
+			UNREFERENCED_VARIABLE(ppPerSubImageTextureViews);
+			UNREFERENCED_VARIABLE(imageCount);
+			UNREFERENCED_VARIABLE(subImageCount);
+			UNREFERENCED_VARIABLE(backBufferBound);
+		}
 
 		/*
 		* Called when a ResourceUpdate is scheduled in the RenderGraph for the given buffer
@@ -81,22 +94,49 @@ namespace LambdaEngine
 		*	count - size of ppBuffers, pOffsets and pSizesInBytes
 		*	backBufferBound - Describes if subresources are bound in array or 1 / Back buffer
 		*/
-		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const * ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound)	= 0;
+		virtual void UpdateBufferResource(
+			const String& resourceName,
+			const Buffer* const* ppBuffers,
+			uint64* pOffsets,
+			uint64* pSizesInBytes,
+			uint32 count,
+			bool backBufferBound)
+		{
+			UNREFERENCED_VARIABLE(resourceName);
+			UNREFERENCED_VARIABLE(ppBuffers);
+			UNREFERENCED_VARIABLE(pOffsets);
+			UNREFERENCED_VARIABLE(pSizesInBytes);
+			UNREFERENCED_VARIABLE(count);
+			UNREFERENCED_VARIABLE(backBufferBound);
+		}
 
 		/*
 		* Called when a ResourceUpdate is scheduled in the RenderGraph for the given acceleration structure
 		*	resourceName - Name of the resource being updated
 		*	pAccelerationStructure - The acceleration structure that represent the update data
 		*/
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)	= 0;
+		virtual void UpdateAccelerationStructureResource(
+			const String& resourceName,
+			const AccelerationStructure* pAccelerationStructure)
+		{
+			UNREFERENCED_VARIABLE(resourceName);
+			UNREFERENCED_VARIABLE(pAccelerationStructure);
+		}
 
 		/*
 		* Called when a ResourceUpdate is scheduled in the RenderGraph for the given draw arg
 		*	resourceName - Name of the resource being updated
 		*	drawArgs - The draw args that represent the update data
 		*/
-		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count) = 0;
-
+		virtual void UpdateDrawArgsResource(
+			const String& resourceName,
+			const DrawArg* pDrawArgs,
+			uint32 count)
+		{
+			UNREFERENCED_VARIABLE(resourceName);
+			UNREFERENCED_VARIABLE(pDrawArgs);
+			UNREFERENCED_VARIABLE(count);
+		}
 
 		/*
 		* Called at rendertime to allow recording device commands
@@ -115,8 +155,8 @@ namespace LambdaEngine
 			CommandList** ppSecondaryExecutionStage,
 			bool sleeping)		= 0;
 
-		virtual FPipelineStageFlag GetFirstPipelineStage()	= 0;
-		virtual FPipelineStageFlag GetLastPipelineStage()	= 0;
+		virtual FPipelineStageFlag GetFirstPipelineStage() const	= 0;
+		virtual FPipelineStageFlag GetLastPipelineStage() const		= 0;
 
 		virtual const String& GetName() const = 0;
 	};

--- a/LambdaEngine/Include/Rendering/ImGuiRenderer.h
+++ b/LambdaEngine/Include/Rendering/ImGuiRenderer.h
@@ -5,7 +5,7 @@
 #include "Containers/String.h"
 
 #include "RenderGraphTypes.h"
-#include "ICustomRenderer.h"
+#include "CustomRenderer.h"
 
 #include "Application/API/Events/EventQueue.h"
 
@@ -57,7 +57,7 @@ namespace LambdaEngine
 		GUID_Lambda	PixelShaderGUID		= GUID_NONE;
 	};
 
-	class LAMBDA_API ImGuiRenderer : public ICustomRenderer
+	class LAMBDA_API ImGuiRenderer : public CustomRenderer
 	{
 		using ImGuiDrawFunc = std::function<void()>;
 
@@ -78,10 +78,7 @@ namespace LambdaEngine
 		virtual void PreBuffersDescriptorSetWrite()		override final;
 		virtual void PreTexturesDescriptorSetWrite()	override final;
 
-		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const* ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
-		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
 		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count) override final;
 
 		virtual void Render(
@@ -91,8 +88,8 @@ namespace LambdaEngine
 			CommandList** ppSecondaryExecutionStage,
 			bool Sleeping)	override final;
 
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
 
 		bool OnEvent(const Event& event);
 		

--- a/LambdaEngine/Include/Rendering/LightRenderer.h
+++ b/LambdaEngine/Include/Rendering/LightRenderer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "RenderGraphTypes.h"
-#include "ICustomRenderer.h"
+#include "CustomRenderer.h"
 #include "Core/API/DescriptorCache.h"
 
 namespace LambdaEngine
@@ -29,7 +29,7 @@ namespace LambdaEngine
 	using ReleaseFrame = uint32;
 	using DescriptorSetIndex = uint32;
 
-	class LightRenderer : public ICustomRenderer
+	class LightRenderer : public CustomRenderer
 	{
 	public:
 		DECL_REMOVE_COPY(LightRenderer);
@@ -44,13 +44,9 @@ namespace LambdaEngine
 
 		void PrepareTextureUpdates(const TArray<LightUpdateData>& textureIndices);
 
-		virtual void PreBuffersDescriptorSetWrite()		override final;
-		virtual void PreTexturesDescriptorSetWrite()	override final;
-
 		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const* ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
 		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
 		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)  override final;
 
 		virtual void Render(
@@ -60,8 +56,8 @@ namespace LambdaEngine
 			CommandList** ppSecondaryExecutionStage,
 			bool Sleeping)	override final;
 
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
 
 		virtual const String& GetName() const override final
 		{

--- a/LambdaEngine/Include/Rendering/LineRenderer.h
+++ b/LambdaEngine/Include/Rendering/LineRenderer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "RenderGraphTypes.h"
-#include "ICustomRenderer.h"
+#include "CustomRenderer.h"
 
 namespace LambdaEngine
 {
@@ -28,7 +28,7 @@ namespace LambdaEngine
 		glm::vec4 Color;
 	};
 
-	class LineRenderer : public ICustomRenderer
+	class LineRenderer : public CustomRenderer
 	{
 	public:
 		LineRenderer(GraphicsDevice* pGraphicsDevice, uint32 verticiesBufferSize, uint32 backBufferCount);
@@ -36,17 +36,13 @@ namespace LambdaEngine
 
 		virtual bool Init() override final;
 
-		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
 		virtual bool RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc) override final;
-		virtual void PreBuffersDescriptorSetWrite() override final;
-		virtual void PreTexturesDescriptorSetWrite() override final;
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const* ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
 		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
-		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count) override final;
 		virtual void Render(uint32 modFrameIndex, uint32 backBufferIndex, CommandList** ppFirstExecutionStage, CommandList** ppSecondaryExecutionStage, bool Sleeping)	override final;
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
+
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
 		FORCEINLINE virtual const String& GetName() const override
 		{
 			static String name = RENDER_GRAPH_PHYSICS_DEBUG_NAME;

--- a/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
+++ b/LambdaEngine/Include/Rendering/PaintMaskRenderer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Rendering/ICustomRenderer.h"
+#include "Rendering/CustomRenderer.h"
 #include "Rendering/RenderGraph.h"
 #include <optional>
 
@@ -46,7 +46,7 @@ namespace LambdaEngine
 		BLUE	= 2
 	};
 
-	class PaintMaskRenderer : public ICustomRenderer
+	class PaintMaskRenderer : public CustomRenderer
 	{
 	public:
 		PaintMaskRenderer(GraphicsDevice* pGraphicsDevice, uint32 backBufferCount);
@@ -55,12 +55,8 @@ namespace LambdaEngine
 		virtual bool Init() override final;
 
 		virtual bool RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc) override final;
-		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
-		virtual void PreBuffersDescriptorSetWrite() override final;
-		virtual void PreTexturesDescriptorSetWrite() override final;
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const * ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
 		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const * ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
 		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count) override final;
 		virtual void Render(
 			uint32 modFrameIndex,
@@ -69,8 +65,8 @@ namespace LambdaEngine
 			CommandList** ppSecondaryExecutionStage,
 			bool sleeping) override final;
 
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
 
 		FORCEINLINE virtual const String& GetName() const override final
 		{

--- a/LambdaEngine/Include/Rendering/ParticleManager.h
+++ b/LambdaEngine/Include/Rendering/ParticleManager.h
@@ -6,7 +6,7 @@
 
 #include "Rendering/Core/API/GraphicsTypes.h"
 
-#define DEBUG_PARTICLE true
+#define DEBUG_PARTICLE false
 
 namespace LambdaEngine 
 {

--- a/LambdaEngine/Include/Rendering/ParticleRenderer.h
+++ b/LambdaEngine/Include/Rendering/ParticleRenderer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "RenderGraphTypes.h"
-#include "ICustomRenderer.h"
+#include "CustomRenderer.h"
 
 #include "Rendering/Core/API/DescriptorCache.h"
 
@@ -14,7 +14,7 @@ namespace LambdaEngine
 		uint64 SizeInByte		= 0;
 	};
 
-	class ParticleRenderer : public ICustomRenderer
+	class ParticleRenderer : public CustomRenderer
 	{
 	public:
 		ParticleRenderer();
@@ -28,14 +28,9 @@ namespace LambdaEngine
 
 		virtual bool RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc) override final;
 
-		virtual void PreBuffersDescriptorSetWrite()		override final;
-		virtual void PreTexturesDescriptorSetWrite()	override final;
-
 		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const* ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
 		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
-		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)  override final;
 
 		virtual void Render(
 			uint32 modFrameIndex,
@@ -44,8 +39,8 @@ namespace LambdaEngine
 			CommandList** ppSecondaryExecutionStage,
 			bool Sleeping)	override final;
 
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_VERTEX_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_PIXEL_SHADER; }
 
 		virtual const String& GetName() const override final
 		{

--- a/LambdaEngine/Include/Rendering/ParticleUpdater.h
+++ b/LambdaEngine/Include/Rendering/ParticleUpdater.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "RenderGraphTypes.h"
-#include "ICustomRenderer.h"
+#include "CustomRenderer.h"
 
 #include "Rendering/Core/API/PipelineContext.h"
 
 namespace LambdaEngine
 {
-	class ParticleUpdater : public ICustomRenderer
+	class ParticleUpdater : public CustomRenderer
 	{
 		struct PushConstantData
 		{
@@ -25,15 +25,9 @@ namespace LambdaEngine
 
 		virtual bool RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc) override final;
 
-		virtual void PreBuffersDescriptorSetWrite()		override final;
-		virtual void PreTexturesDescriptorSetWrite()	override final;
-
 		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
 		virtual void UpdateTextureResource(const String& resourceName, const TextureView* const* ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound) override final;
 		virtual void UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound) override final;
-		virtual void UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure) override final;
-		virtual void UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)  override final;
-
 
 		virtual void Render(
 			uint32 modFrameIndex,
@@ -42,8 +36,8 @@ namespace LambdaEngine
 			CommandList** ppSecondaryExecutionStage,
 			bool Sleeping)	override final;
 
-		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_COMPUTE_SHADER; }
-		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage()	override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_COMPUTE_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_COMPUTE_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final { return FPipelineStageFlag::PIPELINE_STAGE_FLAG_COMPUTE_SHADER; }
 
 		virtual const String& GetName() const override final
 		{

--- a/LambdaEngine/Include/Rendering/RT/ASBuilder.h
+++ b/LambdaEngine/Include/Rendering/RT/ASBuilder.h
@@ -25,14 +25,45 @@ namespace LambdaEngine
 		virtual bool RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc) override final;
 
 		/*
-			Creates a BLAS and SBT Record for the given Vertex- and Index Buffer if index == BLAS_UNINITIALIZED_INDEX, it then generates a unique hash for this BLAS
+		* Creates a BLAS and SBT Record for the given Vertex- and Index Buffer if index == BLAS_UNINITIALIZED_INDEX, it then generates a new index which gets stored in the index variable.
+		* You are exptected to save this index variable and use it to update/remove this BLAS.
+
+		* If index is not equal to BLAS_UNINITIALIZED_INDEX it must correspond to a valid BLAS.
+		* If it corresponds to a valid BLAS it rebuilds that BLAS with pVertexBuffer and pIndexBuffer.
+		* You must make sure that vertexCount and indexCount are the same as they were when you first called BuildTriBLAS with this index and allowUpdate must have been true.
 		*/
 		void BuildTriBLAS(uint32& index, Buffer* pVertexBuffer, Buffer* pIndexBuffer, uint32 vertexCount, uint32 indexCount, bool allowUpdate);
+
+		/*
+		* Releases the BLAS corresponding to index.
+		* Index must be valid.
+		* It is the callers responsibility to make sure all Instances that reference this BLAS are removed prior to calling ReleaseBLAS.
+		*/
 		void ReleaseBLAS(uint32 index);
 
-		uint32 AddInstance(uint32 blasIndex, const glm::mat4& transform, uint32 customIndex, uint8 hitMask, FAccelerationStructureFlags flags);
+		/*
+		* Adds a new Instance to the TLAS.
+		*	blasIndex - An index corresponding to a valid BLAS.
+		*	transform - A valid transform
+		*	customIndex - Lower 24 bits will be copied into the instance
+		*	hitMask - A hit mask which will be set in the instance and can be used when tracing rays to only hit specific instances
+		*	flags - Flags which will be set in the instance
+		*/
+		uint32 AddInstance(uint32 blasIndex, const glm::mat4& transform, uint32 customIndex, uint8 hitMask, FAccelerationStructureInstanceFlags flags);
+
+		/*
+		* Removes an Instance from the TLAS.
+		*/
 		void RemoveInstance(uint32 instanceIndex);
+
+		/*
+		* Updates the transform of the Instance which corresponds to instanceIndex.
+		*/
 		void UpdateInstanceTransform(uint32 instanceIndex, const glm::mat4& transform);
+
+		/*
+		* Loops through each instance and runs updateFunc for it.
+		*/
 		void UpdateInstances(std::function<void(AccelerationStructureInstance&)> updateFunc);
 
 		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;

--- a/LambdaEngine/Include/Rendering/RT/ASBuilder.h
+++ b/LambdaEngine/Include/Rendering/RT/ASBuilder.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "Rendering/CustomRenderer.h"
+
+#include "Rendering/Core/API/AccelerationStructure.h"
+#include "Rendering/Core/API/CommandList.h"
+
+namespace LambdaEngine
+{
+	constexpr const uint32 BLAS_UNINITIALIZED_INDEX = UINT32_MAX;
+
+	class ASBuilder : public CustomRenderer
+	{
+		struct BLASData
+		{
+			AccelerationStructure* pBLAS = nullptr;
+			uint32 SBTRecordOffset = UINT32_MAX;
+		};
+
+	public:
+		ASBuilder();
+		~ASBuilder();
+
+		virtual bool Init() override final;
+		virtual bool RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc) override final;
+
+		/*
+			Creates a BLAS and SBT Record for the given Vertex- and Index Buffer if index == BLAS_UNINITIALIZED_INDEX, it then generates a unique hash for this BLAS
+		*/
+		void BuildTriBLAS(uint32& index, Buffer* pVertexBuffer, Buffer* pIndexBuffer, uint32 vertexCount, uint32 indexCount, bool allowUpdate);
+		void ReleaseBLAS(uint32 index);
+
+		uint32 AddInstance(uint32 blasIndex, const glm::mat4& transform, uint32 customIndex, uint8 hitMask, FAccelerationStructureFlags flags);
+		void RemoveInstance(uint32 instanceIndex);
+		void UpdateInstanceTransform(uint32 instanceIndex, const glm::mat4& transform);
+		void UpdateInstances(std::function<void(AccelerationStructureInstance&)> updateFunc);
+
+		virtual void Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex) override final;
+
+		virtual void Render(
+			uint32 modFrameIndex, 
+			uint32 backBufferIndex, 
+			CommandList** ppFirstExecutionStage,
+			CommandList** ppSecondaryExecutionStage,
+			bool sleeping) override final;
+
+		AccelerationStructureInstance& GetInstance(uint32 instanceIndex);
+
+		FORCEINLINE virtual FPipelineStageFlag GetFirstPipelineStage() const override final	{ return FPipelineStageFlag::PIPELINE_STAGE_FLAG_COMPUTE_SHADER; }
+		FORCEINLINE virtual FPipelineStageFlag GetLastPipelineStage() const override final	{ return FPipelineStageFlag::PIPELINE_STAGE_FLAG_COMPUTE_SHADER; }
+		FORCEINLINE virtual const String& GetName() const override final 
+		{
+			static String name = "AS_BUILDER";
+			return name;
+		}
+
+	private:
+		void ReleaseBackBufferBound();
+
+		bool CreateCommandLists();
+		bool CreateBuffers();
+
+	private:
+		RenderGraph* m_pRenderGraph = nullptr;
+		uint32 m_ModFrameIndex = 0;
+		uint32 m_BackBufferCount = 0;
+
+		CommandAllocator** m_ppComputeCommandAllocators = nullptr;
+		CommandList** m_ppComputeCommandLists = nullptr;
+
+		//BLAS
+		TArray<uint32> m_FreeBLASIndices;	//Keeps track of holes in m_BLASes
+		TArray<BLASData> m_BLASes;			//Non-Dense Array of BLASData
+		TArray<BuildBottomLevelAccelerationStructureDesc> m_DirtyBLASes; //Contains all BLAS build descriptions queued for execution
+		
+		//SBT
+		TArray<uint32> m_FreeSBTIndices;	//Keeps track of holes in m_SBTRecords
+		TArray<SBTRecord> m_SBTRecords;		//Non-Dense Array of SBTRecords
+		bool m_SBTRecordsDirty = false;
+
+		//TLAS
+		TArray<uint32> m_FreeInstanceIndices;				//Keeps track of holes in m_InstanceIndices
+		TArray<uint32> m_InstanceIndices;					//Maps Instance Index returned from AddInstance() to index in m_Instances
+		TArray<AccelerationStructureInstance> m_Instances;	//Dense Array of Instances
+		Buffer** m_ppInstanceBuffers = nullptr;
+		uint32 m_MaxSupportedTLASInstances = 0;
+		uint32 m_BuiltTLASInstanceCount = 0;
+		AccelerationStructure* m_pTLAS = nullptr;
+
+		//Utility
+		TArray<DeviceChild*>* m_pResourcesToRemove = nullptr;
+
+		//Threading
+		SpinLock m_Lock;
+	};
+}

--- a/LambdaEngine/Include/Rendering/RenderGraph.h
+++ b/LambdaEngine/Include/Rendering/RenderGraph.h
@@ -38,7 +38,7 @@ namespace LambdaEngine
 	class PipelineState;
 	class DescriptorSet;
 	class DescriptorHeap;
-	class ICustomRenderer;
+	class CustomRenderer;
 	class CommandList;
 	class TextureView;
 	class Texture;
@@ -54,7 +54,7 @@ namespace LambdaEngine
 		uint32 BackBufferCount								= 3;
 		uint16 BackBufferWidth								= 0;
 		uint16 BackBufferHeight								= 0;
-		TArray<ICustomRenderer*>	CustomRenderers;
+		TArray<CustomRenderer*>	CustomRenderers;
 	};
 
 	struct PushConstantsUpdate
@@ -259,7 +259,7 @@ namespace LambdaEngine
 			glm::uvec3				Dimensions							= glm::uvec3(0);
 
 			bool					UsesCustomRenderer					= false;
-			ICustomRenderer*		pCustomRenderer						= nullptr;
+			CustomRenderer*			pCustomRenderer						= nullptr;
 
 			FPipelineStageFlags		FirstPipelineStage					= FPipelineStageFlag::PIPELINE_STAGE_FLAG_UNKNOWN;
 			FPipelineStageFlags		LastPipelineStage					= FPipelineStageFlag::PIPELINE_STAGE_FLAG_UNKNOWN;
@@ -353,7 +353,7 @@ namespace LambdaEngine
 		/*
 		* Updates the global SBT which is used for all Ray Tracing calls, each SBTRecord should contain addresses to valid Buffers
 		*/
-		void UpdateGlobalSBT(const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*>& removedDeviceResources);
+		void UpdateGlobalSBT(CommandList* pCommandList, const TArray<SBTRecord>& shaderRecords, TArray<DeviceChild*>& removedDeviceResources);
 		/*
 		* Updates the dimensions of a RenderStage, will only set the dimensions which are set to EXTERNAL
 		*/
@@ -421,7 +421,7 @@ namespace LambdaEngine
 		bool CreateCopyCommandLists();
 		bool CreateProfiler(uint32 pipelineStageCount);
 		bool CreateResources(const TArray<RenderGraphResourceDesc>& resourceDescriptions);
-		bool CreateRenderStages(const TArray<RenderStageDesc>& renderStages, const THashTable<String, RenderGraphShaderConstants>& shaderConstants, const TArray<ICustomRenderer*>& customRenderers, TSet<DrawArgMaskDesc>& requiredDrawArgMasks);
+		bool CreateRenderStages(const TArray<RenderStageDesc>& renderStages, const THashTable<String, RenderGraphShaderConstants>& shaderConstants, const TArray<CustomRenderer*>& customRenderers, TSet<DrawArgMaskDesc>& requiredDrawArgMasks);
 		bool CreateSynchronizationStages(const TArray<SynchronizationStageDesc>& synchronizationStageDescriptions, TSet<DrawArgMaskDesc>& requiredDrawArgMasks);
 		bool CreatePipelineStages(const TArray<PipelineStageDesc>& pipelineStageDescriptions);
 
@@ -468,8 +468,8 @@ namespace LambdaEngine
 		Fence*											s_pMaterialFence					= nullptr;
 		uint64											m_SignalValue						= 1;
 
-		TArray<ICustomRenderer*>						m_CustomRenderers;
-		TArray<ICustomRenderer*>						m_DebugRenderers;
+		TArray<CustomRenderer*>							m_CustomRenderers;
+		TArray<CustomRenderer*>							m_DebugRenderers;
 
 		CommandAllocator**								m_ppGraphicsCopyCommandAllocators	= nullptr;
 		CommandList**									m_ppGraphicsCopyCommandLists		= nullptr;

--- a/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
@@ -624,14 +624,6 @@ namespace LambdaEngine
 		}
 	}
 
-	void GUIRenderer::PreBuffersDescriptorSetWrite()
-	{
-	}
-
-	void GUIRenderer::PreTexturesDescriptorSetWrite()
-	{
-	}
-
 	void GUIRenderer::UpdateTextureResource(
 		const String& resourceName,
 		const TextureView* const* ppPerImageTextureViews,
@@ -655,29 +647,6 @@ namespace LambdaEngine
 		{
 			m_DepthStencilTextureView = MakeSharedRef(ppPerSubImageTextureViews[0]);
 		}
-	}
-
-	void GUIRenderer::UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(ppBuffers);
-		UNREFERENCED_VARIABLE(pOffsets);
-		UNREFERENCED_VARIABLE(pSizesInBytes);
-		UNREFERENCED_VARIABLE(count);
-		UNREFERENCED_VARIABLE(backBufferBound);
-	}
-
-	void GUIRenderer::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
-	}
-
-	void GUIRenderer::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pDrawArgs);
-		UNREFERENCED_VARIABLE(count);
 	}
 
 	void GUIRenderer::Render(

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -31,6 +31,7 @@
 
 #include "Rendering/ParticleRenderer.h"
 #include "Rendering/ParticleUpdater.h"
+#include "Rendering/RT/ASBuilder.h"
 
 #include "GUI/Core/GUIApplication.h"
 #include "GUI/Core/GUIRenderer.h"
@@ -363,9 +364,18 @@ namespace LambdaEngine
 				renderGraphDesc.CustomRenderers.PushBack(m_pParticleUpdater);
 			}
 
+			// AS Builder
+			if (m_RayTracingEnabled)
+			{
+				m_pASBuilder = DBG_NEW ASBuilder();
+				m_pASBuilder->Init();
+
+				renderGraphDesc.CustomRenderers.PushBack(m_pASBuilder);
+			}
+
 			//GUI Renderer
 			{
-				ICustomRenderer* pGUIRenderer = GUIApplication::GetRenderer();
+				CustomRenderer* pGUIRenderer = GUIApplication::GetRenderer();
 				renderGraphDesc.CustomRenderers.PushBack(pGUIRenderer);
 			}
 
@@ -416,7 +426,6 @@ namespace LambdaEngine
 	{
 		for (auto& meshAndInstancesIt : m_MeshAndInstancesMap)
 		{
-			SAFERELEASE(meshAndInstancesIt.second.pBLAS);
 			SAFERELEASE(meshAndInstancesIt.second.pPrimitiveIndices);
 			SAFERELEASE(meshAndInstancesIt.second.pUniqueIndices);
 			SAFERELEASE(meshAndInstancesIt.second.pMeshlets);
@@ -428,11 +437,9 @@ namespace LambdaEngine
 			SAFERELEASE(meshAndInstancesIt.second.pStagingMatrixBuffer);
 			SAFERELEASE(meshAndInstancesIt.second.pIndexBuffer);
 			SAFERELEASE(meshAndInstancesIt.second.pRasterInstanceBuffer);
-			SAFERELEASE(meshAndInstancesIt.second.pASInstanceBuffer);
 
 			for (uint32 b = 0; b < BACK_BUFFER_COUNT; b++)
 			{
-				SAFERELEASE(meshAndInstancesIt.second.ppASInstanceStagingBuffers[b]);
 				SAFERELEASE(meshAndInstancesIt.second.ppRasterInstanceStagingBuffers[b]);
 			}
 		}
@@ -442,12 +449,12 @@ namespace LambdaEngine
 		SAFEDELETE(m_pLightRenderer);
 		SAFEDELETE(m_pParticleRenderer);
 		SAFEDELETE(m_pParticleUpdater);
+		SAFEDELETE(m_pASBuilder);
 
 		// Delete Custom Renderers
 		for (uint32 c = 0; c < m_GameSpecificCustomRenderers.GetSize(); c++)
 		{
 			SAFEDELETE(m_GameSpecificCustomRenderers[c]);
-
 		}
 
 		// Remove Pointlight Texture and Texture Views
@@ -462,9 +469,6 @@ namespace LambdaEngine
 			SAFERELEASE(m_CubeSubImageTextureViews[f]);
 		}
 
-		SAFERELEASE(m_pTLAS);
-		SAFERELEASE(m_pCompleteInstanceBuffer);
-
 		for (uint32 b = 0; b < BACK_BUFFER_COUNT; b++)
 		{
 			TArray<DeviceChild*>& resourcesToRemove = m_ResourcesToRemove[b];
@@ -477,7 +481,6 @@ namespace LambdaEngine
 
 			SAFERELEASE(m_ppMaterialParametersStagingBuffers[b]);
 			SAFERELEASE(m_ppPerFrameStagingBuffers[b]);
-			SAFERELEASE(m_ppStaticStagingInstanceBuffers[b]);
 			SAFERELEASE(m_ppLightsStagingBuffer[b]);
 			SAFERELEASE(m_ppPaintMaskColorStagingBuffers[b]);
 		}
@@ -679,17 +682,25 @@ namespace LambdaEngine
 			renderGraphDesc.CustomRenderers.PushBack(m_pLightRenderer);
 		}
 
+		// Particles
 		{
 			renderGraphDesc.CustomRenderers.PushBack(m_pParticleRenderer);
 			renderGraphDesc.CustomRenderers.PushBack(m_pParticleUpdater);
 		}
 
-		//GUI Renderer
+		// AS Builder
+		if (m_RayTracingEnabled)
 		{
-			ICustomRenderer* pGUIRenderer = GUIApplication::GetRenderer();
+			renderGraphDesc.CustomRenderers.PushBack(m_pASBuilder);
+		}
+
+		// GUI Renderer
+		{
+			CustomRenderer* pGUIRenderer = GUIApplication::GetRenderer();
 			renderGraphDesc.CustomRenderers.PushBack(pGUIRenderer);
 		}
 
+		// Paint Mask Renderer
 		{
 			m_pPaintMaskRenderer = DBG_NEW PaintMaskRenderer(RenderAPI::GetDevice(), BACK_BUFFER_COUNT);
 			m_pPaintMaskRenderer->Init();
@@ -707,19 +718,13 @@ namespace LambdaEngine
 		m_PerFrameResourceDirty				= true;
 		m_MaterialsResourceDirty			= true;
 		m_MaterialsPropertiesBufferDirty	= true;
-		m_RenderGraphSBTRecordsDirty		= true;
 		m_LightsBufferDirty					= true;
 		m_PointLightsDirty					= true;
-
-		if (m_RayTracingEnabled)
-		{
-			m_TLASResourceDirty = true;
-		}
 
 		UpdateRenderGraph();
 	}
 
-	void RenderSystem::AddCustomRenderer(ICustomRenderer* pCustomRenderer)
+	void RenderSystem::AddCustomRenderer(CustomRenderer* pCustomRenderer)
 	{
 		if (!pCustomRenderer)
 		{
@@ -1133,23 +1138,18 @@ namespace LambdaEngine
 					}
 				}
 
-				meshAndInstancesIt = m_MeshAndInstancesMap.insert({ meshKey, meshEntry }).first;
-
 				if (m_RayTracingEnabled)
 				{
-					if (isAnimated)
-					{
-						meshAndInstancesIt->second.ShaderRecord.VertexBufferAddress = meshEntry.pAnimatedVertexBuffer->GetDeviceAdress();
-					}
-					else
-					{
-						meshAndInstancesIt->second.ShaderRecord.VertexBufferAddress = meshEntry.pVertexBuffer->GetDeviceAdress();
-					}
-
-					meshAndInstancesIt->second.ShaderRecord.IndexBufferAddress = meshEntry.pIndexBuffer->GetDeviceAdress();
-					m_DirtyBLASs.insert(&meshAndInstancesIt->second);
-					m_SBTRecordsDirty = true;
+					m_pASBuilder->BuildTriBLAS(
+						meshEntry.BLASIndex,
+						isAnimated ? meshEntry.pAnimatedVertexBuffer : meshEntry.pVertexBuffer,
+						meshEntry.pIndexBuffer,
+						meshEntry.VertexCount,
+						meshEntry.IndexCount,
+						isAnimated);
 				}
+
+				meshAndInstancesIt = m_MeshAndInstancesMap.insert({ meshKey, meshEntry }).first;
 			}
 		}
 
@@ -1262,26 +1262,20 @@ namespace LambdaEngine
 
 		if (m_RayTracingEnabled)
 		{
-			uint32 customIndex = (materialIndex & 0xFF) << 8;
-			customIndex |= hasPaintMask ? ((uint32)(std::max(0u, m_PaintMaskTextures.GetSize() - 1))) & 0xFF : 0;
+			uint32 customIndex =
+				((materialIndex & 0xFF) << 8) |
+				(hasPaintMask ? (std::max(0u, m_PaintMaskTextures.GetSize() - 1)) & 0xFF : 0);
+			uint8 hitMask = 0xFF;
+			FAccelerationStructureFlags asFlags	= RAY_TRACING_INSTANCE_FLAG_FORCE_OPAQUE | RAY_TRACING_INSTANCE_FLAG_FRONT_CCW;
 
-			AccelerationStructureInstance asInstance = {};
-			asInstance.Transform		= glm::transpose(transform);
-			asInstance.CustomIndex		= customIndex;
-			asInstance.Mask				= 0xFF;
-			asInstance.Flags			= RAY_TRACING_INSTANCE_FLAG_FORCE_OPAQUE | RAY_TRACING_INSTANCE_FLAG_FRONT_CCW;
+			uint32 asInstanceIndex = m_pASBuilder->AddInstance(
+				meshAndInstancesIt->second.BLASIndex,
+				transform,
+				customIndex,
+				hitMask,
+				asFlags);
 
-			//If the SBT Record is already created in another instance, set it here
-			if (!meshAndInstancesIt->second.ASInstances.IsEmpty())
-				asInstance.SBTRecordOffset = meshAndInstancesIt->second.ASInstances[0].SBTRecordOffset;
-
-			//If the BLAS is already built, set it here
-			if (meshAndInstancesIt->second.pBLAS != nullptr)
-				asInstance.AccelerationStructureAddress	= meshAndInstancesIt->second.pBLAS->GetDeviceAdress();
-
-			meshAndInstancesIt->second.ASInstances.PushBack(asInstance);
-			m_DirtyASInstanceBuffers.insert(&meshAndInstancesIt->second);
-			m_TLASDirty = true;
+			meshAndInstancesIt->second.ASInstanceIndices.PushBack(asInstanceIndex);
 		}
 
 		Instance instance = {};
@@ -1345,13 +1339,14 @@ namespace LambdaEngine
 
 		if (m_RayTracingEnabled)
 		{
-			// Remove RT ASInstance
-			TArray<AccelerationStructureInstance>& asInstances = meshAndInstancesIt->second.ASInstances;
-			const uint32 textureIndex = asInstances[instanceIndex].CustomIndex & 0xFF;
-			asInstances[instanceIndex] = asInstances.GetBack();
-			asInstances.PopBack();
-			m_DirtyASInstanceBuffers.insert(&meshAndInstancesIt->second);
-			m_TLASDirty = true;
+			// Remove ASInstance
+			uint32 asInstanceIndex = meshAndInstancesIt->second.ASInstanceIndices[instanceIndex];
+			const uint32 textureIndex = m_pASBuilder->GetInstance(asInstanceIndex).CustomIndex & 0xFF;
+			m_pASBuilder->RemoveInstance(asInstanceIndex);
+			
+			//Swap Removed with Back
+			meshAndInstancesIt->second.ASInstanceIndices[instanceIndex] = meshAndInstancesIt->second.ASInstanceIndices.GetBack();
+			meshAndInstancesIt->second.ASInstanceIndices.PopBack();
 
 			// Remove and reorder the paint mask textures (if needed) and set new indicies for ASInstances
 			ECSCore* pECS = ECSCore::GetInstance();
@@ -1365,13 +1360,15 @@ namespace LambdaEngine
 				m_PaintMaskTextureViews.PopBack();
 
 				// Update custom indicies
-				for (auto& instance : asInstances)
-				{
-					if (changedIndex == (instance.CustomIndex & 0xFF0000))
+				m_pASBuilder->UpdateInstances(
+					[changedIndex, textureIndex](AccelerationStructureInstance& asInstance)
 					{
-						instance.CustomIndex |= textureIndex;
-					}
-				}
+						if (changedIndex == (asInstance.CustomIndex & 0xFF))
+						{
+							asInstance.CustomIndex &= 0xFFFF00;
+							asInstance.CustomIndex |= textureIndex;
+						}
+					});
 
 				Sampler* pNearestSampler = Sampler::GetNearestSampler();
 				ResourceUpdateDesc unwrappedTextureUpdate = {};
@@ -1430,14 +1427,12 @@ namespace LambdaEngine
 		// Unload Mesh, Todo: Should we always do this?
 		if (meshAndInstancesIt->second.EntityIDs.IsEmpty())
 		{
-			DeleteDeviceResource(meshAndInstancesIt->second.pBLAS);
 			DeleteDeviceResource(meshAndInstancesIt->second.pVertexBuffer);
 			DeleteDeviceResource(meshAndInstancesIt->second.pIndexBuffer);
 			DeleteDeviceResource(meshAndInstancesIt->second.pUniqueIndices);
 			DeleteDeviceResource(meshAndInstancesIt->second.pPrimitiveIndices);
 			DeleteDeviceResource(meshAndInstancesIt->second.pMeshlets);
 			DeleteDeviceResource(meshAndInstancesIt->second.pRasterInstanceBuffer);
-			DeleteDeviceResource(meshAndInstancesIt->second.pASInstanceBuffer);
 
 			if (meshAndInstancesIt->second.pAnimatedVertexBuffer)
 			{
@@ -1461,31 +1456,21 @@ namespace LambdaEngine
 
 			for (uint32 b = 0; b < BACK_BUFFER_COUNT; b++)
 			{
-				DeleteDeviceResource(meshAndInstancesIt->second.ppASInstanceStagingBuffers[b]);
 				DeleteDeviceResource(meshAndInstancesIt->second.ppRasterInstanceStagingBuffers[b]);
 			}
 
-			m_SBTRecordsDirty = true;
-
-			auto dirtyASInstanceToRemove = std::find_if(m_DirtyASInstanceBuffers.begin(), m_DirtyASInstanceBuffers.end(), [meshAndInstancesIt](const MeshEntry* pMeshEntry)
-				{
-					return pMeshEntry == &meshAndInstancesIt->second;
-				});
 			auto dirtyRasterInstanceToRemove = std::find_if(m_DirtyRasterInstanceBuffers.begin(), m_DirtyRasterInstanceBuffers.end(), [meshAndInstancesIt](const MeshEntry* pMeshEntry)
 				{
 					return pMeshEntry == &meshAndInstancesIt->second;
 				});
-			auto dirtyBLASToRemove = std::find_if(m_DirtyBLASs.begin(), m_DirtyBLASs.end(), [meshAndInstancesIt](const MeshEntry* pMeshEntry)
-				{
-					return pMeshEntry == &meshAndInstancesIt->second;
-				});
 
-			if (dirtyASInstanceToRemove != m_DirtyASInstanceBuffers.end())
-				m_DirtyASInstanceBuffers.erase(dirtyASInstanceToRemove);
 			if (dirtyRasterInstanceToRemove != m_DirtyRasterInstanceBuffers.end())
 				m_DirtyRasterInstanceBuffers.erase(dirtyRasterInstanceToRemove);
-			if (dirtyBLASToRemove != m_DirtyBLASs.end())
-				m_DirtyBLASs.erase(dirtyBLASToRemove);
+
+			if (m_RayTracingEnabled)
+			{
+				m_pASBuilder->ReleaseBLAS(meshAndInstancesIt->second.BLASIndex);
+			}
 
 			m_MeshAndInstancesMap.erase(meshAndInstancesIt);
 		}
@@ -1584,8 +1569,17 @@ namespace LambdaEngine
 
 			MeshEntry* pMeshEntry = &meshEntryIt->second;
 			m_AnimationsToUpdate.insert(pMeshEntry);
-			m_DirtyBLASs.insert(pMeshEntry);
-			m_TLASDirty = true;
+
+			if (m_RayTracingEnabled)
+			{
+				m_pASBuilder->BuildTriBLAS(
+					pMeshEntry->BLASIndex,
+					pMeshEntry->pAnimatedVertexBuffer,
+					pMeshEntry->pIndexBuffer,
+					pMeshEntry->VertexCount,
+					pMeshEntry->IndexCount,
+					true);
+			}
 		}
 	}
 
@@ -1618,10 +1612,8 @@ namespace LambdaEngine
 
 		if (m_RayTracingEnabled)
 		{
-			AccelerationStructureInstance* pASInstanceToUpdate = &meshAndInstancesIt->second.ASInstances[instanceKeyIt->second.InstanceIndex];
-			pASInstanceToUpdate->Transform = glm::transpose(transform);
-			m_DirtyASInstanceBuffers.insert(&meshAndInstancesIt->second);
-			m_TLASDirty = true;
+			uint32 asInstanceIndex = meshAndInstancesIt->second.ASInstanceIndices[instanceKeyIt->second.InstanceIndex];
+			m_pASBuilder->UpdateInstanceTransform(asInstanceIndex, transform);
 		}
 
 		Instance* pRasterInstanceToUpdate = &meshAndInstancesIt->second.RasterInstances[instanceKeyIt->second.InstanceIndex];
@@ -1756,15 +1748,6 @@ namespace LambdaEngine
 		// Perform mesh skinning
 		{
 			PerformMeshSkinning(pComputeCommandList);
-		}
-
-		//Update Acceleration Structures
-		if (m_RayTracingEnabled)
-		{
-			UpdateShaderRecords();
-			BuildBLASs(pComputeCommandList);
-			UpdateASInstanceBuffers(pComputeCommandList);
-			BuildTLAS(pComputeCommandList);
 		}
 	}
 
@@ -1918,7 +1901,7 @@ namespace LambdaEngine
 		{
 			uint32 requiredBufferSize = m_MaterialProperties.GetSize() * sizeof(MaterialProperties);
 
-			Buffer* pStagingBuffer = m_ppStaticStagingInstanceBuffers[m_ModFrameIndex];
+			Buffer* pStagingBuffer = m_ppMaterialParametersStagingBuffers[m_ModFrameIndex];
 
 			if (pStagingBuffer == nullptr || pStagingBuffer->GetDesc().SizeInBytes < requiredBufferSize)
 			{
@@ -1931,7 +1914,7 @@ namespace LambdaEngine
 				bufferDesc.SizeInBytes	= requiredBufferSize;
 
 				pStagingBuffer = RenderAPI::GetDevice()->CreateBuffer(&bufferDesc);
-				m_ppStaticStagingInstanceBuffers[m_ModFrameIndex] = pStagingBuffer;
+				m_ppMaterialParametersStagingBuffers[m_ModFrameIndex] = pStagingBuffer;
 			}
 
 			void* pMapped = pStagingBuffer->Map();
@@ -1954,243 +1937,6 @@ namespace LambdaEngine
 			pCommandList->CopyBuffer(pStagingBuffer, 0, m_pMaterialParametersBuffer, 0, requiredBufferSize);
 
 			m_MaterialsPropertiesBufferDirty = false;
-		}
-	}
-
-	void RenderSystem::UpdateShaderRecords()
-	{
-		if (m_SBTRecordsDirty)
-		{
-			m_SBTRecords.Clear();
-
-			for (MeshAndInstancesMap::iterator meshAndInstancesIt = m_MeshAndInstancesMap.begin(); meshAndInstancesIt != m_MeshAndInstancesMap.end(); meshAndInstancesIt++)
-			{
-				uint32 shaderRecordOffset = m_SBTRecords.GetSize();
-
-				for (AccelerationStructureInstance& asInstance : meshAndInstancesIt->second.ASInstances)
-				{
-					asInstance.SBTRecordOffset = shaderRecordOffset;
-				}
-
-				m_SBTRecords.PushBack(meshAndInstancesIt->second.ShaderRecord);
-				m_DirtyASInstanceBuffers.insert(&meshAndInstancesIt->second);
-			}
-
-			m_SBTRecordsDirty = false;
-			m_TLASDirty = true;
-			m_RenderGraphSBTRecordsDirty = true;
-		}
-	}
-
-	void RenderSystem::BuildBLASs(CommandList* pCommandList)
-	{
-		if (!m_DirtyBLASs.empty())
-		{
-			for (MeshEntry* pDirtyBLAS : m_DirtyBLASs)
-			{
-				//We assume that VertexCount/PrimitiveCount does not change and thus do not check if we need to recreate them
-
-				bool update = true;
-
-				if (pDirtyBLAS->pBLAS == nullptr)
-				{
-					update = false;
-
-					AccelerationStructureDesc blasCreateDesc = {};
-					blasCreateDesc.DebugName		= "BLAS";
-					blasCreateDesc.Type				= EAccelerationStructureType::ACCELERATION_STRUCTURE_TYPE_BOTTOM;
-					blasCreateDesc.Flags			= FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
-					blasCreateDesc.MaxTriangleCount = pDirtyBLAS->IndexCount / 3;
-					blasCreateDesc.MaxVertexCount	= pDirtyBLAS->VertexCount;
-					blasCreateDesc.AllowsTransform	= false;
-
-					pDirtyBLAS->pBLAS = RenderAPI::GetDevice()->CreateAccelerationStructure(&blasCreateDesc);
-				}
-
-				BuildBottomLevelAccelerationStructureDesc blasBuildDesc = {};
-				blasBuildDesc.pAccelerationStructure	= pDirtyBLAS->pBLAS;
-				blasBuildDesc.Flags						= FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
-				if (pDirtyBLAS->pAnimatedVertexBuffer)
-				{
-					blasBuildDesc.pVertexBuffer = pDirtyBLAS->pAnimatedVertexBuffer;
-				}
-				else
-				{
-					blasBuildDesc.pVertexBuffer = pDirtyBLAS->pVertexBuffer;
-				}
-
-				blasBuildDesc.FirstVertexIndex		= 0;
-				blasBuildDesc.VertexStride			= sizeof(Vertex);
-				blasBuildDesc.pIndexBuffer			= pDirtyBLAS->pIndexBuffer;
-				blasBuildDesc.IndexBufferByteOffset	= 0;
-				blasBuildDesc.TriangleCount			= pDirtyBLAS->IndexCount / 3;
-				blasBuildDesc.pTransformBuffer		= nullptr;
-				blasBuildDesc.TransformByteOffset	= 0;
-				blasBuildDesc.Update				= update;
-
-				pCommandList->BuildBottomLevelAccelerationStructure(&blasBuildDesc);
-
-				uint64 blasAddress = pDirtyBLAS->pBLAS->GetDeviceAdress();
-				for (AccelerationStructureInstance& asInstance : pDirtyBLAS->ASInstances)
-				{
-					asInstance.AccelerationStructureAddress = blasAddress;
-				}
-
-				m_DirtyASInstanceBuffers.insert(pDirtyBLAS);
-			}
-
-			//This is required to sync up BLAS building with TLAS building, to make sure that the BLAS is built before the TLAS
-			PipelineMemoryBarrierDesc memoryBarrier = {};
-			memoryBarrier.SrcMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE;
-			memoryBarrier.DstMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ;
-			pCommandList->PipelineMemoryBarriers(FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP, FPipelineStageFlag::PIPELINE_STAGE_FLAG_COPY, &memoryBarrier, 1);
-
-			m_DirtyBLASs.clear();
-		}
-	}
-
-	void RenderSystem::UpdateASInstanceBuffers(CommandList* pCommandList)
-	{
-		if (!m_DirtyASInstanceBuffers.empty())
-		{
-			//AS Instances
-			for (MeshEntry* pDirtyInstanceBufferEntry : m_DirtyASInstanceBuffers)
-			{
-				uint32 requiredBufferSize = pDirtyInstanceBufferEntry->ASInstances.GetSize() * sizeof(AccelerationStructureInstance);
-
-				Buffer* pStagingBuffer = pDirtyInstanceBufferEntry->ppASInstanceStagingBuffers[m_ModFrameIndex];
-
-				if (pStagingBuffer == nullptr || pStagingBuffer->GetDesc().SizeInBytes < requiredBufferSize)
-				{
-					if (pStagingBuffer != nullptr) DeleteDeviceResource(pStagingBuffer);
-
-					BufferDesc bufferDesc = {};
-					bufferDesc.DebugName = "AS Instance Staging Buffer";
-					bufferDesc.MemoryType = EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
-					bufferDesc.Flags = FBufferFlag::BUFFER_FLAG_COPY_SRC;
-					bufferDesc.SizeInBytes = requiredBufferSize;
-
-					pStagingBuffer = RenderAPI::GetDevice()->CreateBuffer(&bufferDesc);
-					pDirtyInstanceBufferEntry->ppASInstanceStagingBuffers[m_ModFrameIndex] = pStagingBuffer;
-				}
-
-				void* pMapped = pStagingBuffer->Map();
-				memcpy(pMapped, pDirtyInstanceBufferEntry->ASInstances.GetData(), requiredBufferSize);
-				pStagingBuffer->Unmap();
-
-				if (pDirtyInstanceBufferEntry->pASInstanceBuffer == nullptr || pDirtyInstanceBufferEntry->pASInstanceBuffer->GetDesc().SizeInBytes < requiredBufferSize)
-				{
-					if (pDirtyInstanceBufferEntry->pASInstanceBuffer != nullptr) DeleteDeviceResource(pDirtyInstanceBufferEntry->pASInstanceBuffer);
-
-					BufferDesc bufferDesc = {};
-					bufferDesc.DebugName = "AS Instance Buffer";
-					bufferDesc.MemoryType = EMemoryType::MEMORY_TYPE_GPU;
-					bufferDesc.Flags = FBufferFlag::BUFFER_FLAG_COPY_DST | FBufferFlag::BUFFER_FLAG_COPY_SRC;
-					bufferDesc.SizeInBytes = requiredBufferSize;
-
-					pDirtyInstanceBufferEntry->pASInstanceBuffer = RenderAPI::GetDevice()->CreateBuffer(&bufferDesc);
-				}
-
-				pCommandList->CopyBuffer(pStagingBuffer, 0, pDirtyInstanceBufferEntry->pASInstanceBuffer, 0, requiredBufferSize);
-			}
-
-			PipelineMemoryBarrierDesc memoryBarrier = {};
-			memoryBarrier.SrcMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_WRITE;
-			memoryBarrier.DstMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ;
-			pCommandList->PipelineMemoryBarriers(FPipelineStageFlag::PIPELINE_STAGE_FLAG_COPY, FPipelineStageFlag::PIPELINE_STAGE_FLAG_ACCELERATION_STRUCTURE_BUILD, &memoryBarrier, 1);
-
-			m_DirtyASInstanceBuffers.clear();
-		}
-	}
-
-	void RenderSystem::BuildTLAS(CommandList* pCommandList)
-	{
-		if (m_TLASDirty)
-		{
-			m_TLASDirty = false;
-			m_CompleteInstanceBufferPendingCopies.Clear();
-
-			uint32 newInstanceCount = 0;
-
-			for (MeshAndInstancesMap::const_iterator meshAndInstancesIt = m_MeshAndInstancesMap.begin(); meshAndInstancesIt != m_MeshAndInstancesMap.end(); meshAndInstancesIt++)
-			{
-				uint32 instanceCount = meshAndInstancesIt->second.ASInstances.GetSize();
-
-				PendingBufferUpdate copyToCompleteInstanceBuffer = {};
-				copyToCompleteInstanceBuffer.pSrcBuffer		= meshAndInstancesIt->second.pASInstanceBuffer;
-				copyToCompleteInstanceBuffer.SrcOffset		= 0;
-				copyToCompleteInstanceBuffer.DstOffset		= newInstanceCount * sizeof(AccelerationStructureInstance);
-				copyToCompleteInstanceBuffer.SizeInBytes	= instanceCount * sizeof(AccelerationStructureInstance);
-				m_CompleteInstanceBufferPendingCopies.PushBack(copyToCompleteInstanceBuffer);
-
-				newInstanceCount += instanceCount;
-			}
-
-			if (newInstanceCount == 0)
-				return;
-
-			uint32 requiredCompleteInstancesBufferSize = newInstanceCount * sizeof(AccelerationStructureInstance);
-
-			if (m_pCompleteInstanceBuffer == nullptr || m_pCompleteInstanceBuffer->GetDesc().SizeInBytes < requiredCompleteInstancesBufferSize)
-			{
-				if (m_pCompleteInstanceBuffer != nullptr) DeleteDeviceResource(m_pCompleteInstanceBuffer);
-
-				BufferDesc bufferDesc = {};
-				bufferDesc.DebugName	= "Complete Instance Buffer";
-				bufferDesc.MemoryType	= EMemoryType::MEMORY_TYPE_GPU;
-				bufferDesc.Flags		= FBufferFlag::BUFFER_FLAG_COPY_DST | FBufferFlag::BUFFER_FLAG_RAY_TRACING;
-				bufferDesc.SizeInBytes	= requiredCompleteInstancesBufferSize;
-
-				m_pCompleteInstanceBuffer = RenderAPI::GetDevice()->CreateBuffer(&bufferDesc);
-			}
-
-			for (const PendingBufferUpdate& pendingUpdate : m_CompleteInstanceBufferPendingCopies)
-			{
-				pCommandList->CopyBuffer(pendingUpdate.pSrcBuffer, pendingUpdate.SrcOffset, m_pCompleteInstanceBuffer, pendingUpdate.DstOffset, pendingUpdate.SizeInBytes);
-			}
-
-			if (m_MeshAndInstancesMap.empty())
-				return;
-
-			bool update = true;
-
-			//Recreate TLAS completely if m_MaxSupportedTLASInstances < newInstanceCount
-			if (m_MaxSupportedTLASInstances < newInstanceCount)
-			{
-				if (m_pTLAS != nullptr) DeleteDeviceResource(m_pTLAS);
-
-				m_MaxSupportedTLASInstances = newInstanceCount;
-				m_BuiltTLASInstanceCount = newInstanceCount;
-
-				AccelerationStructureDesc createTLASDesc = {};
-				createTLASDesc.DebugName = "TLAS";
-				createTLASDesc.Type = EAccelerationStructureType::ACCELERATION_STRUCTURE_TYPE_TOP;
-				createTLASDesc.Flags = FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
-				createTLASDesc.InstanceCount = m_MaxSupportedTLASInstances;
-
-				m_pTLAS = RenderAPI::GetDevice()->CreateAccelerationStructure(&createTLASDesc);
-
-				update = false;
-
-				m_TLASResourceDirty = true;
-			}
-			else if (m_BuiltTLASInstanceCount != newInstanceCount)
-			{
-				m_BuiltTLASInstanceCount = newInstanceCount;
-				update = false;
-			}
-
-			if (m_pTLAS != nullptr)
-			{
-				BuildTopLevelAccelerationStructureDesc buildTLASDesc = {};
-				buildTLASDesc.pAccelerationStructure	= m_pTLAS;
-				buildTLASDesc.Flags						= FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
-				buildTLASDesc.Update					= update;
-				buildTLASDesc.pInstanceBuffer			= m_pCompleteInstanceBuffer;
-				buildTLASDesc.InstanceCount				= newInstanceCount;
-
-				pCommandList->BuildTopLevelAccelerationStructure(&buildTLASDesc);
-			}
 		}
 	}
 
@@ -2461,16 +2207,6 @@ namespace LambdaEngine
 			m_DirtyDrawArgs.clear();
 		}
 
-		if (m_RenderGraphSBTRecordsDirty)
-		{
-			if (!m_SBTRecords.IsEmpty())
-			{
-				m_pRenderGraph->UpdateGlobalSBT(m_SBTRecords, m_ResourcesToRemove[m_ModFrameIndex]);
-			}
-
-			m_RenderGraphSBTRecordsDirty = false;
-		}
-
 		if (m_PerFrameResourceDirty)
 		{
 			ResourceUpdateDesc resourceUpdateDesc				= {};
@@ -2558,21 +2294,6 @@ namespace LambdaEngine
 			m_pRenderGraph->UpdateResource(&combinedMaterialMapsUpdateDesc);
 
 			m_MaterialsResourceDirty = false;
-		}
-
-		if (m_RayTracingEnabled)
-		{
-			if (m_TLASResourceDirty)
-			{
-				//Create Resource Update for RenderGraph
-				ResourceUpdateDesc resourceUpdateDesc					= {};
-				resourceUpdateDesc.ResourceName							= SCENE_TLAS;
-				resourceUpdateDesc.ExternalAccelerationStructure.pTLAS	= m_pTLAS;
-
-				m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
-
-				m_TLASResourceDirty = false;
-			}
 		}
 	}
 }

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -148,9 +148,9 @@ namespace LambdaEngine
 					.pSubscriber = &m_ParticleEmitters,
 					.ComponentAccesses =
 					{
-						{ NDA, ParticleEmitterComponent::Type() },
-						{ NDA, PositionComponent::Type() },
-						{ NDA, RotationComponent::Type() }
+						{ RW, ParticleEmitterComponent::Type() },
+						{ RW, PositionComponent::Type() },
+						{ RW, RotationComponent::Type() }
 					},
 					.OnEntityRemoval = std::bind(&RenderSystem::OnEmitterEntityRemoved, this, std::placeholders::_1)
 				}
@@ -611,7 +611,7 @@ namespace LambdaEngine
 			const auto& rotationComp = pRotationComponents->GetConstData(entity);
 			const auto& emitterComp = pEmitterComponents->GetConstData(entity);
 
-			if (positionComp.Dirty || rotationComp.Dirty || emitterComp.Dirty)
+			//if (positionComp.Dirty || rotationComp.Dirty || emitterComp.Dirty)
 				UpdateParticleEmitter(entity, positionComp, rotationComp, emitterComp);
 
 			// If onetime emitter we want to reset active

--- a/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Rendering/RenderSystem.cpp
@@ -611,7 +611,7 @@ namespace LambdaEngine
 			const auto& rotationComp = pRotationComponents->GetConstData(entity);
 			const auto& emitterComp = pEmitterComponents->GetConstData(entity);
 
-			//if (positionComp.Dirty || rotationComp.Dirty || emitterComp.Dirty)
+			if (positionComp.Dirty || rotationComp.Dirty || emitterComp.Dirty)
 				UpdateParticleEmitter(entity, positionComp, rotationComp, emitterComp);
 
 			// If onetime emitter we want to reset active

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/BufferVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/BufferVK.cpp
@@ -167,7 +167,7 @@ namespace LambdaEngine
 		m_Desc.DebugName = debugname;
 	}
 	
-	uint64 BufferVK::GetDeviceAdress() const
+	uint64 BufferVK::GetDeviceAddress() const
 	{
 		return static_cast<uint64>(m_DeviceAddress);
 	}

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
@@ -232,7 +232,7 @@ namespace LambdaEngine
 		geometryData.geometryType							= VK_GEOMETRY_TYPE_INSTANCES_KHR;
 		geometryData.geometry.instances.sType				= VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
 		geometryData.geometry.instances.arrayOfPointers		= VK_FALSE;
-		geometryData.geometry.instances.data.deviceAddress	= pInstanceBufferVk->GetDeviceAdress();
+		geometryData.geometry.instances.data.deviceAddress	= pInstanceBufferVk->GetDeviceAddress();
 
 		VkAccelerationStructureGeometryKHR* pGeometryData = &geometryData;
 
@@ -243,7 +243,7 @@ namespace LambdaEngine
 		accelerationStructureBuildInfo.geometryArrayOfPointers		= VK_FALSE;
 		accelerationStructureBuildInfo.geometryCount				= 1;
 		accelerationStructureBuildInfo.ppGeometries					= &pGeometryData;
-		accelerationStructureBuildInfo.scratchData.deviceAddress	= pScratchBufferVk->GetDeviceAdress();
+		accelerationStructureBuildInfo.scratchData.deviceAddress	= pScratchBufferVk->GetDeviceAddress();
 
 		//Extra Flags
 		{
@@ -300,15 +300,15 @@ namespace LambdaEngine
 		geometryData.geometryType									= VK_GEOMETRY_TYPE_TRIANGLES_KHR;
 		geometryData.geometry.triangles.sType						= VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
 		geometryData.geometry.triangles.vertexFormat				= VK_FORMAT_R32G32B32_SFLOAT;
-		geometryData.geometry.triangles.vertexData.deviceAddress	= pVertexBufferVk->GetDeviceAdress();
+		geometryData.geometry.triangles.vertexData.deviceAddress	= pVertexBufferVk->GetDeviceAddress();
 		geometryData.geometry.triangles.vertexStride				= pBuildDesc->VertexStride;
 		geometryData.geometry.triangles.indexType					= VK_INDEX_TYPE_UINT32;
-		geometryData.geometry.triangles.indexData.deviceAddress		= pIndexBufferVk->GetDeviceAdress();
+		geometryData.geometry.triangles.indexData.deviceAddress		= pIndexBufferVk->GetDeviceAddress();
 
 		if (pBuildDesc->pTransformBuffer != nullptr)
 		{
 			const BufferVK* pTransformBufferVk = reinterpret_cast<const BufferVK*>(pBuildDesc->pTransformBuffer);
-			geometryData.geometry.triangles.transformData.deviceAddress = pTransformBufferVk->GetDeviceAdress();
+			geometryData.geometry.triangles.transformData.deviceAddress = pTransformBufferVk->GetDeviceAddress();
 		}
 
 		VkAccelerationStructureGeometryKHR* pGeometryData = &geometryData;
@@ -323,7 +323,7 @@ namespace LambdaEngine
 		accelerationStructureBuildInfo.update						= VK_FALSE;
 		accelerationStructureBuildInfo.srcAccelerationStructure		= VK_NULL_HANDLE;
 		accelerationStructureBuildInfo.dstAccelerationStructure		= pAccelerationStructureVk->GetAccelerationStructure();
-		accelerationStructureBuildInfo.scratchData.deviceAddress	= pScratchBufferVk->GetDeviceAdress();
+		accelerationStructureBuildInfo.scratchData.deviceAddress	= pScratchBufferVk->GetDeviceAddress();
 
 		//Extra Flags
 		{

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/CommandListVK.cpp
@@ -320,9 +320,6 @@ namespace LambdaEngine
 		accelerationStructureBuildInfo.geometryArrayOfPointers		= VK_FALSE;
 		accelerationStructureBuildInfo.geometryCount				= 1;
 		accelerationStructureBuildInfo.ppGeometries					= &pGeometryData;
-		accelerationStructureBuildInfo.update						= VK_FALSE;
-		accelerationStructureBuildInfo.srcAccelerationStructure		= VK_NULL_HANDLE;
-		accelerationStructureBuildInfo.dstAccelerationStructure		= pAccelerationStructureVk->GetAccelerationStructure();
 		accelerationStructureBuildInfo.scratchData.deviceAddress	= pScratchBufferVk->GetDeviceAddress();
 
 		//Extra Flags

--- a/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
@@ -195,24 +195,6 @@ namespace LambdaEngine
 	{
 	}
 
-	//void ImGuiRenderer::UpdateParameters(void* pData)
-	//{
-	//	UNREFERENCED_VARIABLE(pData);
-	//}
-
-	/*void ImGuiRenderer::UpdatePushConstants(void* pData, uint32 dataSize)
-	{
-		UNREFERENCED_VARIABLE(pData);
-		UNREFERENCED_VARIABLE(dataSize);
-	}*/
-
-	void ImGuiRenderer::Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
-	{
-		UNREFERENCED_VARIABLE(delta);
-		UNREFERENCED_VARIABLE(modFrameIndex);
-		UNREFERENCED_VARIABLE(backBufferIndex);
-	}
-
 	void ImGuiRenderer::UpdateTextureResource(
 		const String& resourceName, 
 		const TextureView* const* ppPerImageTextureViews, 
@@ -318,22 +300,6 @@ namespace LambdaEngine
 		{
 			LOG_WARNING("[ImGuiRenderer]: Textures with subImageCount or imageCount != subImageCount and not BackBufferBound is not implemented. imageCount: %d, subImageCount: %d", imageCount, subImageCount);
 		}
-	}
-
-	void ImGuiRenderer::UpdateBufferResource(const String& resourceName, const Buffer* const* ppBuffers, uint64* pOffsets, uint64* pSizesInBytes, uint32 count, bool backBufferBound)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(ppBuffers);
-		UNREFERENCED_VARIABLE(pOffsets);
-		UNREFERENCED_VARIABLE(pSizesInBytes);
-		UNREFERENCED_VARIABLE(count);
-		UNREFERENCED_VARIABLE(backBufferBound);
-	}
-
-	void ImGuiRenderer::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
 	}
 
 	void ImGuiRenderer::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)

--- a/LambdaEngine/Source/Rendering/LightRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/LightRenderer.cpp
@@ -113,14 +113,6 @@ namespace LambdaEngine
 			m_TextureUpdateQueue.Insert(std::end(m_TextureUpdateQueue), std::begin(textureIndices), std::end(textureIndices));
 	}
 
-	void LightRenderer::PreBuffersDescriptorSetWrite()
-	{
-	}
-
-	void LightRenderer::PreTexturesDescriptorSetWrite()
-	{
-	}
-
 	void LightRenderer::Update(LambdaEngine::Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
 	{
 		UNREFERENCED_VARIABLE(delta);
@@ -176,12 +168,6 @@ namespace LambdaEngine
 				LOG_ERROR("[LightRenderer]: Failed to update DescriptorSet[%d]", 0);
 			}
 		}
-	}
-
-	void LightRenderer::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
 	}
 
 	void LightRenderer::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)

--- a/LambdaEngine/Source/Rendering/LineRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/LineRenderer.cpp
@@ -219,13 +219,6 @@ namespace LambdaEngine
 		m_Verticies.PushBack(toData);
 	}
 
-	void LineRenderer::Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
-	{
-		UNREFERENCED_VARIABLE(delta);
-		UNREFERENCED_VARIABLE(modFrameIndex);
-		UNREFERENCED_VARIABLE(backBufferIndex);
-	}
-
 	bool LineRenderer::RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc)
 	{
 		VALIDATE(pPreInitDesc);
@@ -253,14 +246,6 @@ namespace LambdaEngine
 		}
 		
 		return true;
-	}
-
-	void LineRenderer::PreBuffersDescriptorSetWrite()
-	{
-	}
-
-	void LineRenderer::PreTexturesDescriptorSetWrite()
-	{
 	}
 
 	void LineRenderer::UpdateTextureResource(
@@ -363,19 +348,6 @@ namespace LambdaEngine
 				}
 			}
 		}
-	}
-
-	void LineRenderer::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
-	}
-
-	void LineRenderer::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pDrawArgs);
-		UNREFERENCED_VARIABLE(count);
 	}
 
 	void LineRenderer::Render(

--- a/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/PaintMaskRenderer.cpp
@@ -175,22 +175,6 @@ namespace LambdaEngine
 		return true;
 	}
 
-	void PaintMaskRenderer::Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
-	{
-		UNREFERENCED_VARIABLE(delta);
-		UNREFERENCED_VARIABLE(modFrameIndex);
-		UNREFERENCED_VARIABLE(backBufferIndex);
-	}
-
-
-	void PaintMaskRenderer::PreBuffersDescriptorSetWrite()
-	{
-	}
-
-	void PaintMaskRenderer::PreTexturesDescriptorSetWrite()
-	{
-	}
-
 	void PaintMaskRenderer::UpdateTextureResource(const String& resourceName, const TextureView* const * ppPerImageTextureViews, const TextureView* const* ppPerSubImageTextureViews, uint32 imageCount, uint32 subImageCount, bool backBufferBound)
 	{
 		UNREFERENCED_VARIABLE(ppPerImageTextureViews);
@@ -260,12 +244,6 @@ namespace LambdaEngine
 				}
 			}
 		}
-	}
-
-	void PaintMaskRenderer::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
 	}
 
 	void PaintMaskRenderer::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)

--- a/LambdaEngine/Source/Rendering/ParticleManager.cpp
+++ b/LambdaEngine/Source/Rendering/ParticleManager.cpp
@@ -482,10 +482,10 @@ namespace LambdaEngine
 	bool ParticleManager::ActivateEmitterInstance(EmitterID emitterID, const PositionComponent& positionComp, const RotationComponent& rotationComp, const ParticleEmitterComponent& emitterComp)
 	{
 		auto& emitterInstance = m_Emitters[emitterID];
+		UpdateEmitterInstanceData(emitterInstance, positionComp, rotationComp, emitterComp);
+		
 		if (emitterInstance.ParticleChunk.Size > 0)
 		{
-			UpdateEmitterInstanceData(emitterInstance, positionComp, rotationComp, emitterComp);
-
 			if (!AllocateParticleChunk(emitterInstance.ParticleChunk))
 			{
 				LOG_ERROR("[ParticleManager]: Failed to allocate Emitter Particles. Max particle capacity of %u exceeded!", m_Particles.GetSize());

--- a/LambdaEngine/Source/Rendering/ParticleRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/ParticleRenderer.cpp
@@ -360,14 +360,6 @@ namespace LambdaEngine
 		return true;
 	}
 
-	void ParticleRenderer::PreBuffersDescriptorSetWrite()
-	{
-	}
-
-	void ParticleRenderer::PreTexturesDescriptorSetWrite()
-	{
-	}
-
 	void ParticleRenderer::Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
 	{
 		UNREFERENCED_VARIABLE(delta);
@@ -584,19 +576,6 @@ namespace LambdaEngine
 				}
 			}
 		}
-	}
-
-	void ParticleRenderer::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
-	}
-
-	void ParticleRenderer::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pDrawArgs);
-		UNREFERENCED_VARIABLE(count);
 	}
 
 	void ParticleRenderer::Render(uint32 modFrameIndex, uint32 backBufferIndex, CommandList** ppFirstExecutionStage, CommandList** ppSecondaryExecutionStage, bool Sleeping)

--- a/LambdaEngine/Source/Rendering/ParticleUpdater.cpp
+++ b/LambdaEngine/Source/Rendering/ParticleUpdater.cpp
@@ -229,14 +229,6 @@ namespace LambdaEngine
 		return true;
 	}
 
-	void ParticleUpdater::PreBuffersDescriptorSetWrite()
-	{
-	}
-
-	void ParticleUpdater::PreTexturesDescriptorSetWrite()
-	{
-	}
-
 	void ParticleUpdater::Update(Timestamp delta, uint32 modFrameIndex, uint32 backBufferIndex)
 	{
 		UNREFERENCED_VARIABLE(delta);
@@ -401,19 +393,6 @@ namespace LambdaEngine
 
 			m_UpdatePipeline.UpdateDescriptorSet("Alive Particle Buffer Descriptor Set 0 Binding 5", setIndex, m_DescriptorHeap.Get(), descriptorUpdateDesc);
 		}
-	}
-
-	void ParticleUpdater::UpdateAccelerationStructureResource(const String& resourceName, const AccelerationStructure* pAccelerationStructure)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pAccelerationStructure);
-	}
-
-	void ParticleUpdater::UpdateDrawArgsResource(const String& resourceName, const DrawArg* pDrawArgs, uint32 count)
-	{
-		UNREFERENCED_VARIABLE(resourceName);
-		UNREFERENCED_VARIABLE(pDrawArgs);
-		UNREFERENCED_VARIABLE(count);
 	}
 
 	void ParticleUpdater::Render(uint32 modFrameIndex, uint32 backBufferIndex, CommandList** ppFirstExecutionStage, CommandList** ppSecondaryExecutionStage, bool Sleeping)

--- a/LambdaEngine/Source/Rendering/RT/ASBuilder.cpp
+++ b/LambdaEngine/Source/Rendering/RT/ASBuilder.cpp
@@ -1,0 +1,527 @@
+#include "Rendering/RT/ASBuilder.h"
+
+#include "Rendering/RenderGraphTypes.h"
+
+#include "Rendering/Core/API/AccelerationStructure.h"
+#include "Rendering/Core/API/GraphicsDevice.h"
+#include "Rendering/Core/API/CommandList.h"
+#include "Rendering/Core/API/CommandAllocator.h"
+
+#include "Rendering/RenderAPI.h"
+#include "Rendering/RenderGraph.h"
+
+namespace LambdaEngine
+{
+	ASBuilder::ASBuilder()
+	{
+	}
+
+	ASBuilder::~ASBuilder()
+	{
+		SAFERELEASE(m_pTLAS);
+
+		for (BLASData& blasData : m_BLASes)
+		{
+			SAFERELEASE(blasData.pBLAS);
+		}
+
+		m_BLASes.Clear();
+
+		ReleaseBackBufferBound();
+	}
+
+	bool ASBuilder::Init()
+	{
+		return true;
+	}
+
+	bool ASBuilder::RenderGraphInit(const CustomRendererRenderGraphInitDesc* pPreInitDesc)
+	{
+		m_pRenderGraph = pPreInitDesc->pRenderGraph;
+
+		if (m_BackBufferCount != pPreInitDesc->BackBufferCount)
+		{
+			ReleaseBackBufferBound();
+
+			m_BackBufferCount = pPreInitDesc->BackBufferCount;
+
+			CreateCommandLists();
+			CreateBuffers();
+
+			m_pResourcesToRemove = DBG_NEW TArray<DeviceChild*>[m_BackBufferCount];
+		}
+
+		return true;
+	}
+
+	void ASBuilder::BuildTriBLAS(uint32& index, Buffer* pVertexBuffer, Buffer* pIndexBuffer, uint32 vertexCount, uint32 indexCount, bool allowUpdate)
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		if (index == BLAS_UNINITIALIZED_INDEX)
+		{
+			BLASData blasData = {};
+
+			//Create BLAS and SBT Record
+			{
+				AccelerationStructureDesc blasCreateDesc = {};
+				blasCreateDesc.DebugName		= "BLAS";
+				blasCreateDesc.Type				= EAccelerationStructureType::ACCELERATION_STRUCTURE_TYPE_BOTTOM;
+				blasCreateDesc.Flags			= allowUpdate ? FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE : 0;
+				blasCreateDesc.MaxTriangleCount = indexCount / 3;
+				blasCreateDesc.MaxVertexCount	= vertexCount;
+				blasCreateDesc.AllowsTransform	= false;
+
+				blasData.pBLAS = RenderAPI::GetDevice()->CreateAccelerationStructure(&blasCreateDesc);
+
+				SBTRecord* pSBTRecord;
+
+				if (!m_FreeSBTIndices.IsEmpty())
+				{
+					blasData.SBTRecordOffset = m_FreeSBTIndices.GetBack();
+					m_FreeSBTIndices.PopBack();
+
+					pSBTRecord = &m_SBTRecords[blasData.SBTRecordOffset];
+				}
+				else
+				{
+					blasData.SBTRecordOffset = m_SBTRecords.GetSize();
+					pSBTRecord = &m_SBTRecords.PushBack({});
+				}
+
+				pSBTRecord->VertexBufferAddress	= pVertexBuffer->GetDeviceAddress();
+				pSBTRecord->IndexBufferAddress	= pIndexBuffer->GetDeviceAddress();
+				m_SBTRecordsDirty = true;
+
+				if (!m_FreeBLASIndices.IsEmpty())
+				{
+					index = m_FreeBLASIndices.GetBack();
+					m_FreeBLASIndices.PopBack();
+					m_BLASes[index] = blasData;
+				}
+				else
+				{
+					index = m_BLASes.GetSize();
+					m_BLASes.PushBack(blasData);
+				}
+			}
+
+			//Create Build Desc
+			{
+				BuildBottomLevelAccelerationStructureDesc blasBuildDesc = {};
+				blasBuildDesc.pAccelerationStructure	= blasData.pBLAS;
+				blasBuildDesc.Flags						= allowUpdate ? FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE : 0;
+				blasBuildDesc.pVertexBuffer				= pVertexBuffer;
+				blasBuildDesc.FirstVertexIndex			= 0;
+				blasBuildDesc.VertexStride				= sizeof(Vertex);
+				blasBuildDesc.pIndexBuffer				= pIndexBuffer;
+				blasBuildDesc.IndexBufferByteOffset		= 0;
+				blasBuildDesc.TriangleCount				= indexCount / 3;
+				blasBuildDesc.pTransformBuffer			= nullptr;
+				blasBuildDesc.TransformByteOffset		= 0;
+				blasBuildDesc.Update					= false;
+
+				m_DirtyBLASes.PushBack(blasBuildDesc);
+			}
+		}
+		else if (index < m_BLASes.GetSize())
+		{
+			BLASData& blasData = m_BLASes[index];
+
+			//Create BLAS build Desc
+			{
+				//We assume that vertexCount/indexCount does not change and thus do not check if we need to recreate the BLAS
+				BuildBottomLevelAccelerationStructureDesc blasBuildDesc = {};
+				blasBuildDesc.pAccelerationStructure	= blasData.pBLAS;
+				blasBuildDesc.Flags						= FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
+				blasBuildDesc.pVertexBuffer				= pVertexBuffer;
+				blasBuildDesc.FirstVertexIndex			= 0;
+				blasBuildDesc.VertexStride				= sizeof(Vertex);
+				blasBuildDesc.pIndexBuffer				= pIndexBuffer;
+				blasBuildDesc.IndexBufferByteOffset		= 0;
+				blasBuildDesc.TriangleCount				= indexCount / 3;
+				blasBuildDesc.pTransformBuffer			= nullptr;
+				blasBuildDesc.TransformByteOffset		= 0;
+				blasBuildDesc.Update					= true;
+
+				m_DirtyBLASes.PushBack(blasBuildDesc);
+			}
+
+			//Update SBT Record (if needed)
+			{
+				SBTRecord* pSBTRecord = &m_SBTRecords[blasData.SBTRecordOffset];
+
+				uint64 vertexBufferDeviceAddress	= pVertexBuffer->GetDeviceAddress();
+				uint64 indexBufferDeviceAddress		= pIndexBuffer->GetDeviceAddress();
+
+				if (pSBTRecord->VertexBufferAddress != vertexBufferDeviceAddress)
+				{
+					pSBTRecord->VertexBufferAddress = vertexBufferDeviceAddress;
+					m_SBTRecordsDirty = true;
+				}
+
+				if (pSBTRecord->IndexBufferAddress != indexBufferDeviceAddress)
+				{
+					pSBTRecord->IndexBufferAddress = indexBufferDeviceAddress;
+					m_SBTRecordsDirty = true;
+				}
+			}
+		}
+		else
+		{
+			LOG_ERROR("[ASBuilder]: BuildTriBLAS called with index %u, but that BLAS doesn't exist...", index);
+		}
+	}
+
+	void ASBuilder::ReleaseBLAS(uint32 index)
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		VALIDATE(index < m_BLASes.GetSize());
+
+		BLASData& blasData = m_BLASes[index];
+
+		// Push SBT Offset to Free
+		m_FreeSBTIndices.PushBack(blasData.SBTRecordOffset);
+
+		// Release BLAS
+		m_pResourcesToRemove[m_ModFrameIndex].PushBack(blasData.pBLAS);
+
+		//Dequeue from updating if enqueued
+		std::remove_if(m_DirtyBLASes.Begin(), m_DirtyBLASes.End(), 
+			[blasData](const BuildBottomLevelAccelerationStructureDesc& blasBuildDesc)
+			{ 
+				return blasBuildDesc.pAccelerationStructure == blasData.pBLAS;
+			});
+
+		//Push BLAS Free Index
+		m_FreeBLASIndices.PushBack(index);
+
+		//Reset BLASData
+		blasData.pBLAS = nullptr;
+		blasData.SBTRecordOffset = UINT32_MAX;
+	}
+
+	uint32 ASBuilder::AddInstance(uint32 blasIndex, const glm::mat4& transform, uint32 customIndex, uint8 hitMask, FAccelerationStructureFlags flags)
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		VALIDATE(blasIndex < m_BLASes.GetSize());
+		
+		BLASData& blasData = m_BLASes[blasIndex];
+
+		uint32 instanceIndex = m_Instances.GetSize();
+
+		AccelerationStructureInstance asInstance = {};
+		asInstance.Transform					= glm::transpose(transform);
+		asInstance.CustomIndex					= customIndex;
+		asInstance.Mask							= hitMask;
+		asInstance.SBTRecordOffset				= blasData.SBTRecordOffset;
+		asInstance.Flags						= flags;
+		asInstance.AccelerationStructureAddress	= blasData.pBLAS->GetDeviceAddress();
+
+		m_Instances.PushBack(asInstance);
+			
+		uint32 externalIndex;
+
+		if (!m_FreeInstanceIndices.IsEmpty())
+		{
+			externalIndex = m_FreeInstanceIndices.GetBack();
+			m_FreeInstanceIndices.PopBack();
+			m_InstanceIndices[externalIndex] = instanceIndex;
+		}
+		else
+		{
+			externalIndex = m_InstanceIndices.GetSize();
+			m_InstanceIndices.PushBack(instanceIndex);
+		}
+
+		return externalIndex;
+	}
+
+	void ASBuilder::RemoveInstance(uint32 instanceIndex)
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		VALIDATE(instanceIndex < m_InstanceIndices.GetSize());
+
+		//Get True (Indirect) Instance Index
+		uint32 trueInstanceIndex = m_InstanceIndices[instanceIndex];
+
+		VALIDATE(trueInstanceIndex < m_Instances.GetSize());
+
+		//Find the True (Indirect) Instance Index Entry of the Last Instance
+		uint32 backIndex = m_Instances.GetSize() - 1;
+		auto lastInstanceIndexIt = std::find(m_InstanceIndices.Begin(), m_InstanceIndices.End(), backIndex);
+		VALIDATE(lastInstanceIndexIt != m_InstanceIndices.End());
+
+		//Move the Last Instance to the Removed Instance Index
+		m_Instances[trueInstanceIndex] = m_Instances.GetBack();
+		m_Instances.PopBack();
+
+		//Remap the previous Last Instance True (Indirect) Instance Index to point to the removed Index
+		(*lastInstanceIndexIt) = trueInstanceIndex;
+
+		//Push the Removed Instance Index to Free
+		m_FreeInstanceIndices.PushBack(instanceIndex);
+	}
+
+	void ASBuilder::UpdateInstanceTransform(uint32 instanceIndex, const glm::mat4& transform)
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		VALIDATE(instanceIndex < m_InstanceIndices.GetSize());
+
+		//Get True (Indirect) Instance Index
+		uint32 trueInstanceIndex = m_InstanceIndices[instanceIndex];
+
+		VALIDATE(trueInstanceIndex < m_Instances.GetSize());
+
+		AccelerationStructureInstance& asInstance = m_Instances[trueInstanceIndex];
+		asInstance.Transform = glm::transpose(transform);
+	}
+
+	void ASBuilder::UpdateInstances(std::function<void(AccelerationStructureInstance&)> updateFunc)
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		for (AccelerationStructureInstance& asInstance : m_Instances)
+		{
+			updateFunc(asInstance);
+		}
+	}
+
+	void ASBuilder::Update(
+		Timestamp delta, 
+		uint32 modFrameIndex, 
+		uint32 backBufferIndex)
+	{
+		UNREFERENCED_VARIABLE(delta);
+		UNREFERENCED_VARIABLE(backBufferIndex);
+
+		m_ModFrameIndex = modFrameIndex;
+
+		TArray<DeviceChild*>& deviceResourcesToRemove = m_pResourcesToRemove[m_ModFrameIndex];
+
+		for (DeviceChild* pResource : deviceResourcesToRemove)
+		{
+			SAFERELEASE(pResource);
+		}
+
+		deviceResourcesToRemove.Clear();
+
+		//Record Command List, we do this here instead of in Render as we would like to be able to do RenderGraph::UpdateResource if we recreate the TLAS
+		{
+			//We assume the TLAS is always dirty so it's okay to always begin the Command List
+			m_ppComputeCommandAllocators[m_ModFrameIndex]->Reset();
+			CommandList* pCommandList = m_ppComputeCommandLists[m_ModFrameIndex];
+			pCommandList->Begin(nullptr);
+
+			if (m_SBTRecordsDirty)
+			{
+				m_pRenderGraph->UpdateGlobalSBT(pCommandList, m_SBTRecords, deviceResourcesToRemove);
+				m_SBTRecordsDirty = false;
+			}
+
+			//Build BLASes
+			{
+				for (BuildBottomLevelAccelerationStructureDesc& blasBuildDesc : m_DirtyBLASes)
+				{
+					pCommandList->BuildBottomLevelAccelerationStructure(&blasBuildDesc);
+				}
+
+				//This is required to sync up BLAS building with TLAS building, to make sure that the BLAS is built before the TLAS
+				static constexpr const PipelineMemoryBarrierDesc BLAS_MEMORY_BARRIER
+				{
+					.SrcMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_ACCELERATION_STRUCTURE_WRITE,
+					.DstMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_ACCELERATION_STRUCTURE_READ,
+				};
+
+				pCommandList->PipelineMemoryBarriers(
+					FPipelineStageFlag::PIPELINE_STAGE_FLAG_ACCELERATION_STRUCTURE_BUILD, 
+					FPipelineStageFlag::PIPELINE_STAGE_FLAG_ACCELERATION_STRUCTURE_BUILD, 
+					&BLAS_MEMORY_BARRIER,
+					1);
+
+				m_DirtyBLASes.Clear();
+			}
+
+			//Update TLAS, assume always dirty
+			if (!m_Instances.IsEmpty())
+			{
+				Buffer* pInstanceBuffer = m_ppInstanceBuffers[m_ModFrameIndex];
+				uint32 instanceCount = m_Instances.GetSize();
+				uint64 requiredInstanceBufferSize = uint64(instanceCount) * sizeof(AccelerationStructureInstance);
+
+				if (pInstanceBuffer == nullptr || pInstanceBuffer->GetDesc().SizeInBytes < requiredInstanceBufferSize)
+				{
+					if (pInstanceBuffer != nullptr) deviceResourcesToRemove.PushBack(pInstanceBuffer);
+
+					BufferDesc instanceBufferDesc = {};
+					instanceBufferDesc.DebugName		= "Instance Buffer";
+					instanceBufferDesc.MemoryType		= EMemoryType::MEMORY_TYPE_CPU_VISIBLE;
+					instanceBufferDesc.Flags			= FBufferFlag::BUFFER_FLAG_RAY_TRACING;
+					instanceBufferDesc.SizeInBytes		= requiredInstanceBufferSize;
+
+					pInstanceBuffer = RenderAPI::GetDevice()->CreateBuffer(&instanceBufferDesc);
+					m_ppInstanceBuffers[m_ModFrameIndex] = pInstanceBuffer;
+				}
+
+				void* pMapped = pInstanceBuffer->Map();
+				memcpy(pMapped, m_Instances.GetData(), requiredInstanceBufferSize);
+				pInstanceBuffer->Unmap();
+
+				bool update = true;
+
+				//Recreate TLAS completely if m_MaxSupportedTLASInstances < newInstanceCount
+				if (m_MaxSupportedTLASInstances < instanceCount)
+				{
+					if (m_pTLAS != nullptr) deviceResourcesToRemove.PushBack(m_pTLAS);
+
+					m_MaxSupportedTLASInstances = instanceCount;
+					m_BuiltTLASInstanceCount = instanceCount;
+
+					AccelerationStructureDesc createTLASDesc = {};
+					createTLASDesc.DebugName		= "TLAS";
+					createTLASDesc.Type				= EAccelerationStructureType::ACCELERATION_STRUCTURE_TYPE_TOP;
+					createTLASDesc.Flags			= FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
+					createTLASDesc.InstanceCount	= m_MaxSupportedTLASInstances;
+
+					m_pTLAS = RenderAPI::GetDevice()->CreateAccelerationStructure(&createTLASDesc);
+
+					update = false;
+
+					ResourceUpdateDesc resourceUpdateDesc = {};
+					resourceUpdateDesc.ResourceName							= SCENE_TLAS;
+					resourceUpdateDesc.ExternalAccelerationStructure.pTLAS	= m_pTLAS;
+
+					m_pRenderGraph->UpdateResource(&resourceUpdateDesc);
+				}
+				else if (m_BuiltTLASInstanceCount != instanceCount)
+				{
+					m_BuiltTLASInstanceCount = instanceCount;
+					update = false;
+				}
+
+				BuildTopLevelAccelerationStructureDesc buildTLASDesc = {};
+				buildTLASDesc.pAccelerationStructure	= m_pTLAS;
+				buildTLASDesc.Flags						= FAccelerationStructureFlag::ACCELERATION_STRUCTURE_FLAG_ALLOW_UPDATE;
+				buildTLASDesc.Update					= update;
+				buildTLASDesc.pInstanceBuffer			= pInstanceBuffer;
+				buildTLASDesc.InstanceCount				= instanceCount;
+
+				pCommandList->BuildTopLevelAccelerationStructure(&buildTLASDesc);
+
+				static constexpr const PipelineMemoryBarrierDesc TLAS_MEMORY_BARRIER
+				{
+					.SrcMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_ACCELERATION_STRUCTURE_WRITE,
+					.DstMemoryAccessFlags = FMemoryAccessFlag::MEMORY_ACCESS_FLAG_MEMORY_READ,
+				};
+
+				pCommandList->PipelineMemoryBarriers(
+					FPipelineStageFlag::PIPELINE_STAGE_FLAG_ACCELERATION_STRUCTURE_BUILD,
+					FPipelineStageFlag::PIPELINE_STAGE_FLAG_TOP,
+					&TLAS_MEMORY_BARRIER,
+					1);
+			}
+
+			pCommandList->End();
+		}
+	}
+
+	void ASBuilder::Render(
+		uint32 modFrameIndex, 
+		uint32 backBufferIndex, 
+		CommandList** ppFirstExecutionStage, 
+		CommandList** ppSecondaryExecutionStage, 
+		bool sleeping)
+	{
+		UNREFERENCED_VARIABLE(modFrameIndex);
+		UNREFERENCED_VARIABLE(backBufferIndex);
+		UNREFERENCED_VARIABLE(ppSecondaryExecutionStage);
+
+		if (!sleeping)
+		{
+			CommandList* pCommandList = m_ppComputeCommandLists[m_ModFrameIndex];
+			(*ppFirstExecutionStage) = pCommandList;
+		}
+	}
+
+	AccelerationStructureInstance& ASBuilder::GetInstance(uint32 instanceIndex)
+	{
+		std::scoped_lock<SpinLock> lock(m_Lock);
+
+		VALIDATE(instanceIndex < m_InstanceIndices.GetSize());
+
+		//Get True (Indirect) Instance Index
+		uint32 trueInstanceIndex = m_InstanceIndices[instanceIndex];
+
+		VALIDATE(trueInstanceIndex < m_Instances.GetSize());
+
+		return m_Instances[trueInstanceIndex];
+	}
+
+	void ASBuilder::ReleaseBackBufferBound()
+	{
+		for (uint32 b = 0; b < m_BackBufferCount; b++)
+		{
+			TArray<DeviceChild*>& resourcesToRemove = m_pResourcesToRemove[b];
+
+			for (DeviceChild* pResource : resourcesToRemove)
+			{
+				SAFERELEASE(pResource);
+			}
+
+			SAFERELEASE(m_ppComputeCommandAllocators[b]);
+			SAFERELEASE(m_ppComputeCommandLists[b]);
+			SAFERELEASE(m_ppInstanceBuffers[b]);
+		}
+
+		SAFEDELETE_ARRAY(m_pResourcesToRemove);
+		SAFEDELETE_ARRAY(m_ppComputeCommandAllocators);
+		SAFEDELETE_ARRAY(m_ppComputeCommandLists);
+		SAFEDELETE_ARRAY(m_ppInstanceBuffers);
+	}
+
+	bool ASBuilder::CreateCommandLists()
+	{
+		m_ppComputeCommandAllocators = DBG_NEW CommandAllocator*[m_BackBufferCount];
+		m_ppComputeCommandLists = DBG_NEW CommandList*[m_BackBufferCount];
+
+		for (uint32 b = 0; b < m_BackBufferCount; b++)
+		{
+			m_ppComputeCommandAllocators[b] = RenderAPI::GetDevice()->CreateCommandAllocator("AS Builder Compute Command Allocator " + std::to_string(b), ECommandQueueType::COMMAND_QUEUE_TYPE_COMPUTE);
+
+			if (!m_ppComputeCommandAllocators[b])
+			{
+				return false;
+			}
+
+			CommandListDesc commandListDesc = {};
+			commandListDesc.DebugName			= "AS Builder Compute Command List " + std::to_string(b);
+			commandListDesc.CommandListType		= ECommandListType::COMMAND_LIST_TYPE_PRIMARY;
+			commandListDesc.Flags				= FCommandListFlag::COMMAND_LIST_FLAG_ONE_TIME_SUBMIT;
+
+			m_ppComputeCommandLists[b] = RenderAPI::GetDevice()->CreateCommandList(m_ppComputeCommandAllocators[b], &commandListDesc);
+
+			if (!m_ppComputeCommandLists[b])
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool ASBuilder::CreateBuffers()
+	{
+		m_ppInstanceBuffers = DBG_NEW Buffer*[m_BackBufferCount];
+
+		for (uint32 b = 0; b < m_BackBufferCount; b++)
+		{
+			m_ppInstanceBuffers[b] = nullptr;
+		}
+
+		return true;
+	}
+}

--- a/LambdaEngine/Source/Rendering/RT/ASBuilder.cpp
+++ b/LambdaEngine/Source/Rendering/RT/ASBuilder.cpp
@@ -262,6 +262,9 @@ namespace LambdaEngine
 		//Remap the previous Last Instance True (Indirect) Instance Index to point to the removed Index
 		(*lastInstanceIndexIt) = trueInstanceIndex;
 
+		//Invalidate Removed Instance Index
+		m_InstanceIndices[instanceIndex] = UINT32_MAX;
+
 		//Push the Removed Instance Index to Free
 		m_FreeInstanceIndices.PushBack(instanceIndex);
 	}

--- a/LambdaEngine/Source/Rendering/RT/ASBuilder.cpp
+++ b/LambdaEngine/Source/Rendering/RT/ASBuilder.cpp
@@ -188,11 +188,17 @@ namespace LambdaEngine
 		m_pResourcesToRemove[m_ModFrameIndex].PushBack(blasData.pBLAS);
 
 		//Dequeue from updating if enqueued
-		std::remove_if(m_DirtyBLASes.Begin(), m_DirtyBLASes.End(), 
-			[blasData](const BuildBottomLevelAccelerationStructureDesc& blasBuildDesc)
-			{ 
-				return blasBuildDesc.pAccelerationStructure == blasData.pBLAS;
-			});
+		for (auto dirtyBLASIt = m_DirtyBLASes.Begin(); dirtyBLASIt != m_DirtyBLASes.End();)
+		{
+			if (dirtyBLASIt->pAccelerationStructure == blasData.pBLAS)
+			{
+				dirtyBLASIt = m_DirtyBLASes.Erase(dirtyBLASIt);
+			}
+			else
+			{
+				dirtyBLASIt++;
+			}
+		}
 
 		//Push BLAS Free Index
 		m_FreeBLASIndices.PushBack(index);
@@ -202,7 +208,7 @@ namespace LambdaEngine
 		blasData.SBTRecordOffset = UINT32_MAX;
 	}
 
-	uint32 ASBuilder::AddInstance(uint32 blasIndex, const glm::mat4& transform, uint32 customIndex, uint8 hitMask, FAccelerationStructureFlags flags)
+	uint32 ASBuilder::AddInstance(uint32 blasIndex, const glm::mat4& transform, uint32 customIndex, uint8 hitMask, FAccelerationStructureInstanceFlags flags)
 	{
 		std::scoped_lock<SpinLock> lock(m_Lock);
 


### PR DESCRIPTION
## Purpose
  - The task being implemented is called "Move AS Building to a Custom Renderer".
  - We want to be able to Ray Trace both Particles and Metaballs, but these are / are going to be generated in a Custom Renderer. This leads to a problem with the current Acceleration Structure (AS) Building, since that is done in RenderSystem Render which would mean that the Ray Tracer would lag behind the Rasterized Result by one frame.
  - This fixes that problem by moving Acceleration Structure Building into a Custom Renderer called ASBuilder meaning that Acceleration Structure Building can be done at any time in the Render Pipeline.
  - The TLAS, BLAS and SBT has also been completely reworked in how they are handled, it is now much simpler and more optimized.
  - This also allows for easier integration with new systems as all they have to do is call "BuildBLAS" or "AddInstance" to add data to the Ray Tracer.

## Changes
 - Most of the solution is implemented in the ASBuilder. Much code has also been removed from RenderSystem.
