### PR TITLE
Lightrenderer now uses predefined descriptors for drawArgs

### DIFF
--- a/Assets/Shaders/ShadowMap/PointLShadowMap.vert
+++ b/Assets/Shaders/ShadowMap/PointLShadowMap.vert
@@ -8,21 +8,21 @@
 #include "../Defines.glsl"
 
 layout( push_constant ) uniform PushConstants {
-    uint Iteration;
-    uint PointLightIndex;
+	uint Iteration;
+	uint PointLightIndex;
 } pc;
 
-layout(binding = 0, set = BUFFER_SET_INDEX) restrict readonly buffer LightsBuffer
+layout(binding = 0, set = 0) restrict readonly buffer LightsBuffer
 {
 	SLightsBuffer val; 
 	SPointLight pointLights[];  
 } b_LightsBuffer;
 
-layout(binding = 0, set = DRAW_SET_INDEX) restrict readonly buffer Vertices         { SVertex val[]; }      b_Vertices;
-layout(binding = 1, set = DRAW_SET_INDEX) restrict readonly buffer Instances        { SInstance val[]; }    b_Instances;
-layout(binding = 2, set = DRAW_SET_INDEX) restrict readonly buffer Meshlets			{ SMeshlet Val[]; } 	b_Meshlets;
-layout(binding = 3, set = DRAW_SET_INDEX) restrict readonly buffer UniqueIndices	{ uint Val[]; } 		b_UniqueIndices;
-layout(binding = 4, set = DRAW_SET_INDEX) restrict readonly buffer PrimitiveIndices	{ uint Val[]; } 		b_PrimitiveIndices;
+layout(binding = 0, set = 1) restrict readonly buffer Vertices         { SVertex val[]; }       b_Vertices;
+layout(binding = 1, set = 1) restrict readonly buffer Instances        { SInstance val[]; }     b_Instances;
+layout(binding = 2, set = 1) restrict readonly buffer Meshlets			{ SMeshlet Val[]; } 	b_Meshlets;
+layout(binding = 3, set = 1) restrict readonly buffer UniqueIndices	{ uint Val[]; } 		    b_UniqueIndices;
+layout(binding = 4, set = 1) restrict readonly buffer PrimitiveIndices	{ uint Val[]; } 		b_PrimitiveIndices;
 
 layout(location = 0) out vec4 out_WorldPos;
 layout(location = 1) out flat vec3 out_PointLightPosition;
@@ -30,16 +30,16 @@ layout(location = 2) out flat float out_FarPlane;
 
 void main()
 {
-    SVertex vertex                              = b_Vertices.val[gl_VertexIndex];
-    SInstance instance                          = b_Instances.val[gl_InstanceIndex];
-    SLightsBuffer lightsBuffer                  = b_LightsBuffer.val;
-    
-    uint faceIndex          = pc.Iteration % 6U;
-    SPointLight pointLight = b_LightsBuffer.pointLights[pc.PointLightIndex];
+	SVertex vertex                              = b_Vertices.val[gl_VertexIndex];
+	SInstance instance                          = b_Instances.val[gl_InstanceIndex];
+	SLightsBuffer lightsBuffer                  = b_LightsBuffer.val;
+	
+	uint faceIndex          = pc.Iteration % 6U;
+	SPointLight pointLight = b_LightsBuffer.pointLights[pc.PointLightIndex];
 
-    out_FarPlane            = pointLight.FarPlane;
-    out_WorldPos            = instance.Transform * vec4(vertex.Position.xyz, 1.0f);
-    out_PointLightPosition  = pointLight.Position;
-    gl_Position             = pointLight.ProjView[faceIndex] * out_WorldPos;
-    gl_Position.y           *= -1.0;
+	out_FarPlane            = pointLight.FarPlane;
+	out_WorldPos            = instance.Transform * vec4(vertex.Position.xyz, 1.0f);
+	out_PointLightPosition  = pointLight.Position;
+	gl_Position             = pointLight.ProjView[faceIndex] * out_WorldPos;
+	gl_Position.y           *= -1.0;
 }

--- a/LambdaEngine/Source/Rendering/LightRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/LightRenderer.cpp
@@ -180,38 +180,16 @@ namespace LambdaEngine
 				m_pDrawArgs = pDrawArgs;
 				m_DrawCount = count;
 
-				constexpr DescriptorSetIndex setIndex = 1U;
-
 				m_DrawArgsDescriptorSets.Clear();
 				m_DrawArgsDescriptorSets.Resize(m_DrawCount);
