### PR TITLE
Fixed Jetpack

### DIFF
--- a/LambdaEngine/Include/Game/ECS/Systems/Physics/PhysicsSystem.h
+++ b/LambdaEngine/Include/Game/ECS/Systems/Physics/PhysicsSystem.h
@@ -7,6 +7,7 @@
 #include "Math/Math.h"
 #include "Physics/PhysX/ErrorCallback.h"
 #include "Physics/PhysX/PhysX.h"
+#include "Physics/PhysX/QueryFilterCallback.h"
 
 #include <variant>
 
@@ -246,5 +247,7 @@ namespace LambdaEngine
 		PxScene*				m_pScene;
 
 		PxMaterial* m_pMaterial;
+
+		QueryFilterCallback m_QueryFilterCallback;
 	};
 }

--- a/LambdaEngine/Include/Physics/PhysX/QueryFilterCallback.h
+++ b/LambdaEngine/Include/Physics/PhysX/QueryFilterCallback.h
@@ -6,17 +6,20 @@ namespace LambdaEngine
 	class QueryFilterCallback : public physx::PxQueryFilterCallback
 	{
 	public:
-		DECL_SINGLETON_CLASS(QueryFilterCallback);
+		DECL_UNIQUE_CLASS(QueryFilterCallback);
 
-		inline virtual physx::PxQueryHitType::Enum preFilter(const physx::PxFilterData& filterData, const physx::PxShape* shape, const physx::PxRigidActor* actor, physx::PxHitFlags& queryFlags) override final
+		QueryFilterCallback() = default;
+		~QueryFilterCallback() = default;
+
+		inline virtual physx::PxQueryHitType::Enum preFilter(const physx::PxFilterData& filterData, const physx::PxShape* pShape, const physx::PxRigidActor* pActor, physx::PxHitFlags& queryFlags) override final
 		{
-			UNREFERENCED_VARIABLE(actor);
+			UNREFERENCED_VARIABLE(pActor);
 			UNREFERENCED_VARIABLE(queryFlags);
 
 			using namespace physx;
 
 			// We only need to check word2 as it has already passed dataFilter, we also use SimulationFilterData for this
-			if (filterData.word2 != shape->getSimulationFilterData().word2)
+			if (filterData.word2 != pShape->getSimulationFilterData().word2)
 			{
 				return PxQueryHitType::eTOUCH;
 			}
@@ -31,14 +34,5 @@ namespace LambdaEngine
 
 			return physx::PxQueryHitType::eTOUCH;
 		}
-
-		FORCEINLINE static QueryFilterCallback* GetInstance() 
-		{
-			static QueryFilterCallback callbackInstance;
-			return &callbackInstance;
-		}
-		
-	private:
-		static QueryFilterCallback s_Instance;
 	};
 }

--- a/LambdaEngine/Include/Physics/PhysX/QueryFilterCallback.h
+++ b/LambdaEngine/Include/Physics/PhysX/QueryFilterCallback.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "Physics/PhysX/PhysX.h"
+
+namespace LambdaEngine
+{
+	class QueryFilterCallback : public physx::PxQueryFilterCallback
+	{
+	public:
+		DECL_SINGLETON_CLASS(QueryFilterCallback);
+
+		inline virtual physx::PxQueryHitType::Enum preFilter(const physx::PxFilterData& filterData, const physx::PxShape* shape, const physx::PxRigidActor* actor, physx::PxHitFlags& queryFlags) override final
+		{
+			UNREFERENCED_VARIABLE(actor);
+			UNREFERENCED_VARIABLE(queryFlags);
+
+			using namespace physx;
+
+			// We only need to check word2 as it has already passed dataFilter, we also use SimulationFilterData for this
+			if (filterData.word2 != shape->getSimulationFilterData().word2)
+			{
+				return PxQueryHitType::eTOUCH;
+			}
+
+			return PxQueryHitType::eNONE;
+		}
+
+		inline virtual physx::PxQueryHitType::Enum postFilter(const physx::PxFilterData& filterData, const physx::PxQueryHit& hit) override final
+		{
+			UNREFERENCED_VARIABLE(filterData);
+			UNREFERENCED_VARIABLE(hit);
+
+			return physx::PxQueryHitType::eTOUCH;
+		}
+
+		FORCEINLINE static QueryFilterCallback* GetInstance() 
+		{
+			static QueryFilterCallback callbackInstance;
+			return &callbackInstance;
+		}
+		
+	private:
+		static QueryFilterCallback s_Instance;
+	};
+}

--- a/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
@@ -7,7 +7,6 @@
 #include "Game/ECS/Components/Rendering/MeshComponent.h"
 #include "Input/API/InputActionSystem.h"
 #include "Physics/PhysX/FilterShader.h"
-#include "Physics/PhysX/QueryFilterCallback.h"
 #include "Resources/ResourceManager.h"
 
 #define PX_RELEASE(x) if(x)	{ x->release(); x = nullptr; }
@@ -683,7 +682,7 @@ namespace LambdaEngine
 			0u
 		);
 
-		PxControllerFilters controllerFilters(pFilterData, QueryFilterCallback::GetInstance());
+		PxControllerFilters controllerFilters(pFilterData, &m_QueryFilterCallback);
 
 		// Set filter data to be used when simulating the physics world
 		PxRigidDynamic* pActor = pController->getActor();

--- a/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
+++ b/LambdaEngine/Source/Game/ECS/Systems/Physics/PhysicsSystem.cpp
@@ -7,6 +7,7 @@
 #include "Game/ECS/Components/Rendering/MeshComponent.h"
 #include "Input/API/InputActionSystem.h"
 #include "Physics/PhysX/FilterShader.h"
+#include "Physics/PhysX/QueryFilterCallback.h"
 #include "Resources/ResourceManager.h"
 
 #define PX_RELEASE(x) if(x)	{ x->release(); x = nullptr; }
@@ -682,7 +683,7 @@ namespace LambdaEngine
 			0u
 		);
 
-		PxControllerFilters controllerFilters(pFilterData);
+		PxControllerFilters controllerFilters(pFilterData, QueryFilterCallback::GetInstance());
 
 		// Set filter data to be used when simulating the physics world
 		PxRigidDynamic* pActor = pController->getActor();


### PR DESCRIPTION
## Purpose
  - This removes the jetpack functionality.
  - The previous solution to disable projectile-player collisions between only worked in one direction. This is because dynamic objects, such as the projectiles, use the filtershader, a modification to this was the previous solution. However, character controllers do not use this filtershader because it uses scene queries to check collision in its move function.
  - The new solution is to also include a collision callback for scene queries for character controllers.

## Changes
 - A new class has been introduced which handles character controller queries.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark
