### PR TITLE
Fix first person weapon rendering on spectator view

### DIFF
--- a/Assets/NoesisGUI/Xaml/HUD.xaml
+++ b/Assets/NoesisGUI/Xaml/HUD.xaml
@@ -117,7 +117,7 @@
                     </Image>
                     <Image Grid.Column="1" Grid.Row="3" Source="HealthBorderNew.png"   RenderTransformOrigin="0.5,0.75"  Width="475" Height="243" Margin="11,0,0,0"/>
 
-                <TextBlock x:Name="HEALTH_DISPLAY"  Grid.Column="1" Grid.Row="3" Text="100%" FontSize="24" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,-157,28" Foreground="#Black" FontWeight="Bold" Height="31.922" Width="62.224" />
+                <TextBlock x:Name="HEALTH_DISPLAY"  Grid.Column="1" Grid.Row="3" Text="100%" FontSize="24" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,-157,28" Foreground="Black" FontWeight="Bold" Height="31.922" Width="62.224" />
                 
                 </Grid>
  

--- a/CrazyCanvas/Source/ECS/Systems/Camera/SpectateCameraSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Camera/SpectateCameraSystem.cpp
@@ -102,6 +102,7 @@ bool SpectateCameraSystem::OnPlayerAliveUpdated(const PlayerAliveUpdatedEvent& e
 			{
 				for (Entity cameraEntity : m_CameraEntities)
 				{
+					RenderSystem::GetInstance().SetRenderStageSleeping("RENDER_STAGE_FIRST_PERSON_WEAPON", false);
 					ParentComponent& parentComponent = pParentComponents->GetData(cameraEntity);
 					OffsetComponent& cameraOffsetComponent = pOffsetComponents->GetData(cameraEntity);
 
@@ -117,6 +118,7 @@ bool SpectateCameraSystem::OnPlayerAliveUpdated(const PlayerAliveUpdatedEvent& e
 			{
 				for (Entity cameraEntity : m_CameraEntities)
 				{
+					RenderSystem::GetInstance().SetRenderStageSleeping("RENDER_STAGE_FIRST_PERSON_WEAPON", true);
 					OffsetComponent& cameraOffsetComponent = pOffsetComponents->GetData(cameraEntity);
 
 					cameraOffsetComponent.Offset *= 2;


### PR DESCRIPTION
## Purpose
  - When specatating other players we only want a clean view without gui and weapon
  - This sleeps the first person weapon render stage.


## Screenshot
![image](https://user-images.githubusercontent.com/3958329/100458909-3aed6f00-30cd-11eb-80ef-fa8bc609d461.png)

## Tested
[x] 3 clients multiplayer