### PR TITLE
Fixed GUI Resize Crash

### DIFF
--- a/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
+++ b/CrazyCanvas/Source/RenderStages/PlayerRenderer.cpp
@@ -134,10 +134,6 @@ namespace LambdaEngine
 		// Fetching render targets
 		if (resourceName == "INTERMEDIATE_OUTPUT_IMAGE") 
 		{
-			if (imageCount != 0)
-			{
-				LOG_WARNING("RenderGraph has been altered. imageCount is %d but should be 0", imageCount);
-			}
 			m_IntermediateOutputImage = MakeSharedRef(ppPerImageTextureViews[0]);
 		}
 		

--- a/LambdaEngine/Include/GUI/Core/GUIRenderTarget.h
+++ b/LambdaEngine/Include/GUI/Core/GUIRenderTarget.h
@@ -40,6 +40,9 @@ namespace LambdaEngine
 		FORCEINLINE const ClearColorDesc* GetClearColors() const { return m_pClearColorDesc; }
 		FORCEINLINE uint32 GetClearColorCount() const { return ARR_SIZE(m_pClearColorDesc); }
 
+		FORCEINLINE uint32 GetWidth() const { return m_Desc.Width; }
+		FORCEINLINE uint32 GetHeight() const { return m_Desc.Height; }
+
 	private:
 		bool CreateColorTextures(const GUIRenderTargetDesc* pDesc);
 		bool CreateDepthStencilTexture(const GUIRenderTargetDesc* pDesc);

--- a/LambdaEngine/Include/GUI/Core/GUIRenderer.h
+++ b/LambdaEngine/Include/GUI/Core/GUIRenderer.h
@@ -160,9 +160,6 @@ namespace LambdaEngine
 		CommandAllocator*	m_ppRenderCommandAllocators[BACK_BUFFER_COUNT];
 		CommandList*		m_ppRenderCommandLists[BACK_BUFFER_COUNT];
 
-		uint32_t m_CurrentSurfaceWidth	= 0;
-		uint32_t m_CurrentSurfaceHeight	= 0;
-
 		GUIRenderTarget* m_pCurrentRenderTarget = nullptr;
 		Sampler* m_pGUISampler = nullptr;
 

--- a/LambdaEngine/Include/Rendering/RenderGraph.h
+++ b/LambdaEngine/Include/Rendering/RenderGraph.h
@@ -452,12 +452,12 @@ namespace LambdaEngine
 		void UpdateRelativeResourceDimensions(InternalResourceUpdateDesc* pResourceUpdateDesc);
 
 		void ExecuteSynchronizationStage(
-			SynchronizationStage* pSynchronizationStage, 
-			CommandAllocator* pGraphicsCommandAllocator, 
-			CommandList* pGraphicsCommandList, 
-			CommandAllocator* pComputeCommandAllocator, 
-			CommandList* pComputeCommandList, 
-			CommandList** ppFirstExecutionStage, 
+			SynchronizationStage* pSynchronizationStage,
+			CommandAllocator* pGraphicsCommandAllocator,
+			CommandList* pGraphicsCommandList,
+			CommandAllocator* pComputeCommandAllocator,
+			CommandList* pComputeCommandList,
+			CommandList** ppFirstExecutionStage,
 			CommandList** ppSecondExecutionStage);
 		
 		void ExecuteGraphicsRenderStage(

--- a/LambdaEngine/Source/GUI/Core/GUIRenderTarget.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIRenderTarget.cpp
@@ -31,6 +31,8 @@ namespace LambdaEngine
 		m_pColorTextureView			= nullptr;
 		m_pResolveTexture			= nullptr;
 		m_pResolveTextureView		= nullptr;
+
+		ZERO_MEMORY(m_ppRenderTargets, sizeof(m_ppRenderTargets));
 	}
 
 	bool GUIRenderTarget::Init(const GUIRenderTargetDesc* pDesc)

