### PR TITLE
Fix players bounding box

### DIFF
--- a/CrazyCanvas/Include/World/LevelObjectCreator.h
+++ b/CrazyCanvas/Include/World/LevelObjectCreator.h
@@ -103,7 +103,7 @@ class LevelObjectCreator
 		LambdaEngine::TArray<LambdaEngine::Entity>&,
 		LambdaEngine::TArray<LambdaEngine::TArray<std::tuple<LambdaEngine::String, bool, LambdaEngine::Entity>>>&);
 
-	static constexpr const float PLAYER_CAPSULE_HEIGHT = 1.8f;
+	static constexpr const float PLAYER_CAPSULE_HEIGHT = 1.6f;
 	static constexpr const float PLAYER_CAPSULE_RADIUS = 0.325f;
 
 public:

--- a/CrazyCanvas/Include/World/LevelObjectCreator.h
+++ b/CrazyCanvas/Include/World/LevelObjectCreator.h
@@ -104,7 +104,7 @@ class LevelObjectCreator
 		LambdaEngine::TArray<LambdaEngine::TArray<std::tuple<LambdaEngine::String, bool, LambdaEngine::Entity>>>&);
 
 	static constexpr const float PLAYER_CAPSULE_HEIGHT = 1.8f;
-	static constexpr const float PLAYER_CAPSULE_RADIUS = 0.2f;
+	static constexpr const float PLAYER_CAPSULE_RADIUS = 0.325f;
 
 public:
 	DECL_STATIC_CLASS(LevelObjectCreator);


### PR DESCRIPTION
## Purpose
  - It was hard to hit other players. The bounding box has been resized, made them fatter and short.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

## Other
The testing was done when one of the client was standing still. These changes might change depending on how well it feels in multiplayer.