### PR TITLE
Fixed Render Stages sleeping in Benchmark

### DIFF
--- a/CrazyCanvas/Include/GUI/MainMenuGUI.h
+++ b/CrazyCanvas/Include/GUI/MainMenuGUI.h
@@ -49,7 +49,6 @@ private:
 	friend class HUDGUI;
 
 	void OnButtonBackClick(Noesis::BaseComponent* pSender, const Noesis::RoutedEventArgs& args);
-	void SetRenderStagesSleeping();
 	void SetDefaultSettings();
 	void SetDefaultKeyBindings();
 	bool KeyboardCallback(const LambdaEngine::KeyPressedEvent& event);

--- a/CrazyCanvas/Source/GUI/MainMenuGUI.cpp
+++ b/CrazyCanvas/Source/GUI/MainMenuGUI.cpp
@@ -173,8 +173,6 @@ void MainMenuGUI::OnButtonBenchmarkClick(Noesis::BaseComponent* pSender, const N
 
 	LambdaEngine::GUIApplication::SetView(nullptr);
 
-	SetRenderStagesSleeping();
-
 	State* pStartingState = DBG_NEW BenchmarkState();
 	StateManager::GetInstance()->EnqueueStateTransition(pStartingState, STATE_TRANSITION::POP_AND_PUSH);
 }
@@ -294,16 +292,6 @@ void MainMenuGUI::OnButtonCancelKeyBindingsClick(Noesis::BaseComponent* pSender,
 	m_KeysToSet.clear();
 
 	OnButtonBackClick(pSender, args);
-}
-
-/*
-*
-*	HELPER FUNCTIONS
-*
-*/
-void MainMenuGUI::SetRenderStagesSleeping()
-{
-	DisablePlaySessionsRenderstages();
 }
 
 void MainMenuGUI::SetDefaultSettings()

--- a/CrazyCanvas/Source/States/BenchmarkState.cpp
+++ b/CrazyCanvas/Source/States/BenchmarkState.cpp
@@ -44,6 +44,8 @@
 
 #include "Lobby/PlayerManagerClient.h"
 
+#include "GUI/GUIHelpers.h"
+
 BenchmarkState::BenchmarkState()
 {
 	using namespace LambdaEngine;
@@ -64,6 +66,9 @@ BenchmarkState::~BenchmarkState()
 void BenchmarkState::Init()
 {
 	using namespace LambdaEngine;
+
+	EnablePlaySessionsRenderstages();
+
 	Input::Disable();
 
 	TSharedRef<Window> window = CommonApplication::Get()->GetMainWindow();


### PR DESCRIPTION
## Purpose
  - Fixes a blackscreen in benchmark.

## Changes
 - There was a call to SetRenderStagesSleeping when transitioning to Benchmark for some reason.

## Testing
How have one tested the feature to ensure it works?
- [ ] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [x] Tested in Benchmark