--- a/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
@@ -251,6 +251,9 @@ namespace LambdaEngine
 
 	void GUIRenderer::BeginTile(const Noesis::Tile& tile, uint32_t surfaceWidth, uint32_t surfaceHeight)
 	{
+		UNREFERENCED_VARIABLE(surfaceWidth);
+		UNREFERENCED_VARIABLE(surfaceHeight);
+		
 		CommandList* pCommandList = BeginOrGetRenderCommandList();
 		
 		// Do not set to false here will check in end tile if we were in a renderpass
@@ -274,9 +277,6 @@ namespace LambdaEngine
 
 		pCommandList->SetScissorRects(&scissorRect, 0, 1);
 
-		m_CurrentSurfaceWidth	= surfaceWidth;
-		m_CurrentSurfaceHeight	= surfaceHeight;
-
 #ifdef PRINT_FUNC
 		LOG_INFO("BeginTile W: %u, H: %u", m_CurrentSurfaceWidth, m_CurrentSurfaceHeight);
 #endif
@@ -286,8 +286,6 @@ namespace LambdaEngine
 	{
 		EndCurrentRenderPass();
 		m_TileBegun					= false;
-		//m_CurrentSurfaceWidth		= 0;
-		//m_CurrentSurfaceHeight	= 0;
 #ifdef PRINT_FUNC
 		LOG_INFO("EndTile");
 #endif
@@ -799,8 +797,8 @@ namespace LambdaEngine
 				beginRenderPass.ppRenderTargets		= m_pCurrentRenderTarget->GetRenderTargets();
 				beginRenderPass.RenderTargetCount	= 2; // The rendertarget + resolve target
 				beginRenderPass.pDepthStencil		= m_pCurrentRenderTarget->GetDepthStencil();
-				beginRenderPass.Width				= m_CurrentSurfaceWidth;
-				beginRenderPass.Height				= m_CurrentSurfaceHeight;
+				beginRenderPass.Width				= m_pCurrentRenderTarget->GetWidth();
+				beginRenderPass.Height				= m_pCurrentRenderTarget->GetHeight();
 				beginRenderPass.Flags				= FRenderPassBeginFlag::RENDER_PASS_BEGIN_FLAG_INLINE;
 				beginRenderPass.pClearColors		= m_pCurrentRenderTarget->GetClearColors();
 				beginRenderPass.ClearColorCount		= m_pCurrentRenderTarget->GetClearColorCount();

--- a/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
@@ -792,7 +792,7 @@ namespace LambdaEngine
 		//Begin RenderPass
 		if (!m_TileBegun)
 		{
-			if (m_pCurrentRenderTarget)
+			if (m_pCurrentRenderTarget && m_pCurrentRenderTarget->GetRenderPass())
 			{
 				BeginRenderPassDesc beginRenderPass = {};
 				beginRenderPass.pRenderPass			= m_pCurrentRenderTarget->GetRenderPass();
@@ -863,7 +863,7 @@ namespace LambdaEngine
 	void GUIRenderer::ResumeRenderPass()
 	{
 #ifdef PRINT_FUNC
-		LOG_INFO("Trying to resumt renderpass: tileBegun: %d", m_TileBegun);
+		LOG_INFO("Trying to resume renderpass: tileBegun: %d", m_TileBegun);
 #endif
 
 		if (!m_IsInRenderPass)


### PR DESCRIPTION
## Purpose
  - GUIRenderer crashed sometimes when resizing the window, this fixes that.
  - There were two problems, the first one seems to be that a GUIRenderTarget is somehow deleted but GUIRenderer is not notified of this.
  - The solution is to just check that the RenderPass in the GUIRenderTarget isn't nullptr when we render.
  - The second problem is that SetRenderTarget can be called without an accompanying BeginTile, this would cause the variables m_CurrentSurfaceWidth & m_CurrentSurfaceHeight to become desynced with the current Render Target.
  - The solution to this problem is to not store m_CurrentSurfaceWidth & m_CurrentSurfaceHeight at all, but instead just use the width/height of the current RenderTarget when beginning a Tiled Render Pass.

## Changes
 - Changes have been made to GUIRenderer.
 - Also removed an unnecessary LOG_WARNING in PlayerRenderer.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

