### PR TITLE
Fixed Scroll Problem

### DIFF
--- a/LambdaEngine/Source/Application/Win32/Win32Application.cpp
+++ b/LambdaEngine/Source/Application/Win32/Win32Application.cpp
@@ -373,22 +373,26 @@ namespace LambdaEngine
 
 			case WM_MOUSEWHEEL:
 			{
-				const int32 x = GET_X_LPARAM(lParam);
-				const int32 y = GET_Y_LPARAM(lParam);
+				POINT point;
+				point.x = GET_X_LPARAM(lParam);
+				point.y = GET_Y_LPARAM(lParam);
+				ScreenToClient(hWnd, &point);
 
 				const int32 scrollDelta = GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
-				m_EventHandler->OnMouseScrolled(0, scrollDelta, x, y);
+				m_EventHandler->OnMouseScrolled(0, scrollDelta, point.x, point.y);
 
 				break;
 			}
 
 			case WM_MOUSEHWHEEL:
 			{
-				const int32 x = GET_X_LPARAM(lParam);
-				const int32 y = GET_Y_LPARAM(lParam);
+				POINT point;
+				point.x = GET_X_LPARAM(lParam);
+				point.y = GET_Y_LPARAM(lParam);
+				ScreenToClient(hWnd, &point);
 
 				const int32 scrollDelta = GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
-				m_EventHandler->OnMouseScrolled(scrollDelta, 0, x, y);
+				m_EventHandler->OnMouseScrolled(scrollDelta, 0, point.x, point.y);
 				break;
 			}
 

--- a/LambdaEngine/Source/GUI/Core/GUIApplication.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIApplication.cpp
@@ -205,8 +205,8 @@ namespace LambdaEngine
 		if (s_pView.GetPtr() == nullptr)
 			return true;
 
-		if (mouseScrolledEvent.DeltaY > 0)		s_pView->MouseWheel(mouseScrolledEvent.Position.x, mouseScrolledEvent.Position.y, mouseScrolledEvent.DeltaY);
-		else if (mouseScrolledEvent.DeltaX > 0)	s_pView->MouseHWheel(mouseScrolledEvent.Position.x, mouseScrolledEvent.Position.y, mouseScrolledEvent.DeltaX);
+		if (glm::abs(mouseScrolledEvent.DeltaY) > 0)		s_pView->MouseWheel(mouseScrolledEvent.Position.x, mouseScrolledEvent.Position.y, 120 * mouseScrolledEvent.DeltaY);
+		else if (glm::abs(mouseScrolledEvent.DeltaX) > 0)	s_pView->MouseHWheel(mouseScrolledEvent.Position.x, mouseScrolledEvent.Position.y, 120 * mouseScrolledEvent.DeltaX);
 
 		return true;
 	}


### PR DESCRIPTION
## Purpose
  - Fixes the scrolling issue in Noesis GUI panels.

## Changes
 - There were two problems, one in GUIApplication where I should've checked abs(someValue) but didn't.
 - The other problem was that all Windows mouse events like WM_LBUTTONDOWN store client relative position in lParam, but for WM_MOUSEWHEEL it instead stores window relative position for some god-forsaken reason.

## Testing
How have one tested the feature to ensure it works?
- [ ] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark
- Tested in lobby

