### PR TITLE
Player Speed While Holding Flag

### DIFF
--- a/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerAction.h
+++ b/CrazyCanvas/Include/Multiplayer/Packet/PacketPlayerAction.h
@@ -13,6 +13,7 @@ struct PacketPlayerAction : Packet
 	glm::quat	Rotation;
 	glm::i8vec3	DeltaAction;
 	bool		Walking;
+	bool		HoldingFlag		= false;
 	bool		StartedReload	= false;
 	EAmmoType	FiredAmmo		= EAmmoType::AMMO_TYPE_NONE; // Default is that we fired no projectiles
 	uint32		Angle			= 0;

--- a/CrazyCanvas/Include/World/Player/Client/PlayerLocalSystem.h
+++ b/CrazyCanvas/Include/World/Player/Client/PlayerLocalSystem.h
@@ -18,7 +18,7 @@ class PlayerLocalSystem : public ReplaySystem<PlayerGameState, PacketPlayerActio
 {
 public:
 	DECL_UNIQUE_CLASS(PlayerLocalSystem);
-	
+
 	PlayerLocalSystem();
 	virtual ~PlayerLocalSystem() = default;
 
@@ -46,5 +46,6 @@ private:
 
 private:
 	LambdaEngine::IDVector m_Entities;
+	LambdaEngine::IDVector m_FlagEntities;
 	PlayerActionSystem m_PlayerActionSystem;
 };

--- a/CrazyCanvas/Include/World/Player/PlayerActionSystem.h
+++ b/CrazyCanvas/Include/World/Player/PlayerActionSystem.h
@@ -29,5 +29,5 @@ public:
 private:
 	static bool m_MouseEnabled;
 
-	static float m_Speed;
+	static float32 m_Speed;
 };

--- a/CrazyCanvas/Include/World/Player/PlayerActionSystem.h
+++ b/CrazyCanvas/Include/World/Player/PlayerActionSystem.h
@@ -23,9 +23,11 @@ private:
 	bool OnKeyPressed(const LambdaEngine::KeyPressedEvent& event);
 
 public:
-	static void ComputeVelocity(const glm::quat& rotation, const glm::i8vec3& deltaAction, bool walking, float32 dt, glm::vec3& velocity);
+	static void ComputeVelocity(const glm::quat& rotation, const glm::i8vec3& deltaAction, bool walking, float32 dt, glm::vec3& velocity, bool isHoldingFlag);
 	static void SetMouseEnabled(bool isEnabled);
 
 private:
 	static bool m_MouseEnabled;
+
+	static float m_Speed;
 };

--- a/CrazyCanvas/Include/World/Player/PlayerGameState.h
+++ b/CrazyCanvas/Include/World/Player/PlayerGameState.h
@@ -11,6 +11,7 @@ struct PlayerGameState
 	glm::quat Rotation;
 	glm::i8vec3 DeltaAction;
 	bool Walking;
+	bool HoldingFlag;
 };
 
 struct GameStateComparator

--- a/CrazyCanvas/Source/ECS/Systems/Match/ClientFlagSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Match/ClientFlagSystem.cpp
@@ -173,11 +173,11 @@ void ClientFlagSystem::FixedTickMainThreadInternal(LambdaEngine::Timestamp delta
 			switch (editedPacket.FlagPacketType)
 			{
 			case EFlagPacketType::FLAG_PACKET_TYPE_PICKED_UP:
-				OnFlagPickedUp(MultiplayerUtils::GetEntity(editedPacket.PickedUpNetworkUID), flagEntity);
-				break;
+					OnFlagPickedUp(MultiplayerUtils::GetEntity(editedPacket.PickedUpNetworkUID), flagEntity);
+					break;
 			case EFlagPacketType::FLAG_PACKET_TYPE_DROPPED:
-				OnFlagDropped(flagEntity, editedPacket.DroppedPosition);
-				break;
+					OnFlagDropped(flagEntity, editedPacket.DroppedPosition);
+					break;
 			}
 		}
 	}

