### PR TITLE
Implement jump

### DIFF
--- a/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerAction.h
+++ b/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerAction.h
@@ -11,8 +11,7 @@ struct PacketPlayerAction : Packet
 	DECL_PACKET(PacketPlayerAction);
 
 	glm::quat Rotation;
-	int8 DeltaForward	= 0;
-	int8 DeltaLeft		= 0;
+	glm::i8vec3 DeltaAction;
 	bool StartedReload	= false;
 	EAmmoType FiredAmmo	= EAmmoType::AMMO_TYPE_NONE; // Default is that we fired no projectiles
 	uint32 Angle		= 0;

--- a/CrazyCanvas/Include/World/Player/PlayerActionSystem.h
+++ b/CrazyCanvas/Include/World/Player/PlayerActionSystem.h
@@ -23,7 +23,7 @@ private:
 	bool OnKeyPressed(const LambdaEngine::KeyPressedEvent& event);
 
 public:
-	static void ComputeVelocity(const glm::quat& rotation, int8 deltaForward, int8 deltaLeft, glm::vec3& result);
+	static void ComputeVelocity(const glm::quat& rotation, const glm::i8vec3& deltaAction, glm::vec3& result);
 	static void SetMouseEnabled(bool isEnabled);
 
 private:

--- a/CrazyCanvas/Include/World/Player/PlayerGameState.h
+++ b/CrazyCanvas/Include/World/Player/PlayerGameState.h
@@ -9,8 +9,7 @@ struct PlayerGameState
 	glm::vec3 Position;
 	glm::vec3 Velocity;
 	glm::quat Rotation;
-	int8 DeltaForward = 0;
-	int8 DeltaLeft = 0;
+	glm::i8vec3 DeltaAction;
 };
 
 struct GameStateComparator

