### PR TITLE
Fix Resize Error

### DIFF
--- a/LambdaEngine/Include/Application/API/Events/RenderEvents.h
+++ b/LambdaEngine/Include/Application/API/Events/RenderEvents.h
@@ -10,8 +10,10 @@ namespace LambdaEngine
 	struct PreSwapChainRecreatedEvent : public Event
 	{
 	public:
-		inline PreSwapChainRecreatedEvent()
+		inline PreSwapChainRecreatedEvent(uint32 width, uint32 height)
 			: Event()
+			, PreviousWidth(width)
+			, PreviousHeight(height)
 		{
 		}
 
@@ -22,6 +24,9 @@ namespace LambdaEngine
 			return String("PreSwapChainRecreatedEvent");
 		}
 
+	public:
+		uint32 PreviousWidth;
+		uint32 PreviousHeight;
 	};
 
 	/*
@@ -30,8 +35,10 @@ namespace LambdaEngine
 	struct PostSwapChainRecreatedEvent : public Event
 	{
 	public:
-		inline PostSwapChainRecreatedEvent()
+		inline PostSwapChainRecreatedEvent(uint32 width, uint32 height)
 			: Event()
+			, NewWidth(width)
+			, NewHeight(height)
 		{
 		}
 
@@ -42,5 +49,8 @@ namespace LambdaEngine
 			return String("PostSwapChainRecreatedEvent");
 		}
 
+	public:
+		uint32 NewWidth;
+		uint32 NewHeight;
 	};
 }

--- a/LambdaEngine/Include/GUI/Core/GUIApplication.h
+++ b/LambdaEngine/Include/GUI/Core/GUIApplication.h
@@ -5,7 +5,7 @@
 
 #include "Time/API/Timestamp.h"
 
-#include "Application/API/Events/WindowEvents.h"
+#include "Application/API/Events/RenderEvents.h"
 #include "Application/API/Events/KeyEvents.h"
 #include "Application/API/Events/MouseEvents.h"
 
@@ -42,7 +42,7 @@ namespace LambdaEngine
 		static void NoesisLogHandler(const char* file, uint32_t line, uint32_t level, const char* channel, const char* message);
 		static void NoesisErrorHandler(const char* file, uint32_t line, const char* message, bool fatal);
 
-		static bool OnWindowResized(const WindowResizedEvent& windowEvent);
+		static bool OnPostSwapChainRecreated(const PostSwapChainRecreatedEvent& postSwapChainRecreatedEvent);
 		static bool OnKeyPressed(const KeyPressedEvent& keyPressedEvent);
 		static bool OnKeyReleased(const KeyReleasedEvent& keyReleasedEvent);
 		static bool OnKeyTyped(const KeyTypedEvent& keyTypedEvent);

--- a/LambdaEngine/Include/Rendering/RenderGraph.h
+++ b/LambdaEngine/Include/Rendering/RenderGraph.h
@@ -415,7 +415,6 @@ namespace LambdaEngine
 		bool GetResourceAccelerationStructure(const char* pResourceName, const AccelerationStructure** ppAccelerationStructure)					const;
 
 	private:
-		bool OnWindowResized(const WindowResizedEvent& windowEvent);
 		bool OnPreSwapChainRecreated(const PreSwapChainRecreatedEvent& swapChainEvent);
 		bool OnPostSwapChainRecreated(const PostSwapChainRecreatedEvent& swapChainEvent);
 		bool OnPipelineStatesRecompiled(const PipelineStatesRecompiledEvent& event);

--- a/LambdaEngine/Source/GUI/Core/GUIApplication.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIApplication.cpp
@@ -25,7 +25,7 @@ namespace LambdaEngine
 
 	bool GUIApplication::Init()
 	{
-		EventQueue::RegisterEventHandler<WindowResizedEvent>(&GUIApplication::OnWindowResized);
+		EventQueue::RegisterEventHandler<PostSwapChainRecreatedEvent>(&GUIApplication::OnPostSwapChainRecreated);
 		EventQueue::RegisterEventHandler<KeyPressedEvent>(&GUIApplication::OnKeyPressed);
 		EventQueue::RegisterEventHandler<KeyReleasedEvent>(&GUIApplication::OnKeyReleased);
 		EventQueue::RegisterEventHandler<KeyTypedEvent>(&GUIApplication::OnKeyTyped);
@@ -57,6 +57,15 @@ namespace LambdaEngine
 
 	bool GUIApplication::Release()
 	{
+		EventQueue::UnregisterEventHandler<PostSwapChainRecreatedEvent>(&GUIApplication::OnPostSwapChainRecreated);
+		EventQueue::UnregisterEventHandler<KeyPressedEvent>(&GUIApplication::OnKeyPressed);
+		EventQueue::UnregisterEventHandler<KeyReleasedEvent>(&GUIApplication::OnKeyReleased);
+		EventQueue::UnregisterEventHandler<KeyTypedEvent>(&GUIApplication::OnKeyTyped);
+		EventQueue::UnregisterEventHandler<MouseButtonClickedEvent>(&GUIApplication::OnMouseButtonClicked);
+		EventQueue::UnregisterEventHandler<MouseButtonReleasedEvent>(&GUIApplication::OnMouseButtonReleased);
+		EventQueue::UnregisterEventHandler<MouseScrolledEvent>(&GUIApplication::OnMouseScrolled);
+		EventQueue::UnregisterEventHandler<MouseMovedEvent>(&GUIApplication::OnMouseMoved);
+
 		if (s_pView.GetPtr() != nullptr)
 		{
 			s_pView->GetRenderer()->Shutdown();
@@ -158,10 +167,10 @@ namespace LambdaEngine
 		}
 	}
 
-	bool GUIApplication::OnWindowResized(const WindowResizedEvent& windowEvent)
+	bool GUIApplication::OnPostSwapChainRecreated(const PostSwapChainRecreatedEvent& postSwapChainRecreatedEvent)
 	{
 		if (s_pView.GetPtr() != nullptr)
-			s_pView->SetSize(windowEvent.Width, windowEvent.Height);
+			s_pView->SetSize(postSwapChainRecreatedEvent.NewWidth, postSwapChainRecreatedEvent.NewHeight);
 		return true;
 	}
 

--- a/LambdaEngine/Source/Rendering/Core/Vulkan/SwapChainVK.cpp
+++ b/LambdaEngine/Source/Rendering/Core/Vulkan/SwapChainVK.cpp
@@ -101,6 +101,9 @@ namespace LambdaEngine
 		CommandQueueVK* pVkQueue = reinterpret_cast<CommandQueueVK*>(m_Desc.pQueue);
 		pVkQueue->Flush();
 
+		PreSwapChainRecreatedEvent preEvent(m_Desc.Width, m_Desc.Height);
+		EventQueue::SendEventImmediate(preEvent);
+
 		ReleaseInternal();
 		ReleaseSurface();
 
@@ -115,6 +118,9 @@ namespace LambdaEngine
 		{
 			return result;
 		}
+
+		PostSwapChainRecreatedEvent postEvent(m_Desc.Width, m_Desc.Height);
+		EventQueue::SendEventImmediate(postEvent);
 
 		AquireNextBufferIndex();
 		return AquireNextImage();
@@ -568,13 +574,13 @@ namespace LambdaEngine
 		m_Desc.Height	= height;
 		m_Desc.pQueue->Flush();
 
-		PreSwapChainRecreatedEvent preEvent = {};
+		PreSwapChainRecreatedEvent preEvent(m_Desc.Width, m_Desc.Height);
 		EventQueue::SendEventImmediate(preEvent);
 		ReleaseInternal();
 
 		if (InitInternal() == VK_SUCCESS)
 		{
-			PostSwapChainRecreatedEvent postEvent = {};
+			PostSwapChainRecreatedEvent postEvent(m_Desc.Width, m_Desc.Height);
 			EventQueue::SendEventImmediate(postEvent);
 			return true;
 		}

--- a/LambdaEngine/Source/Rendering/RenderGraph.cpp
+++ b/LambdaEngine/Source/Rendering/RenderGraph.cpp
@@ -53,7 +53,6 @@ namespace LambdaEngine
 		VALIDATE(m_pGraphicsDevice != nullptr);
 		m_pGraphicsDevice->QueryDeviceFeatures(&m_Features);
 
-		EventQueue::RegisterEventHandler<WindowResizedEvent>(this, &RenderGraph::OnWindowResized);
 		EventQueue::RegisterEventHandler<PreSwapChainRecreatedEvent>(this, &RenderGraph::OnPreSwapChainRecreated);
 		EventQueue::RegisterEventHandler<PostSwapChainRecreatedEvent>(this, &RenderGraph::OnPostSwapChainRecreated);
 		EventQueue::RegisterEventHandler<PipelineStatesRecompiledEvent>(this, &RenderGraph::OnPipelineStatesRecompiled);
@@ -61,7 +60,9 @@ namespace LambdaEngine
 
 	RenderGraph::~RenderGraph()
 	{
-		EventQueue::UnregisterEventHandler(this, &RenderGraph::OnWindowResized);
+		EventQueue::UnregisterEventHandler<PreSwapChainRecreatedEvent>(this, &RenderGraph::OnPreSwapChainRecreated);
+		EventQueue::UnregisterEventHandler<PostSwapChainRecreatedEvent>(this, &RenderGraph::OnPostSwapChainRecreated);
+		EventQueue::UnregisterEventHandler<PipelineStatesRecompiledEvent>(this, &RenderGraph::OnPipelineStatesRecompiled);
 
 		s_pMaterialFence->Wait(m_SignalValue - 1, UINT64_MAX);
 		SAFERELEASE(s_pMaterialFence);
@@ -1082,23 +1083,6 @@ namespace LambdaEngine
 		return false;
 	}
 
-	bool RenderGraph::OnWindowResized(const WindowResizedEvent& windowEvent)
-	{
-		if (IsEventOfType<WindowResizedEvent>(windowEvent))
-		{
-			m_WindowWidth	= (float32)windowEvent.Width;
-			m_WindowHeight	= (float32)windowEvent.Height;
-
-			UpdateRelativeParameters();
-
-			return true;
-		}
-		else
-		{
-			return false;
-		}
-	}
-
 	bool RenderGraph::OnPreSwapChainRecreated(const PreSwapChainRecreatedEvent& swapChainEvent)
 	{
 		UNREFERENCED_VARIABLE(swapChainEvent);
@@ -1132,7 +1116,10 @@ namespace LambdaEngine
 
 	bool RenderGraph::OnPostSwapChainRecreated(const PostSwapChainRecreatedEvent& swapChainEvent)
 	{
-		UNREFERENCED_VARIABLE(swapChainEvent);
+		m_WindowWidth = (float32)swapChainEvent.NewWidth;
+		m_WindowHeight = (float32)swapChainEvent.NewHeight;
+
+		UpdateRelativeParameters();
 
 		auto backBufferResourceIt = m_ResourceMap.find(RENDER_GRAPH_BACK_BUFFER_ATTACHMENT);
 


### PR DESCRIPTION
## Purpose
  - When resizing the window using the fullscreen checkbox in settings a single Validation Error got printed from GUIRenderer. This was found to be related to be related to not sending the "OnWindowResizedEvent" immediately but the SwapChain got resized immediately. The Pre- and PostSwapChainRecreatedEvents were not sent when the Swapchain got resized through being discovered as "Out of date" which lead to further problems. These have all been resolved.

## Changes
 - Changes were made to the swapchain to now include the previous swapchain size in PreSwapChainRecreatedEvents and the new swapchain size in PostSwapChainRecreatedEvents, these events are now also sent from HandleOutOfDate. 
 - Changes were made to the RenderGraph so that it doesn't use OnWindowResized and instead just uses the SwapChainRecreated events. 
 - The same applies to GUIApplication.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

