### PR TITLE
Fix ImGui Crash

### DIFF
--- a/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
@@ -1028,7 +1028,7 @@ namespace LambdaEngine
 
 		DescriptorHeapDesc descriptorHeapDesc = { };
 		descriptorHeapDesc.DebugName			= "ImGui Descriptor Heap";
-		descriptorHeapDesc.DescriptorSetCount	= 256;
+		descriptorHeapDesc.DescriptorSetCount	= 1024;
 		descriptorHeapDesc.DescriptorCount		= descriptorCountDesc;
 
 		m_DescriptorHeap = m_pGraphicsDevice->CreateDescriptorHeap(&descriptorHeapDesc);


### PR DESCRIPTION
## Purpose
  - Fixes crash in ImGuiRenderer.

## Changes
 - I just increased the Descriptor Set count in the Descriptor Heap.
 - We simply have more textures now, Sandbox creates 25 roughness/metallic balls, new map with more materials, etc.
 - We should however consider completely disabling this feature later to save memory.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

