### PR TITLE
Fixed it drawArg Update to zero is fine

### DIFF
--- a/CrazyCanvas/Source/RenderStages/FirstPersonWeaponRenderer.cpp
+++ b/CrazyCanvas/Source/RenderStages/FirstPersonWeaponRenderer.cpp
@@ -574,7 +574,7 @@ namespace LambdaEngine
 			}
 			else
 			{
-				LOG_ERROR("[FirstPersonWeapon]: Failed to update descriptors for drawArgs");
+				m_DrawCount = 0;
 			}
 		}
 	}


### PR DESCRIPTION
## Purpose
  - Fixed crash on closing server due to draw arg count changed to zero. This is fine and should only update `m_DrawCount`

