### PR TITLE
Fix flag crash

### DIFF
--- a/CrazyCanvas/Source/ECS/Systems/Match/ServerFlagSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Match/ServerFlagSystem.cpp
@@ -221,7 +221,7 @@ void ServerFlagSystem::OnDeliveryPointFlagCollision(LambdaEngine::Entity entity0
 		{ ComponentPermissions::R,	ParentComponent::Type() },
 	};
 
-    	job.Function = [entity0, entity1]()
+	job.Function = [entity0, entity1]()
 	{
 		Entity flagEntity = entity0;
 		Entity deliveryPointEntity = entity1;

--- a/CrazyCanvas/Source/Match/MatchClient.cpp
+++ b/CrazyCanvas/Source/Match/MatchClient.cpp
@@ -282,8 +282,6 @@ bool MatchClient::OnPacketGameOverReceived(const PacketReceivedEvent<PacketGameO
 
 	EventQueue::SendEvent<GameOverEvent>(packet.WinningTeamIndex);
 
-	ResetMatch();
-
 	return true;
 }
 

--- a/CrazyCanvas/Source/States/LobbyState.cpp
+++ b/CrazyCanvas/Source/States/LobbyState.cpp
@@ -19,6 +19,8 @@
 #include "World/Player/PlayerActionSystem.h"
 #include "Input/API/Input.h"
 
+#include "Match/Match.h"
+
 using namespace LambdaEngine;
 
 LobbyState::LobbyState(const PacketGameSettings& gameSettings, const Player* pPlayer) : 
@@ -81,6 +83,8 @@ void LobbyState::Init()
 	LambdaEngine::GUIApplication::SetView(m_View);
 
 	m_LobbyGUI->InitGUI();
+
+	Match::ResetMatch();
 
 	if (!m_IsReplayLobby)
 	{

--- a/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/ImGuiRenderer.cpp
@@ -1028,7 +1028,7 @@ namespace LambdaEngine
 
 		DescriptorHeapDesc descriptorHeapDesc = { };
 		descriptorHeapDesc.DebugName			= "ImGui Descriptor Heap";
-		descriptorHeapDesc.DescriptorSetCount	= 256;
+		descriptorHeapDesc.DescriptorSetCount	= 1024;
 		descriptorHeapDesc.DescriptorCount		= descriptorCountDesc;
 
 		m_DescriptorHeap = m_pGraphicsDevice->CreateDescriptorHeap(&descriptorHeapDesc);


### PR DESCRIPTION
## Purpose
  - There was a crash in a Flag Job on the Client. I have no way of reliably testing this, my theory is however that the Client got a package of the flag being returned, queued up a job to respawn the flag, and then got a package which told it that the game was over. When it got that package it instantly reset the match which also deleted the level. The flag entity gets deleted upon Level deletion which made the queued job later crash.

## Changes
 - The fix is to reset the match when we get to the LobbyState instead of instantly resetting it when getting a "GameOverPackage".

## Testing
How have one tested the feature to ensure it works?
- [ ] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [x] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark
