### PR TITLE
Player Weapon rendered correctly

### DIFF
--- a/CrazyCanvas/Include/RenderStages/PlayerRenderer.h
+++ b/CrazyCanvas/Include/RenderStages/PlayerRenderer.h
@@ -16,10 +16,19 @@ namespace LambdaEngine
 		glm::vec3 Positon;
 	};
 
+	struct WeaponData
+	{
+		uint32 EntityId;
+		uint32 DrawArgIndex;
+		uint32 InstanceIndex;
+	};
+
 	struct PlayerData
 	{
 		uint32 DrawArgIndex;
+		uint32 EntityId;
 		uint32 TeamId;
+		WeaponData Weapon;
 		glm::vec3 Position;
 		float32 Distance2ToViewer;
 	};

--- a/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
+++ b/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
@@ -390,7 +390,6 @@ namespace LambdaEngine
 								// Store weapons for later use. Easier to map to players
 								if (pWeaponComponents->HasComponent(entity))
 								{
-									LOG_INFO("d: %d , with entityID: %d is a weapon, entityIds: %d", d, entity, m_pDrawArgs[d].EntityIDs.GetSize());
 									weapons.PushBack({ .EntityId = entity, .DrawArgIndex = d, .InstanceIndex = i});
 								}
 								else 
@@ -446,11 +445,15 @@ namespace LambdaEngine
 				{
 					auto weaponOwner = pWeaponComponents->GetConstData(weapon.EntityId).WeaponOwner;
 					auto it = std::find_if(m_PlayerData.Begin(), m_PlayerData.End(),
-						[&weaponOwner](const PlayerData& pd) {return pd.EntityId == weaponOwner; });
+						[&weaponOwner](const PlayerData& pd) { return pd.EntityId == weaponOwner; });
 
 					if (it != m_PlayerData.end())
 					{
 						it->Weapon = weapon;
+					}
+					else
+					{
+						LOG_WARNING("[PlayerRenderer] A Weapon %d without a player is present.", weapon.EntityId);
 					}
 				}
 

--- a/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
+++ b/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
@@ -12,7 +12,9 @@
 #include "ECS/ECSCore.h"
 #include "ECS/Components/Team/TeamComponent.h"
 #include "ECS/Components/Player/Player.h"
+#include "ECS/Components/Player/WeaponComponent.h"
 
+#include "Game/ECS/Components/Player/PlayerRelatedComponent.h"
 #include "Game/ECS/Systems/Rendering/RenderSystem.h"
 #include "Game/ECS/Components/Rendering/MeshPaintComponent.h"
 
@@ -363,10 +365,14 @@ namespace LambdaEngine
 
 				ECSCore* pECSCore = ECSCore::GetInstance();
 				const ComponentArray<TeamComponent>* pTeamComponents = pECSCore->GetComponentArray<TeamComponent>();
+				const ComponentArray<PlayerRelatedComponent>* pPlayerRelatedComponents = pECSCore->GetComponentArray<PlayerRelatedComponent>();
 				const ComponentArray<PositionComponent>* pPositionComponents = pECSCore->GetComponentArray<PositionComponent>();
 				const ComponentArray<PlayerLocalComponent>* pPlayerLocalComponents = pECSCore->GetComponentArray<PlayerLocalComponent>();
+				const ComponentArray<WeaponComponent>* pWeaponComponents = pECSCore->GetComponentArray<WeaponComponent>();
 
 				m_PlayerData.Clear();
