### PR TITLE
Player Noise Position fix

### DIFF
--- a/Assets/Shaders/Animation/Skinning.comp
+++ b/Assets/Shaders/Animation/Skinning.comp
@@ -76,6 +76,11 @@ void main()
 	SVertex skinnedVertex = b_SkinnedVertices.Val[gl_GlobalInvocationID.x];
 	vertex.Position.w = skinnedVertex.Position.w;
 	vertex.Normal.w = skinnedVertex.Normal.w;
+
+	// Store the vertex's original position to use when applying paint on the players.
+	SVertex originalVertex = b_OriginalVertices.Val[gl_GlobalInvocationID.x];
+	vertex.Tangent.w = originalVertex.Position.x;
+	vertex.TexCoord.zw = originalVertex.Position.yz;
 	b_SkinnedVertices.Val[gl_GlobalInvocationID.x] = vertex;
 #endif
 }

--- a/Assets/Shaders/FirstPerson/Weapon.frag
+++ b/Assets/Shaders/FirstPerson/Weapon.frag
@@ -23,6 +23,7 @@ layout(location = 9) in flat uint	in_InstanceIndex;
 layout(location = 10) in vec3 		in_ViewDirection;
 layout(location = 11) in vec4		in_PaintInfo4;
 layout(location = 12) in float 		in_PaintDist;
