### PR TITLE
Health system fix

### DIFF
--- a/CrazyCanvas/Include/ECS/Systems/Player/HealthSystem.h
+++ b/CrazyCanvas/Include/ECS/Systems/Player/HealthSystem.h
@@ -31,6 +31,7 @@ protected:
 
 public:
 	static bool Init();
+	static void Release();
 
 	FORCEINLINE static HealthSystem& GetInstance() 
 	{ 

--- a/CrazyCanvas/Source/ECS/Systems/Player/HealthSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Player/HealthSystem.cpp
@@ -37,6 +37,11 @@ bool HealthSystem::Init()
 	return s_Instance->InitInternal();
 }
 
+void HealthSystem::Release()
+{
+	s_Instance.Reset();
+}
+
 void HealthSystem::CreateBaseSystemRegistration(LambdaEngine::SystemRegistration& systemReg)
 {
 	using namespace LambdaEngine;

--- a/CrazyCanvas/Source/Lobby/PlayerManagerClient.cpp
+++ b/CrazyCanvas/Source/Lobby/PlayerManagerClient.cpp
@@ -67,7 +67,6 @@ void PlayerManagerClient::RegisterLocalPlayer(const String& name, bool isHost)
 	IClient* pClient = ClientSystem::GetInstance().GetClient();
 
 	ASSERT(s_Players.empty());
-	ASSERT(pClient->IsConnected());
 	ASSERT(!MultiplayerUtils::IsServer());
 
 	PacketJoin packet;

--- a/CrazyCanvas/Source/Multiplayer/MultiplayerBase.cpp
+++ b/CrazyCanvas/Source/Multiplayer/MultiplayerBase.cpp
@@ -16,6 +16,8 @@ MultiplayerBase::~MultiplayerBase()
 	{
 		LOG_ERROR("Match Release Failed");
 	}
+
+	HealthSystem::Release();
 }
 
 void MultiplayerBase::InitInternal()

--- a/LambdaEngine/Source/Game/ECS/ComponentOwners/Rendering/MeshPaintComponentOwner.cpp
+++ b/LambdaEngine/Source/Game/ECS/ComponentOwners/Rendering/MeshPaintComponentOwner.cpp
@@ -2,6 +2,7 @@
 
 #include "Rendering/Core/API/Texture.h"
 #include "Rendering/Core/API/TextureView.h"
+#include "Rendering/Core/API/Buffer.h"
 
 namespace LambdaEngine
 {
@@ -44,9 +45,10 @@ namespace LambdaEngine
 
 	void MeshPaintComponentOwner::ReleaseMeshPaintComponent(MeshPaintComponent& meshPaintComponent)
 	{
-		auto& resourcesToRelease = m_ResourcesToRelease[m_ModFrameIndex];
+		TArray<DeviceChild*>& resourcesToRelease = m_ResourcesToRelease[m_ModFrameIndex];
 		resourcesToRelease.PushBack(meshPaintComponent.pTexture);
 		resourcesToRelease.PushBack(meshPaintComponent.pTextureView);
+		resourcesToRelease.PushBack(meshPaintComponent.pReadBackBuffer);
 	}
 
 	void MeshPaintComponentOwner::MeshPaintDestructor(MeshPaintComponent& meshPaintComponent, Entity entity)


### PR DESCRIPTION
## Purpose
* Fixes crash in HealthSystemClient when exiting the application
* Fixes crash in PlayerManagerClient when starting a Sandbox session
* Fixes memory leak from the readback buffer that the HealthSystem uses to read the current health of player's

## Changes
* Added static Release-Method to HealthSystem that is called in MultiplayerBase's destructor. The problem was that the TUniquePtr that holds the HealthSystem instance was destroyed after we returned from main (Since this is a static variable). Since the HealthSystem's destructor is unregistering from the EventQueue, this caused a crash since the EventQueue no longer exists.
* Removed an assert in PlayerManagerClient::RegisterLocalPlayer
* Now, the readback buffer is enqueued for release in MeshPaintComponentOwner.
