### PR TITLE
Remove player on disconnect

### DIFF
--- a/CrazyCanvas/Include/Match/MatchServer.h
+++ b/CrazyCanvas/Include/Match/MatchServer.h
@@ -34,7 +34,7 @@ protected:
 	virtual bool OnWeaponFired(const WeaponFiredEvent& event) override final;
 
 private:
-	bool OnClientDisconnected(const LambdaEngine::ClientDisconnectedEvent& event);
+	bool OnPlayerLeft(const PlayerLeftEvent& event);
 	bool OnFlagDelivered(const FlagDeliveredEvent& event);
 	bool OnFlagRespawn(const FlagRespawnEvent& event);
 

--- a/CrazyCanvas/Source/Match/MatchServer.cpp
+++ b/CrazyCanvas/Source/Match/MatchServer.cpp
@@ -52,7 +52,7 @@ MatchServer::~MatchServer()
 	
 	EventQueue::UnregisterEventHandler<FlagDeliveredEvent>(this, &MatchServer::OnFlagDelivered);
 	EventQueue::UnregisterEventHandler<FlagRespawnEvent>(this, &MatchServer::OnFlagRespawn);
-	EventQueue::UnregisterEventHandler<ClientDisconnectedEvent>(this, &MatchServer::OnClientDisconnected);
+	EventQueue::UnregisterEventHandler<PlayerLeftEvent>(this, &MatchServer::OnPlayerLeft);
 }
 
 bool MatchServer::InitInternal()
@@ -61,7 +61,7 @@ bool MatchServer::InitInternal()
 
 	EventQueue::RegisterEventHandler<FlagDeliveredEvent>(this, &MatchServer::OnFlagDelivered);
 	EventQueue::RegisterEventHandler<FlagRespawnEvent>(this, &MatchServer::OnFlagRespawn);
-	EventQueue::RegisterEventHandler<ClientDisconnectedEvent>(this, &MatchServer::OnClientDisconnected);
+	EventQueue::RegisterEventHandler<PlayerLeftEvent>(this, &MatchServer::OnPlayerLeft);
 
 	return true;
 }
@@ -398,24 +398,17 @@ void MatchServer::DeleteGameLevelObject(LambdaEngine::Entity entity)
 	m_pLevel->DeleteObject(entity);
 
 	PacketDeleteLevelObject packet;
-	packet.NetworkUID = entity;
+	packet.NetworkUID = int32(entity);
 
 	ServerHelper::SendBroadcast(packet);
 }
 
-bool MatchServer::OnClientDisconnected(const LambdaEngine::ClientDisconnectedEvent& event)
+bool MatchServer::OnPlayerLeft(const PlayerLeftEvent& event)
 {
-	VALIDATE(event.pClient != nullptr);
+	using namespace LambdaEngine;
 
-	const Player* pPlayer = PlayerManagerBase::GetPlayer(event.pClient);
-	if (pPlayer)
-	{
-		MatchServer::KillPlayer(pPlayer->GetEntity(), UINT32_MAX);
-	}
-	
-
-	// TODO: Fix this
-	//DeleteGameLevelObject(playerEntity);
+	Entity playerEntity = event.pPlayer->GetEntity();
+	DeleteGameLevelObject(playerEntity);
 
 	return true;
 }

--- a/CrazyCanvas/Source/World/LevelObjectCreator.cpp
+++ b/CrazyCanvas/Source/World/LevelObjectCreator.cpp
@@ -697,6 +697,7 @@ bool LevelObjectCreator::CreatePlayer(
 	pECS->AddComponent<CharacterColliderComponent>(playerEntity, characterColliderComponent);
 
 	Entity weaponEntity = pECS->CreateEntity();
+	childEntities.PushBack(weaponEntity);
 	pECS->AddComponent<WeaponComponent>(weaponEntity, { .WeaponOwner = playerEntity });
 	pECS->AddComponent<PacketComponent<PacketWeaponFired>>(weaponEntity, { });
 	pECS->AddComponent<PositionComponent>(weaponEntity, PositionComponent{ .Position = pPlayerDesc->Position });


### PR DESCRIPTION
## Purpose
  - This implements the task of removing the Player when a client disconnects.

## Changes
 - Changes were made to MatchServer so that it deletes the Player instead of killing him on disconnect.
 - A change was also made to LevelObjectCreator so that the Weapon Entity is registered as a Player Entity Child thus making sure that it's deleted when the Player gets deleted.

## Testing
How have one tested the feature to ensure it works?
- [ ] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [x] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