+layout(location = 13) in vec3 		in_LocalPosition;
 	
 layout(binding = 0, set = BUFFER_SET_INDEX) uniform PerFrameBuffer
 { 
@@ -65,8 +66,8 @@ void main()
 	SMaterialParameters materialParameters = b_MaterialParameters.val[in_MaterialSlot];
 	uint packedPaintInfo = 0;
 	float dist = 1.f;
-	GetVec4ToPackedPaintInfoAndDistance(in_WorldPosition, in_PaintInfo4, in_PaintDist, packedPaintInfo, dist);
-	SPaintDescription paintDescription = InterpolatePaint(TBN, in_WorldPosition, tangent, bitangent, packedPaintInfo, dist);
+	GetVec4ToPackedPaintInfoAndDistance(in_LocalPosition, in_PaintInfo4, in_PaintDist, packedPaintInfo, dist);
+	SPaintDescription paintDescription = InterpolatePaint(TBN, in_LocalPosition, tangent, bitangent, packedPaintInfo, dist);
 
 	shadingNormal = mix(shadingNormal, paintDescription.Normal + shadingNormal * 0.2f, paintDescription.Interpolation);
 

--- a/Assets/Shaders/FirstPerson/Weapon.vert
+++ b/Assets/Shaders/FirstPerson/Weapon.vert
@@ -31,6 +31,7 @@ layout(location = 9) out flat uint out_InstanceIndex;
 layout(location = 10) out vec3 out_ViewDirection;
 layout(location = 11) out vec4 out_PaintInfo4;
 layout(location = 12) out float out_PaintDist;
+layout(location = 13) out vec3 out_LocalPosition;
 
 void main()
 {
@@ -60,6 +61,7 @@ void main()
 	out_ViewDirection		= normalize(vec3(perFrameBuffer.View[0][2], perFrameBuffer.View[1][2], perFrameBuffer.View[2][2]));
 	out_PaintInfo4 			= PackedPaintInfoToVec4(PackPaintInfo(floatBitsToUint(vertex.Position.w)));
 	out_PaintDist 			= vertex.Normal.w; // Distance from target. 0 is at the target, 1 is at the edge.
+	out_LocalPosition		= vec3(vertex.Tangent.x, vertex.TexCoord.z, vertex.TexCoord.w); // Original vertex position
 
 	out_ClipPosition		= perFrameBuffer.Projection * perFrameBuffer.View * worldPosition;
 

--- a/Assets/Shaders/MeshPaintFunc.glsl
+++ b/Assets/Shaders/MeshPaintFunc.glsl
@@ -4,6 +4,7 @@
 #define PAINT_THRESHOLD			0.4f
 #define PAINT_FREQ              5.0f
 #define PAINT_AMPL              0.4f
+#define UINT32_MAX              0xffffffff
 
 #include "Noise.glsl"
 

--- a/Assets/Shaders/Players/Players.frag
+++ b/Assets/Shaders/Players/Players.frag
@@ -24,7 +24,7 @@ layout(location = 9) in vec3 		in_ViewDirection;
 // Mesh painting
 layout(location = 10) in vec4 		in_PaintInfo4;
 layout(location = 11) in float 		in_PaintDist;
-layout(location = 12) in vec3 		in_ModelPosition;
+layout(location = 12) in vec3 		in_LocalPosition;
 
 layout(push_constant) uniform TeamIndex
 {
@@ -71,8 +71,8 @@ void main()
 	SMaterialParameters materialParameters = b_MaterialParameters.val[in_MaterialSlot];
 	uint packedPaintInfo = 0;
 	float dist = 1.f;
-	GetVec4ToPackedPaintInfoAndDistance(in_ModelPosition, in_PaintInfo4, in_PaintDist, packedPaintInfo, dist);
-	SPaintDescription paintDescription = InterpolatePaint(TBN, in_ModelPosition, tangent, bitangent, packedPaintInfo, dist);
+	GetVec4ToPackedPaintInfoAndDistance(in_LocalPosition, in_PaintInfo4, in_PaintDist, packedPaintInfo, dist);
+	SPaintDescription paintDescription = InterpolatePaint(TBN, in_LocalPosition, tangent, bitangent, packedPaintInfo, dist);
 	shadingNormal = mix(shadingNormal, normalize(paintDescription.Normal + shadingNormal*0.2f), paintDescription.Interpolation);
 
 	vec2 currentNDC		= (in_ClipPosition.xy / in_ClipPosition.w) * 0.5f + 0.5f;

--- a/Assets/Shaders/Players/Players.vert
+++ b/Assets/Shaders/Players/Players.vert
@@ -25,7 +25,7 @@ layout(location = 9) out vec3 out_ViewDirection;
 // Mesh painting
 layout(location = 10) out vec4 out_PaintInfo4;
 layout(location = 11) out float out_PaintDist;
-layout(location = 12) out vec3 out_ModelPosition;
+layout(location = 12) out vec3 out_LocalPosition;
 
 void main()
 {
@@ -54,7 +54,7 @@ void main()
 	
 	out_PaintInfo4 			= PackedPaintInfoToVec4(PackPaintInfo(floatBitsToUint(vertex.Position.w)));
 	out_PaintDist 			= vertex.Normal.w;
-	out_ModelPosition		= vertex.Position.xyz;
+	out_LocalPosition		= vec3(vertex.Tangent.x, vertex.TexCoord.z, vertex.TexCoord.w); // Original vertex position
 
 	out_ClipPosition		= perFrameBuffer.Projection * perFrameBuffer.View * worldPosition;
 	gl_Position = out_ClipPosition;

--- a/LambdaEngine/Include/Resources/Mesh.h
+++ b/LambdaEngine/Include/Resources/Mesh.h
@@ -24,12 +24,13 @@ namespace LambdaEngine
 	{
 		alignas(16) glm::vec4 PositionXYZPaintBitsW = { 0.0f, 0.0f, 0.0f, glm::uintBitsToFloat(0) };
 		alignas(16) glm::vec4 NormalXYZPaintDistW = { 0.0f, 1.0f, 0.0f, 0.0f };
-		alignas(16) glm::vec3 Tangent;
-		alignas(16) glm::vec2 TexCoord;
+		alignas(16) glm::vec4 TangentXYZOriginalPosW = { 1.0, 0.0f, 0.0f, 0.0f };
+		alignas(16) glm::vec4 TexCoordXYOriginalPosZW = { 0.0f, 0.0f, 0.0f, 0.0f };
 
 		bool operator==(const Vertex& other) const
 		{
-			return PositionXYZPaintBitsW == other.PositionXYZPaintBitsW && NormalXYZPaintDistW == other.NormalXYZPaintDistW && Tangent == other.Tangent && TexCoord == other.TexCoord;
+			return PositionXYZPaintBitsW == other.PositionXYZPaintBitsW && NormalXYZPaintDistW == other.NormalXYZPaintDistW 
+				&& TangentXYZOriginalPosW == other.TangentXYZOriginalPosW && TexCoordXYOriginalPosZW == other.TexCoordXYOriginalPosZW;
 		}
 
 		/*
@@ -46,6 +47,22 @@ namespace LambdaEngine
 		glm::vec3 ExtractNormal() const
 		{
 			return { NormalXYZPaintDistW.x, NormalXYZPaintDistW.y, NormalXYZPaintDistW.z };
+		}
+
+		/*
+		* Returns a glm::vec3 with just the tangent - omitting the OriginalPosition's x component stored in W.
+		*/
+		glm::vec3 ExtractTangent() const
+		{
+			return { TangentXYZOriginalPosW.x, TangentXYZOriginalPosW.y, TangentXYZOriginalPosW.z };
+		}
+
+		/*
+		* Returns a glm::vec2 with just the texture coordinate - omitting the OriginalPosition's y and z components stored in Z and W.
+		*/
+		glm::vec3 ExtractTexCoord() const
+		{
+			return { TangentXYZOriginalPosW.x, TangentXYZOriginalPosW.y, TangentXYZOriginalPosW.z };
 		}
 	};
 
@@ -219,7 +236,7 @@ namespace std
 			return
 				((hash<glm::vec3>()(vertex.PositionXYZPaintBitsW) ^
 				 (hash<glm::vec3>()(vertex.NormalXYZPaintDistW) << 1)) >> 1) ^
-				 (hash<glm::vec2>()(vertex.TexCoord) << 1);
+				 (hash<glm::vec2>()(vertex.TexCoordXYOriginalPosZW) << 1);
 		}
 	};
 }

--- a/LambdaEngine/Source/Resources/Mesh.cpp
+++ b/LambdaEngine/Source/Resources/Mesh.cpp
@@ -10,10 +10,10 @@ namespace LambdaEngine
 	{
 		Vertex vertices[4] = 
 		{
-			{ glm::vec4(-1.0f, 0.0f, -1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec3(1.0f, 0.0f, 0.0f), glm::vec2(0.0f, 1.0f) },
-			{ glm::vec4(-1.0f, 0.0f,  1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec3(1.0f, 0.0f, 0.0f), glm::vec2(0.0f, 0.0f) },
-			{ glm::vec4( 1.0f, 0.0f,  1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec3(1.0f, 0.0f, 0.0f), glm::vec2(1.0f, 0.0f) },
-			{ glm::vec4( 1.0f, 0.0f, -1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec3(1.0f, 0.0f, 0.0f), glm::vec2(1.0f, 1.0f) }
+			{ glm::vec4(-1.0f, 0.0f, -1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec4(1.0f, 0.0f, 0.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f) },
+			{ glm::vec4(-1.0f, 0.0f,  1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec4(1.0f, 0.0f, 0.0f, 0.0f), glm::vec4(0.0f, 0.0f, 0.0f, 0.0f) },
+			{ glm::vec4( 1.0f, 0.0f,  1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec4(1.0f, 0.0f, 0.0f, 0.0f), glm::vec4(1.0f, 0.0f, 0.0f, 0.0f) },
+			{ glm::vec4( 1.0f, 0.0f, -1.0f, 0.0f), glm::vec4(0.0f, 1.0f, 0.0f, 0.0f), glm::vec4(1.0f, 0.0f, 0.0f, 0.0f), glm::vec4(1.0f, 1.0f, 0.0f, 0.0f) }
 		};
 
 		uint32 indices[6] =

--- a/LambdaEngine/Source/Resources/ResourceLoader.cpp
+++ b/LambdaEngine/Source/Resources/ResourceLoader.cpp
@@ -1588,7 +1588,6 @@ namespace LambdaEngine
 			vertex.PositionXYZPaintBitsW.x = pMeshAI->mVertices[vertexIdx].x;
 			vertex.PositionXYZPaintBitsW.y = pMeshAI->mVertices[vertexIdx].y;
 			vertex.PositionXYZPaintBitsW.z = pMeshAI->mVertices[vertexIdx].z;
-			vertex.PositionXYZPaintBitsW.w = glm::uintBitsToFloat(UINT32_MAX);
 
 			maxExtent.x = glm::max<float>(maxExtent.x, glm::abs(vertex.PositionXYZPaintBitsW.x));
 			maxExtent.y = glm::max<float>(maxExtent.y, glm::abs(vertex.PositionXYZPaintBitsW.y));
@@ -1606,21 +1605,27 @@ namespace LambdaEngine
 				vertex.NormalXYZPaintDistW.x = pMeshAI->mNormals[vertexIdx].x;
 				vertex.NormalXYZPaintDistW.y = pMeshAI->mNormals[vertexIdx].y;
 				vertex.NormalXYZPaintDistW.z = pMeshAI->mNormals[vertexIdx].z;
-				vertex.NormalXYZPaintDistW.w = 1.0f;
 			}
 
 			if (pMeshAI->HasTangentsAndBitangents())
 			{
-				vertex.Tangent.x = pMeshAI->mTangents[vertexIdx].x;
-				vertex.Tangent.y = pMeshAI->mTangents[vertexIdx].y;
-				vertex.Tangent.z = pMeshAI->mTangents[vertexIdx].z;
+				vertex.TangentXYZOriginalPosW.x = pMeshAI->mTangents[vertexIdx].x;
+				vertex.TangentXYZOriginalPosW.y = pMeshAI->mTangents[vertexIdx].y;
+				vertex.TangentXYZOriginalPosW.z = pMeshAI->mTangents[vertexIdx].z;
 			}
 
 			if (pMeshAI->HasTextureCoords(0))
 			{
-				vertex.TexCoord.x = pMeshAI->mTextureCoords[0][vertexIdx].x;
-				vertex.TexCoord.y = pMeshAI->mTextureCoords[0][vertexIdx].y;
+				vertex.TexCoordXYOriginalPosZW.x = pMeshAI->mTextureCoords[0][vertexIdx].x;
+				vertex.TexCoordXYOriginalPosZW.y = pMeshAI->mTextureCoords[0][vertexIdx].y;
 			}
+
+			// Store data for mesh painting.
+			vertex.PositionXYZPaintBitsW.w = glm::uintBitsToFloat(UINT32_MAX);
+			vertex.NormalXYZPaintDistW.w = 1.0f;
+			vertex.TangentXYZOriginalPosW.w = glm::uintBitsToFloat(UINT32_MAX);
+			vertex.TexCoordXYOriginalPosZW.z = glm::uintBitsToFloat(UINT32_MAX);
+			vertex.TexCoordXYOriginalPosZW.w = glm::uintBitsToFloat(UINT32_MAX);
 
 			pMesh->Vertices[vertexIdx] = vertex;
 		}


### PR DESCRIPTION
## Purpose
  - Fixes the bug where the paint would move on the players.

## Changes
 - Stored the original position in the w-component of the tangent and the zw-components of the TexCoord.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