+				TArray<WeaponData> weapons;
+
 				for (uint32 d = 0; d < m_DrawCount; d++)
 				{
 					constexpr DescriptorSetIndex setIndex = 2U;
@@ -376,50 +382,75 @@ namespace LambdaEngine
 
 					if (m_DescriptorSetList2[d] != nullptr)
 					{
-						// Assume EntityIDs is always 1 in length. (Because animated meshes.)
-						Entity entity = m_pDrawArgs[d].EntityIDs[0];
-
-						// Used to sort by distance in render()
-						if (pTeamComponents->HasComponent(entity))
+						for (uint32 i = 0; i < m_pDrawArgs[d].EntityIDs.GetSize(); i++)
 						{
-							PlayerData playerData;
-							playerData.DrawArgIndex = d;
-							playerData.TeamId = pTeamComponents->GetConstData(entity).TeamIndex;
-							playerData.Position = pPositionComponents->GetConstData(entity).Position;
-							m_PlayerData.PushBack(playerData);
-
-							if (pPlayerLocalComponents && pPlayerLocalComponents->HasComponent(entity))
+							Entity entity = m_pDrawArgs[d].EntityIDs[i];
+							if (pPlayerRelatedComponents->HasComponent(entity))
 							{
-								m_Viewer.TeamId = pTeamComponents->GetConstData(entity).TeamIndex;
-								m_Viewer.EntityId = entity;
-								m_Viewer.DrawArgIndex = d;
-								m_Viewer.Positon = pPositionComponents->GetConstData(entity).Position;
+								// Store weapons for later use. Easier to map to players
+								if (pWeaponComponents->HasComponent(entity))
+								{
+									LOG_INFO("d: %d , with entityID: %d is a weapon, entityIds: %d", d, entity, m_pDrawArgs[d].EntityIDs.GetSize());
+									weapons.PushBack({ .EntityId = entity, .DrawArgIndex = d, .InstanceIndex = i});
+								}
+								else 
+								{
+									// Set player data for distance and weapon sorting
+									PlayerData playerData;
+									playerData.DrawArgIndex = d;
+									playerData.TeamId = pTeamComponents->GetConstData(entity).TeamIndex;
+									playerData.Position = pPositionComponents->GetConstData(entity).Position;
+									playerData.EntityId = entity;
+									m_PlayerData.PushBack(playerData);
+								}
+
+								// Set viewer data
+								if (pPlayerLocalComponents && pPlayerLocalComponents->HasComponent(entity))
+								{
+									m_Viewer.TeamId = pTeamComponents->GetConstData(entity).TeamIndex;
+									m_Viewer.EntityId = entity;
+									m_Viewer.DrawArgIndex = d;
+									m_Viewer.Positon = pPositionComponents->GetConstData(entity).Position;
+								}
+								else
+								{
+									// Set Vertex and Instance buffer for rendering
+									Buffer* ppBuffers[2] = { m_pDrawArgs[d].pVertexBuffer, m_pDrawArgs[d].pInstanceBuffer };
+									uint64 pOffsets[2] = { 0, 0 };
+									uint64 pSizes[2] = { m_pDrawArgs[d].pVertexBuffer->GetDesc().SizeInBytes, m_pDrawArgs[d].pInstanceBuffer->GetDesc().SizeInBytes };
+
+									m_DescriptorSetList2[d]->WriteBufferDescriptors(
+										ppBuffers,
+										pOffsets,
+										pSizes,
+										0,
+										2,
+										EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER
+									);
+								}
 							}
 							else
 							{
-								// Set Vertex and Instance buffer for rendering
-								Buffer* ppBuffers[2] = { m_pDrawArgs[d].pVertexBuffer, m_pDrawArgs[d].pInstanceBuffer };
-								uint64 pOffsets[2] = { 0, 0 };
-								uint64 pSizes[2] = { m_pDrawArgs[d].pVertexBuffer->GetDesc().SizeInBytes, m_pDrawArgs[d].pInstanceBuffer->GetDesc().SizeInBytes };
-
-								m_DescriptorSetList2[d]->WriteBufferDescriptors(
-									ppBuffers,
-									pOffsets,
-									pSizes,
-									0,
-									2,
-									EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER
-								);
+								LOG_ERROR("[PlayerRenderer]: A entity must have a TeamComponent for it to be processed by PlayerRenderer!");
 							}
-						}
-						else
-						{
-							LOG_ERROR("[PlayerRenderer]: A entity must have a TeamComponent for it to be processed by PlayerRenderer!");
 						}
 					}
 					else
 					{
 						LOG_ERROR("[PlayerRenderer]: Failed to update descriptors for drawArgs vertices and instance buffers");
+					}
+				}
+
+				// Decide weapon for all players
+				for (auto const& weapon : weapons)
+				{
+					auto weaponOwner = pWeaponComponents->GetConstData(weapon.EntityId).WeaponOwner;
+					auto it = std::find_if(m_PlayerData.Begin(), m_PlayerData.End(),
+						[&weaponOwner](const PlayerData& pd) {return pd.EntityId == weaponOwner; });
+
+					if (it != m_PlayerData.end())
+					{
+						it->Weapon = weapon;
 					}
 				}
 
@@ -436,7 +467,7 @@ namespace LambdaEngine
 					}
 				}
 
-				// Get Paint Mask Texture from each player
+				// Get Paint Mask Texture from each player & weapon
 				for (uint32 d = 0; d < count; d++)
 				{
 					constexpr DescriptorSetIndex setIndex = 3U;
@@ -568,7 +599,6 @@ namespace LambdaEngine
 									uint64& pipelineId) 
 	{
 		pCommandList->BindGraphicsPipeline(PipelineStateManager::GetPipelineState(pipelineId));
-
 		pCommandList->BindDescriptorSetGraphics(m_DescriptorSet0.Get(), m_PipelineLayout.Get(), 0); // BUFFER_SET_INDEX
 		pCommandList->BindDescriptorSetGraphics(m_DescriptorSet1.Get(), m_PipelineLayout.Get(), 1); // TEXTURE_SET_INDEX
 
@@ -591,23 +621,31 @@ namespace LambdaEngine
 				bool isEnemy = (player.TeamId == 1);
 				bool isTeamMate = (player.TeamId == 0);
 
-				// Filter enemies if rendering teamates
+				// Remove enemies if rendering teamates
 				if (!renderEnemy && isEnemy) {
 					continue;
 				}
 
-				// Filter teammates if rendering enemies
+				// Remove teammates if rendering enemies
 				if (renderEnemy && isTeamMate) {
 					continue;
 				}
 
+				// Draw player
 				const DrawArg& drawArg = m_pDrawArgs[player.DrawArgIndex];
-
 				pCommandList->SetConstantRange(m_PipelineLayout.Get(), FShaderStageFlag::SHADER_STAGE_FLAG_PIXEL_SHADER, &player.TeamId, sizeof(uint32), 0);
 				pCommandList->BindIndexBuffer(drawArg.pIndexBuffer, 0, EIndexType::INDEX_TYPE_UINT32);
 				pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList2[player.DrawArgIndex].Get(), m_PipelineLayout.Get(), 2); // Mesh data (Vertices and instance buffers)
 				pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList3[player.DrawArgIndex].Get(), m_PipelineLayout.Get(), 3); // Paint Masks
 				pCommandList->DrawIndexInstanced(drawArg.IndexCount, drawArg.InstanceCount, 0, 0, 0);
