### PR TITLE
Fixed Particles, Movement Speed and an Incorrect Print

### DIFF
--- a/CrazyCanvas/Include/World/Player/PlayerSettings.h
+++ b/CrazyCanvas/Include/World/Player/PlayerSettings.h
@@ -3,7 +3,7 @@
 #include "LambdaEngine.h"
 
 constexpr const float32 PLAYER_FALLING_MULTIPLIER	= 1.0f;
-constexpr const float32 PLAYER_WALK_MOVEMENT_SPEED	= 2.0f;
-constexpr const float32 PLAYER_RUN_MOVEMENT_SPEED	= 4.0f;
+constexpr const float32 PLAYER_WALK_MOVEMENT_SPEED	= 2.5f;
+constexpr const float32 PLAYER_RUN_MOVEMENT_SPEED	= 5.0f;
 constexpr const float32 PLAYER_DRAG					= 15.0f;
 constexpr const float32 PLAYER_JUMP_SPEED			= 5.0f;

--- a/CrazyCanvas/Source/Match/Match.cpp
+++ b/CrazyCanvas/Source/Match/Match.cpp
@@ -67,7 +67,6 @@ bool Match::ResetMatch()
 		return true;
 	}
 
-	LOG_ERROR("Match::ResetMatch() Faild becouse s_pMatchInstance == nullptr");
 	return false;
 }
 
@@ -79,7 +78,7 @@ void Match::StartMatch()
 	if (s_pMatchInstance)
 		s_pMatchInstance->MatchStart();
 	else
-		LOG_ERROR("Match::StartMatch() Faild becouse s_pMatchInstance == nullptr");
+		LOG_ERROR("Match::StartMatch() Failed because s_pMatchInstance == nullptr");
 }
 
 void Match::BeginLoading()
@@ -90,7 +89,7 @@ void Match::BeginLoading()
 	if (s_pMatchInstance)
 		s_pMatchInstance->BeginLoading();
 	else
-		LOG_ERROR("Match::BeginLoading() Faild becouse s_pMatchInstance == nullptr");
+		LOG_ERROR("Match::BeginLoading() Failed because s_pMatchInstance == nullptr");
 }
 
 void Match::KillPlaneCallback(LambdaEngine::Entity killPlaneEntity, LambdaEngine::Entity otherEntity)

--- a/CrazyCanvas/Source/World/LevelObjectCreator.cpp
+++ b/CrazyCanvas/Source/World/LevelObjectCreator.cpp
@@ -1019,10 +1019,6 @@ bool LevelObjectCreator::CreatePlayer(
 				.MaterialGUID = ResourceCatalog::WEAPON_MATERIAL_GUID,
 			});
 
-		pECS->AddComponent<RayTracedComponent>(weaponEntity, RayTracedComponent{
-				.HitMask = 0xFF
-			});
-
 		pECS->AddComponent<AnimationAttachedComponent>(weaponEntity, AnimationAttachedComponent
 			{
 				.JointName	= "mixamorig:RightHand",
@@ -1155,9 +1151,6 @@ bool LevelObjectCreator::CreatePlayer(
 		pAnimationGraph->AddTransition(DBG_NEW Transition("Run Backward & Strafe Right", "Running & Strafe Right"));
 		pAnimationGraph->AddTransition(DBG_NEW Transition("Run Backward & Strafe Right", "Run Backward & Strafe Left"));
 #endif
-		pECS->AddComponent<RayTracedComponent>(playerEntity, RayTracedComponent{
-				.HitMask = 0xFF
-			});
 
 		//Add Audio Instances
 		{
@@ -1177,9 +1170,25 @@ bool LevelObjectCreator::CreatePlayer(
 		if (!pPlayerDesc->IsLocal)
 		{
 			pECS->AddComponent<PlayerForeignComponent>(playerEntity, PlayerForeignComponent());
+
+			pECS->AddComponent<RayTracedComponent>(playerEntity, RayTracedComponent{
+				.HitMask = 0xFF
+			});
+
+			pECS->AddComponent<RayTracedComponent>(weaponEntity, RayTracedComponent{
+				.HitMask = 0xFF
+			});
 		}
 		else
 		{
+			pECS->AddComponent<RayTracedComponent>(playerEntity, RayTracedComponent{
+				.HitMask = 0x02
+			});
+
+			pECS->AddComponent<RayTracedComponent>(weaponEntity, RayTracedComponent{
+				.HitMask = 0x02
+			});
+
 			if (pPlayerDesc->pCameraDesc == nullptr)
 			{
 				pECS->RemoveEntity(playerEntity);


### PR DESCRIPTION
## Purpose
  - Increased movement speed by 1 unit when running and by 0.5 units when walking.
  - Changed so that particles don't collide with "my" player.
  - Removed an incorrect print in ResetMatch(). We reset the match in LobbyState and the Match might not be initialized there, so it is no error if s_pMatchInstance == nullptr.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