--- a/CrazyCanvas/Source/World/Player/CharacterControllerHelper.cpp
+++ b/CrazyCanvas/Source/World/Player/CharacterControllerHelper.cpp
@@ -65,6 +65,7 @@ void CharacterControllerHelper::TickCharacterController(
 	// Update velocity
 	glm::vec3& velocity = velocityComp.Velocity;
 	velocity.y -= GRAVITATIONAL_ACCELERATION;
+	LOG_WARNING("TRANSLATION: %f, %f, %f", velocity.x, velocity.y, velocity.z);
 
 	// Calculate Tick Translation
 	PxVec3 translationPX = { velocity.x, velocity.y, velocity.z };

--- a/CrazyCanvas/Source/World/Player/CharacterControllerHelper.cpp
+++ b/CrazyCanvas/Source/World/Player/CharacterControllerHelper.cpp
@@ -64,8 +64,7 @@ void CharacterControllerHelper::TickCharacterController(
 
 	// Update velocity
 	glm::vec3& velocity = velocityComp.Velocity;
-	velocity.y -= GRAVITATIONAL_ACCELERATION;
-	LOG_WARNING("TRANSLATION: %f, %f, %f", velocity.x, velocity.y, velocity.z);
+	velocity.y -= GRAVITATIONAL_ACCELERATION * dt;
 
 	// Calculate Tick Translation
 	PxVec3 translationPX = { velocity.x, velocity.y, velocity.z };

--- a/CrazyCanvas/Source/World/Player/Client/PlayerLocalSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/Client/PlayerLocalSystem.cpp
@@ -118,15 +118,21 @@ void PlayerLocalSystem::DoAction(Timestamp deltaTime, Entity entityPlayer, Playe
 
 	ECSCore* pECS = ECSCore::GetInstance();
 
+	const ComponentArray<RotationComponent>* pRotationComponents			= pECS->GetComponentArray<RotationComponent>();
+	const ComponentArray<CharacterColliderComponent>* pCharacterColliders	= pECS->GetComponentArray<CharacterColliderComponent>();
+	ComponentArray<VelocityComponent>* pVelocityComponents					= pECS->GetComponentArray<VelocityComponent>();
+
+	const CharacterColliderComponent& characterColliderComponent = pCharacterColliders->GetConstData(entityPlayer);
+
+	physx::PxControllerState playerControllerState;
+	characterColliderComponent.pController->getState(playerControllerState);
+
 	glm::i8vec3 deltaAction =
 	{
 		int8(InputActionSystem::IsActive(EAction::ACTION_MOVE_RIGHT) - InputActionSystem::IsActive(EAction::ACTION_MOVE_LEFT)),			// X: Right
-		int8(InputActionSystem::IsActive(EAction::ACTION_MOVE_JUMP)),																	// Y: Up
+		int8(InputActionSystem::IsActive(EAction::ACTION_MOVE_JUMP)) * int8(playerControllerState.touchedShape != nullptr),				// Y: Up
 		int8(InputActionSystem::IsActive(EAction::ACTION_MOVE_BACKWARD) - InputActionSystem::IsActive(EAction::ACTION_MOVE_FORWARD)),	// Z: Forward
 	};
-
-	const ComponentArray<RotationComponent>* pRotationComponents = pECS->GetComponentArray<RotationComponent>();
-	ComponentArray<VelocityComponent>* pVelocityComponents = pECS->GetComponentArray<VelocityComponent>();
 
 	const RotationComponent& rotationComponent = pRotationComponents->GetConstData(entityPlayer);
 	VelocityComponent& velocityComponent = pVelocityComponents->GetData(entityPlayer);

--- a/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
@@ -94,23 +94,25 @@ bool PlayerActionSystem::OnKeyPressed(const KeyPressedEvent& event)
 	return false;
 }
 
-void PlayerActionSystem::ComputeVelocity(const glm::quat& rotation, int8 deltaForward, int8 deltaLeft, glm::vec3& result)
+void PlayerActionSystem::ComputeVelocity(const glm::quat& rotation, const glm::i8vec3& deltaAction, glm::vec3& result)
 {
-	if (!Match::HasBegun() || (deltaForward == 0 && deltaLeft == 0))
+	if (!Match::HasBegun() || (deltaAction.x == 0 && deltaAction.y == 0 && deltaAction.z == 0))
 	{
 		result.x = 0.0f;
 		result.z = 0.0f;
 		return;
 	}
 
-	float32 movespeed = 4.0f;
+	float32 moveSpeed = 4.0f;
+	float32 jumpSpeed = 20.0f;
 	glm::vec3 currentVelocity;
-	currentVelocity		= rotation * glm::vec3(deltaForward, 0.0f, deltaLeft);
+	currentVelocity		= rotation * glm::vec3(deltaAction.x, 0.0f, deltaAction.z);
 	currentVelocity.y	= 0.0f;
 	currentVelocity		= glm::normalize(currentVelocity);
-	currentVelocity		*= movespeed;
+	currentVelocity		*= moveSpeed;
 
 	result.x = currentVelocity.x;
+	result.y = result.y * float32(1 - deltaAction.y) + jumpSpeed * float32(deltaAction.y);
 	result.z = currentVelocity.z;
 }
 

--- a/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
@@ -96,24 +96,40 @@ bool PlayerActionSystem::OnKeyPressed(const KeyPressedEvent& event)
 
 void PlayerActionSystem::ComputeVelocity(const glm::quat& rotation, const glm::i8vec3& deltaAction, glm::vec3& result)
 {
-	if (!Match::HasBegun() || (deltaAction.x == 0 && deltaAction.y == 0 && deltaAction.z == 0))
+	bool horizontalMovement = deltaAction.x != 0 || deltaAction.z != 0;
+	bool verticalMovement = deltaAction.y != 0;
+	bool anyMovement = horizontalMovement || verticalMovement;
+
+	if (!Match::HasBegun() || !anyMovement)
 	{
 		result.x = 0.0f;
 		result.z = 0.0f;
 		return;
 	}
 
-	float32 moveSpeed = 4.0f;
-	float32 jumpSpeed = 20.0f;
-	glm::vec3 currentVelocity;
-	currentVelocity		= rotation * glm::vec3(deltaAction.x, 0.0f, deltaAction.z);
-	currentVelocity.y	= 0.0f;
-	currentVelocity		= glm::normalize(currentVelocity);
-	currentVelocity		*= moveSpeed;
+	if (horizontalMovement)
+	{
+		float32 moveSpeed = 4.0f;
+		glm::vec3 currentVelocity;
+		currentVelocity		= rotation * glm::vec3(deltaAction.x, 0.0f, deltaAction.z);
+		currentVelocity.y	= 0.0f;
+		currentVelocity		= glm::normalize(currentVelocity);
+		currentVelocity		*= moveSpeed;
 
-	result.x = currentVelocity.x;
-	result.y = result.y * float32(1 - deltaAction.y) + jumpSpeed * float32(deltaAction.y);
-	result.z = currentVelocity.z;
+		result.x = currentVelocity.x;
+		result.z = currentVelocity.z;
+	}
+	else
+	{
+		result.x = 0.0f;
+		result.z = 0.0f;
+	}
+
+	if (verticalMovement)
+	{
+		float32 jumpSpeed = 5.0f;
+		result.y = result.y * float32(1 - deltaAction.y) + jumpSpeed * float32(deltaAction.y);
+	}
 }
 
 void PlayerActionSystem::SetMouseEnabled(bool isEnabled)

--- a/CrazyCanvas/Source/World/Player/Server/PlayerRemoteSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/Server/PlayerRemoteSystem.cpp
@@ -85,7 +85,7 @@ void PlayerRemoteSystem::FixedTickMainThread(LambdaEngine::Timestamp deltaTime)
 				rotationComponent.Dirty			= true;
 			}
 
-			PlayerActionSystem::ComputeVelocity(constRotationComponent.Quaternion, gameState.DeltaForward, gameState.DeltaLeft, velocityComponent.Velocity);
+			PlayerActionSystem::ComputeVelocity(constRotationComponent.Quaternion, gameState.DeltaAction, velocityComponent.Velocity);
 			CharacterControllerHelper::TickCharacterController(dt, entityPlayer, pCharacterColliderComponents, pNetPosComponents, pVelocityComponents);
 
 			PacketPlayerActionResponse packet;


### PR DESCRIPTION
## Purpose
  - This task implements jumping.
  - It also fixes the gravity problem that we've had for players.

## Changes
 - Changes have been made to how we compute velocity for players. It now includes "Jump Action", which translates to y velocity.
 - The player is checked to make sure he stands on a surface before he can jump.
 - After some testing I decided to not check if the "Jump Action" was released the previous frame, checking if the player is standing on solid ground seems to be enough.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