+
+				// Draw player weapon
+				const DrawArg& drawArgWeapon = m_pDrawArgs[player.Weapon.DrawArgIndex];
+				pCommandList->SetConstantRange(m_PipelineLayout.Get(), FShaderStageFlag::SHADER_STAGE_FLAG_PIXEL_SHADER, &player.TeamId, sizeof(uint32), 0);
+				pCommandList->BindIndexBuffer(drawArgWeapon.pIndexBuffer, 0, EIndexType::INDEX_TYPE_UINT32);
+				pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList2[player.Weapon.DrawArgIndex].Get(), m_PipelineLayout.Get(), 2); // Mesh data (Vertices and instance buffers)
+				pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList3[player.Weapon.DrawArgIndex].Get(), m_PipelineLayout.Get(), 3); // Paint Masks
+				pCommandList->DrawIndexInstanced(drawArgWeapon.IndexCount, 1, 0, 0, player.Weapon.InstanceIndex);
 			}
 
 		}


### PR DESCRIPTION
## Purpose
  - Related to task "Enemy weapons are visible for one team"
  - Now the opposing team is completely invisible
  - The viewers weapon is now excluded from rendering

## Changes
 - When UpdateDrawArg function is called weapon data is saved in a temporary `TArray<WeaponData> weapons`.
 - Directly after collecting all weapons they are attached to corresponding  `m_PlayerData` such that each player has a weapon.
 - For each player Draw call its weapon is drawn directly after.

## Testing
How have one tested the feature to ensure it works?
- [ ] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [x] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

## Context (Optional)
The issue was that the Weapons are sometimes in the same drawArg. Which meant that I was drawing my team players weapon twice. Once in the hand of the team mate and once in the hand of an enemy.

Using `player.Weapon.InstanceIndex` makes sure the correct weapon instance associated with the current player is being drawn.

`pCommandList->DrawIndexInstanced(drawArgWeapon.IndexCount, 1, 0, 0, player.Weapon.InstanceIndex);`

```cpp
// Draw player
const DrawArg& drawArg = m_pDrawArgs[player.DrawArgIndex];
pCommandList->SetConstantRange(m_PipelineLayout.Get(), FShaderStageFlag::SHADER_STAGE_FLAG_PIXEL_SHADER, &player.TeamId, sizeof(uint32), 0);
pCommandList->BindIndexBuffer(drawArg.pIndexBuffer, 0, EIndexType::INDEX_TYPE_UINT32);
pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList2[player.DrawArgIndex].Get(), m_PipelineLayout.Get(), 2); // Mesh data (Vertices and instance buffers)
pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList3[player.DrawArgIndex].Get(), m_PipelineLayout.Get(), 3); // Paint Masks
pCommandList->DrawIndexInstanced(drawArg.IndexCount, drawArg.InstanceCount, 0, 0, 0);

// Draw player weapon
const DrawArg& drawArgWeapon = m_pDrawArgs[player.Weapon.DrawArgIndex];
pCommandList->SetConstantRange(m_PipelineLayout.Get(), FShaderStageFlag::SHADER_STAGE_FLAG_PIXEL_SHADER, &player.TeamId, sizeof(uint32), 0);
pCommandList->BindIndexBuffer(drawArgWeapon.pIndexBuffer, 0, EIndexType::INDEX_TYPE_UINT32);
pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList2[player.Weapon.DrawArgIndex].Get(), m_PipelineLayout.Get(), 2); // Mesh data (Vertices and instance buffers)
pCommandList->BindDescriptorSetGraphics(m_DescriptorSetList3[player.Weapon.DrawArgIndex].Get(), m_PipelineLayout.Get(), 3); // Paint Masks
pCommandList->DrawIndexInstanced(drawArgWeapon.IndexCount, 1, 0, 0, player.Weapon.InstanceIndex); // <--- HERE
``` 

## Screen Captures (Optional)
Red team view
![image](https://user-images.githubusercontent.com/3958329/99265724-ac563380-282a-11eb-9f35-cbab63112cb8.png)

Blue team view
![image](https://user-images.githubusercontent.com/3958329/99265791-c4c64e00-282a-11eb-847e-28bfd36ba9b1.png)


