### PR TITLE
Fixed Unloading Bug

### DIFF
--- a/LambdaEngine/Source/Resources/ResourceManager.cpp
+++ b/LambdaEngine/Source/Resources/ResourceManager.cpp
@@ -1387,9 +1387,18 @@ namespace LambdaEngine
 		auto textureIt = s_Textures.find(guid);
 		if (textureIt != s_Textures.end())
 		{
+			auto textureViewIt = s_TextureViews.find(guid);
+			if (textureViewIt == s_TextureViews.end())
+			{
+				LOG_ERROR("[ResourceManager]: UnloadTexture Failed at s_TextureViews GUID: %d", guid);
+				return false;
+			}
+
 			D_LOG_WARNING("Deleted Texture GUID: %d", guid);
 
-			SAFEDELETE(textureIt->second);
+			SAFERELEASE(textureViewIt->second);
+			s_TextureViews.erase(textureViewIt);
+			SAFERELEASE(textureIt->second);
 			s_Textures.erase(textureIt);
 
 			auto textureGUIDToNameIt = s_TextureGUIDsToNames.find(guid);
@@ -1434,7 +1443,7 @@ namespace LambdaEngine
 		{
 			D_LOG_WARNING("Deleted Shader GUID: %d", guid);
 
-			SAFEDELETE(shaderIt->second);
+			SAFERELEASE(shaderIt->second);
 			s_Shaders.erase(shaderIt);
 
 			auto shaderGUIDToNameIt = s_ShaderGUIDsToNames.find(guid);


### PR DESCRIPTION
## Purpose
  - Fixes two bugs in Resource Manager Unloading:
     - Device Resources were not released with SAFERELEASE but with SAFEDELETE
     - Texture Views were not released when the corresponding texture was released.

## Changes
 - Minor changes in Resource Manager.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