-
-				// Create DrawArgs Descriptors
-				// TODO: Get descriptors instead of reacreating them
 				for (uint32 d = 0; d < m_DrawCount; d++)
 				{
-					// Create a new descriptor or use an old descriptor
-					m_DrawArgsDescriptorSets[d] = m_DescriptorCache.GetDescriptorSet("Light Renderer Descriptor Set " + std::to_string(d), m_PipelineLayout.Get(), setIndex, m_DescriptorHeap.Get());
-
-					if (m_DrawArgsDescriptorSets[d] != nullptr)
-					{
-						Buffer* ppBuffers[2] = { m_pDrawArgs[d].pVertexBuffer, m_pDrawArgs[d].pInstanceBuffer };
-						uint64 pOffsets[2]	 = { 0, 0 };
-						uint64 pSizes[2]	 = { m_pDrawArgs[d].pVertexBuffer->GetDesc().SizeInBytes, m_pDrawArgs[d].pInstanceBuffer->GetDesc().SizeInBytes };
-
-						m_DrawArgsDescriptorSets[d]->WriteBufferDescriptors(
-							ppBuffers,
-							pOffsets,
-							pSizes,
-							0,
-							2,
-							EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER
-						);
-					}
+					m_DrawArgsDescriptorSets[d] = MakeSharedRef(pDrawArgs[d].pDescriptorSet);
 				}
 			}
 			else
 			{
-				LOG_ERROR("[LightRenderer]: Failed to update descriptors for drawArgs");
+				m_DrawCount = 0;
 			}
 		}
 	}
@@ -312,13 +290,31 @@ namespace LambdaEngine
 		verticesBindingDesc.DescriptorType = EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER;
 		verticesBindingDesc.DescriptorCount = 1;
 		verticesBindingDesc.Binding = 0;
-		verticesBindingDesc.ShaderStageMask = FShaderStageFlag::SHADER_STAGE_FLAG_VERTEX_SHADER;
+		verticesBindingDesc.ShaderStageMask = FShaderStageFlag::SHADER_STAGE_FLAG_ALL;
 
 		DescriptorBindingDesc instanceBindingDesc = {};
 		instanceBindingDesc.DescriptorType = EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER;
 		instanceBindingDesc.DescriptorCount = 1;
 		instanceBindingDesc.Binding = 1;
-		instanceBindingDesc.ShaderStageMask = FShaderStageFlag::SHADER_STAGE_FLAG_VERTEX_SHADER;
+		instanceBindingDesc.ShaderStageMask = FShaderStageFlag::SHADER_STAGE_FLAG_ALL;
+
+		DescriptorBindingDesc meshletsDesc = {};
+		meshletsDesc.DescriptorType = EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER;
+		meshletsDesc.DescriptorCount = 1;
+		meshletsDesc.Binding = 2;
+		meshletsDesc.ShaderStageMask = FShaderStageFlag::SHADER_STAGE_FLAG_ALL;
+
+		DescriptorBindingDesc uniqueIndicesDesc = {};
+		uniqueIndicesDesc.DescriptorType = EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER;
+		uniqueIndicesDesc.DescriptorCount = 1;
+		uniqueIndicesDesc.Binding = 3;
+		uniqueIndicesDesc.ShaderStageMask = FShaderStageFlag::SHADER_STAGE_FLAG_ALL;
+
+		DescriptorBindingDesc primitiveIndicesDesc = {};
+		primitiveIndicesDesc.DescriptorType = EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER;
+		primitiveIndicesDesc.DescriptorCount = 1;
+		primitiveIndicesDesc.Binding = 4;
+		primitiveIndicesDesc.ShaderStageMask = FShaderStageFlag::SHADER_STAGE_FLAG_ALL;
 
 		DescriptorBindingDesc lightsBindingDesc = {};
 		lightsBindingDesc.DescriptorType = EDescriptorType::DESCRIPTOR_TYPE_UNORDERED_ACCESS_BUFFER;
@@ -330,7 +326,7 @@ namespace LambdaEngine
 		descriptorSetLayoutDesc1.DescriptorBindings = { lightsBindingDesc };
 
 		DescriptorSetLayoutDesc descriptorSetLayoutDesc2 = {};
-		descriptorSetLayoutDesc2.DescriptorBindings = { verticesBindingDesc, instanceBindingDesc };
+		descriptorSetLayoutDesc2.DescriptorBindings = { verticesBindingDesc, instanceBindingDesc, meshletsDesc, uniqueIndicesDesc, primitiveIndicesDesc };
 
 		ConstantRangeDesc constantRangeDesc = {};
 		constantRangeDesc.OffsetInBytes = 0U;
@@ -354,7 +350,7 @@ namespace LambdaEngine
 		descriptorCountDesc.TextureDescriptorCount = 0;
 		descriptorCountDesc.TextureCombinedSamplerDescriptorCount = 0;
 		descriptorCountDesc.ConstantBufferDescriptorCount = 0;
-		descriptorCountDesc.UnorderedAccessBufferDescriptorCount = 3;
+		descriptorCountDesc.UnorderedAccessBufferDescriptorCount = 6;
 		descriptorCountDesc.UnorderedAccessTextureDescriptorCount = 0;
 		descriptorCountDesc.AccelerationStructureDescriptorCount = 0;
 


### PR DESCRIPTION
## Purpose
Lightrenderer used to create it's own descriptors sets for the drawargs, due to how the descriptor cache works a lot of descriptors were allocated, which caused validation error VK_POOL_OUT_OF_MEMORY. Lightrenderer now uses the drawargs descriptors which are passed in the parameter of UpdateDrawArgsResource, this decrases the descriptor set allocations. 

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

