### PR TITLE
Fix server path

### DIFF
--- a/CrazyCanvas/Include/GUI/MultiplayerGUI.h
+++ b/CrazyCanvas/Include/GUI/MultiplayerGUI.h
@@ -61,7 +61,7 @@ private:
 	bool CheckServerStatus();
 	bool CheckServerSettings(const HostGameDescription& serverSettings);
 
-	bool StartUpServer(const std::string& applicationName, const std::string& commandLine);
+	bool StartUpServer(const std::string& commandLine);
 
 	void HandleServerInfo(ServerInfo& serverInfo, bool forceSave = false);
 

--- a/CrazyCanvas/Source/GUI/MultiplayerGUI.cpp
+++ b/CrazyCanvas/Source/GUI/MultiplayerGUI.cpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <sstream>
 #include <wchar.h>
+#include <Psapi.h>
+#include "Utilities/StringUtilities.h"
 
 #include "Math\Random.h"
 
@@ -259,13 +261,8 @@ void MultiplayerGUI::OnButtonHostGameClick(Noesis::BaseComponent* pSender, const
 		//start Server with populated struct
 		NotiPopUP(HOST_NOTIFICATION);
 
-#if defined(LAMBDA_CONFIG_DEBUG)
-		StartUpServer("../Build/bin/Debug-windows-x86_64-x64/CrazyCanvas/Server.exe", "--state=server");
-#elif defined(LAMBDA_CONFIG_RELEASE)
-		StartUpServer("../Build/bin/Release-windows-x86_64-x64/CrazyCanvas/Server.exe", "--state=server");
-#elif defined(LAMBDA_CONFIG_PRODUCTION)
-		StartUpServer("../Build/bin/Production-windows-x86_64-x64/CrazyCanvas/Server.exe", "--state=server");
-#endif
+		StartUpServer("--state=server");
+
 		//LambdaEngine::GUIApplication::SetView(nullptr);
 	}
 }
@@ -345,15 +342,33 @@ bool MultiplayerGUI::CheckServerStatus()
 	return false;
 }
 
-bool MultiplayerGUI::StartUpServer(const std::string& applicationName, const std::string& commandLine)
+bool MultiplayerGUI::StartUpServer(const std::string& commandLine)
 {
+	// Get application (.exe) path
+	HANDLE processHandle = NULL;
+	WString filePath;
+
+	processHandle = GetCurrentProcess();
+	if (processHandle != NULL)
+	{
+		TCHAR filename[MAX_PATH];
+		if (GetModuleFileNameEx(processHandle, NULL, filename, MAX_PATH) > 0)
+		{
+			filePath = WString(filename);
+		}
+		else
+		{
+			LOG_ERROR("Failed to get current process file path - cannot start server");
+			return false;
+		}
+	}
+
 	//additional Info
 	STARTUPINFOA lpStartupInfo;
 	PROCESS_INFORMATION lpProcessInfo;
-
 	m_ClientHostID = Random::Int32();
 
-	std::string finalCLine = applicationName + " " + commandLine + " " + std::to_string(m_ClientHostID);
+	std::string finalCLine = ConvertToAscii(filePath) + " " + commandLine + " " + std::to_string(m_ClientHostID);
 
 	// set the size of the structures
 	ZeroMemory(&lpStartupInfo, sizeof(lpStartupInfo));


### PR DESCRIPTION
## Purpose
  - Server path when pressing the "host" button in MultiplayerGUI had hardcoded paths to start the server, which will not work when using the installer.

## Changes
  - StartUpServer now gets the current .exe file path to start another instance of it using the right arguments.

## Testing
This does not affect any of the below options.

How have one tested the feature to ensure it works?
- [ ] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