--- a/CrazyCanvas/Source/ECS/Systems/Match/ServerFlagSystem.cpp
+++ b/CrazyCanvas/Source/ECS/Systems/Match/ServerFlagSystem.cpp
@@ -238,7 +238,7 @@ void ServerFlagSystem::OnDeliveryPointFlagCollision(LambdaEngine::Entity entity0
 			const TeamComponent& playerTeamComponent = pTeamComponents->GetConstData(entityPlayer);
 
 			TeamComponent flagTeamComponent = {};
-			
+
 			bool validFlagDelivery = false;
 			if (pTeamComponents->GetConstIf(flagEntity, flagTeamComponent))
 			{

--- a/CrazyCanvas/Source/World/Player/Client/PlayerLocalSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/Client/PlayerLocalSystem.cpp
@@ -145,6 +145,7 @@ void PlayerLocalSystem::DoAction(
 	ECSCore* pECS = ECSCore::GetInstance();
 	auto pParentComponents = pECS->GetComponentArray<ParentComponent>();
 	bool holdingFlag = false;
+
 	for (Entity flagEntity : m_FlagEntities)
 	{
 		const ParentComponent& parentComponent = pParentComponents->GetConstData(flagEntity);
@@ -154,6 +155,7 @@ void PlayerLocalSystem::DoAction(
 			break;
 		}
 	}
+
 	PlayerActionSystem::ComputeVelocity(rotationComponent.Quaternion, deltaAction, walking, dt, velocityComponent.Velocity, holdingFlag);
 	PlayerSoundHelper::HandleMovementSound(velocityComponent, audibleComponent, deltaAction, walking, inAir);
 

--- a/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
@@ -25,7 +25,7 @@ using namespace LambdaEngine;
 
 
 bool PlayerActionSystem::m_MouseEnabled = true;
-float PlayerActionSystem::m_Speed = 1.0f;
+float32 PlayerActionSystem::m_Speed = 1.0f;
 
 PlayerActionSystem::PlayerActionSystem()
 {
@@ -107,7 +107,7 @@ void PlayerActionSystem::ComputeVelocity(const glm::quat& rotation, const glm::i
 	bool verticalMovement = deltaAction.y != 0;
 
 	if (isHoldingFlag)
-		m_Speed = 0.8;
+		m_Speed = 0.8f;
 	else
 		m_Speed = 1.0f;
 

--- a/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/PlayerActionSystem.cpp
@@ -15,6 +15,9 @@
 #include "Application/API/CommonApplication.h"
 #include "Application/API/Events/EventQueue.h"
 
+#include "ECS/Components/Match/FlagComponent.h"
+
+#include "Game/ECS/Components/Misc/InheritanceComponent.h"
 
 #include "Match/Match.h"
 
@@ -22,6 +25,7 @@ using namespace LambdaEngine;
 
 
 bool PlayerActionSystem::m_MouseEnabled = true;
+float PlayerActionSystem::m_Speed = 1.0f;
 
 PlayerActionSystem::PlayerActionSystem()
 {
@@ -97,10 +101,15 @@ bool PlayerActionSystem::OnKeyPressed(const KeyPressedEvent& event)
 	return false;
 }
 
-void PlayerActionSystem::ComputeVelocity(const glm::quat& rotation, const glm::i8vec3& deltaAction, bool walking, float32 dt, glm::vec3& velocity)
+void PlayerActionSystem::ComputeVelocity(const glm::quat& rotation, const glm::i8vec3& deltaAction, bool walking, float32 dt, glm::vec3& velocity, bool isHoldingFlag)
 {
 	bool horizontalMovement = deltaAction.x != 0 || deltaAction.z != 0;
 	bool verticalMovement = deltaAction.y != 0;
+
+	if (isHoldingFlag)
+		m_Speed = 0.8;
+	else
+		m_Speed = 1.0f;
 
 	if (!Match::HasBegun())
 	{
@@ -120,7 +129,7 @@ void PlayerActionSystem::ComputeVelocity(const glm::quat& rotation, const glm::i
 		currentVelocity		= rotationNoPitch * glm::vec3(deltaAction.x, 0.0f, deltaAction.z);
 		currentVelocity.y	= 0.0f;
 		currentVelocity		= glm::normalize(currentVelocity);
-		currentVelocity		*= (PLAYER_WALK_MOVEMENT_SPEED * float32(walking)) + (PLAYER_RUN_MOVEMENT_SPEED * float32(!walking));
+		currentVelocity		*= (PLAYER_WALK_MOVEMENT_SPEED * float32(walking)) + (PLAYER_RUN_MOVEMENT_SPEED * float32(!walking)) * m_Speed;
 
 		velocity.x = currentVelocity.x;
 		velocity.z = currentVelocity.z;

--- a/CrazyCanvas/Source/World/Player/Server/PlayerRemoteSystem.cpp
+++ b/CrazyCanvas/Source/World/Player/Server/PlayerRemoteSystem.cpp
@@ -90,7 +90,7 @@ void PlayerRemoteSystem::FixedTickMainThread(LambdaEngine::Timestamp deltaTime)
 					rotationComponent.Dirty = true;
 				}
 
-				PlayerActionSystem::ComputeVelocity(constRotationComponent.Quaternion, gameState.DeltaAction, gameState.Walking, dt, velocityComponent.Velocity);
+				PlayerActionSystem::ComputeVelocity(constRotationComponent.Quaternion, gameState.DeltaAction, gameState.Walking, dt, velocityComponent.Velocity, gameState.HoldingFlag);
 				CharacterControllerHelper::TickCharacterController(dt, characterColliderComponent, netPosComponent, velocityComponent);
 
 				physx::PxControllerState playerControllerState;


### PR DESCRIPTION
## Purpose
  - Player is slower while holding flag, this gives a chance for other team to keep up and recapture their flag back.

## Changes
 - PacketPlayerAction holds a new variable called HoldingFlag which keeps track who holds the flag.
 - ComputeVelocity function receives a new parameter and sets the speed whether the player has the flag or not.

## Testing
How have one tested the feature to ensure it works?
- [ ] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark