### PR TITLE
Fix Leave-Join Crash

### DIFF
--- a/CrazyCanvas/Source/RenderStages/FirstPersonWeaponRenderer.cpp
+++ b/CrazyCanvas/Source/RenderStages/FirstPersonWeaponRenderer.cpp
@@ -478,7 +478,7 @@ namespace LambdaEngine
 					constexpr DescriptorSetIndex setIndex = 3U;
 
 					// Create a new descriptor or use an old descriptor
-					m_DescriptorSetList3[d] = m_DescriptorCache.GetDescriptorSet("FirstPersonWeapon Renderer Descriptor Set 3 - Draw arg-" + std::to_string(d), m_PipelineLayout.Get(), setIndex, m_DescriptorHeap.Get());
+					m_DescriptorSetList3[d] = m_DescriptorCache.GetDescriptorSet("FirstPersonWeapon Renderer Descriptor Set 3 - Draw arg-" + std::to_string(d), m_PipelineLayout.Get(), setIndex, m_DescriptorHeap.Get(), false);
 
 					if (m_DescriptorSetList3[d] != nullptr)
 					{


### PR DESCRIPTION
## Purpose
  - Fixes the crash that happened after leaving a game/exiting singleplayer and then joining a new game.

## Changes
 - The Weapon Renderer used GetDescriptorSet from the Descriptor Cache with "shouldCopy" set to true, this causes problems as we have noticed in other Custom Renderers.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

