### PR TITLE
LobbyGUI & MultiplayerGUI Cleanup

### DIFF
--- a/Assets/NoesisGUI/Xaml/Multiplayer.xaml
+++ b/Assets/NoesisGUI/Xaml/Multiplayer.xaml
@@ -209,7 +209,7 @@
     </TabItem>
 
   </TabControl >
-  <Grid x:Name="ERROR_BOX_CONTAINER" Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" Height="100" VerticalAlignment="Center" Width="250">
+  <Grid x:Name="ERROR_BOX_CONTAINER" Visibility="Collapsed" Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" Height="100" VerticalAlignment="Center" Width="250">
     <Grid.Background>
       <SolidColorBrush Color="Teal" Opacity="0"/>
     </Grid.Background>
@@ -235,7 +235,7 @@
     </Button>
   </Grid>
 
-  <Grid x:Name="NOTIFICATION_BOX_CONTAINER" Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" Height="100" VerticalAlignment="Center" Width="250">
+  <Grid x:Name="NOTIFICATION_BOX_CONTAINER" Visibility="Collapsed" Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" Height="100" VerticalAlignment="Center" Width="250">
     <Grid.Background>
       <SolidColorBrush Color="Teal" Opacity="0"/>
     </Grid.Background>

--- a/CrazyCanvas/Include/Events/ServerEvents.h
+++ b/CrazyCanvas/Include/Events/ServerEvents.h
@@ -4,13 +4,7 @@
 
 #include "Lobby/ServerInfo.h"
 
-enum EServerState
-{
-	SERVER_STATE_LOBBY,
-	SERVER_STATE_SETUP,
-	SERVER_STATE_LOADING,
-	SERVER_STATE_PLAYING
-};
+#include "Lobby/EServerState.h"
 
 struct ServerStateEvent : public LambdaEngine::Event
 {

--- a/CrazyCanvas/Include/GUI/MultiplayerGUI.h
+++ b/CrazyCanvas/Include/GUI/MultiplayerGUI.h
@@ -9,26 +9,6 @@
 #include "NsGui/ListBox.h"
 #include "NsGui/TextBox.h"
 
-struct HostGameDescription
-{
-	int8 PlayersNumber = -1;
-	int8 MapNumber = -1;
-};
-
-enum PopUpCode
-{
-	CONNECT_ERROR,
-	CONNECT_ERROR_INVALID,
-	JOIN_ERROR,
-	JOIN_ERROR_OFFLINE,
-	HOST_ERROR,
-	OTHER_ERROR,
-	HOST_NOTIFICATION,
-	JOIN_NOTIFICATION
-};
-
-class MultiplayerState;
-
 class MultiplayerGUI : public Noesis::Grid
 {
 	friend class MultiplayerState;
@@ -60,6 +40,12 @@ private:
 	void ServerInfoToUniqeString(const ServerInfo& serverInfo, LambdaEngine::String& str) const;
 	const ServerInfo* GetServerInfoFromGrid(const LambdaEngine::THashTable<uint64, ServerInfo>& servers, Noesis::Grid* pGrid) const;
 
+	void DisplayErrorMessage(const char* error);
+	void DisplayNotification(const char* error);
+	void CloseNotification();
+
+	NS_IMPLEMENT_INLINE_REFLECTION_(MultiplayerGUI, Noesis::Grid)
+
 private:
 	Noesis::Grid* m_pGridServers;
 	Noesis::ListBox* m_pListBoxServersLAN;
@@ -68,15 +54,4 @@ private:
 	Noesis::TextBox* m_pTextBoxName;
 
 	MultiplayerState* m_pMulitplayerState;
-
-private:
-	void DisplayErrorMessage(const char* error);
-	void NotiPopUP(PopUpCode notificationCode);
-
-	void ErrorPopUpClose();
-	void NotiPopUpClose();
-
-	bool CheckServerSettings(const HostGameDescription& serverSettings);
-
-	NS_IMPLEMENT_INLINE_REFLECTION_(MultiplayerGUI, Noesis::Grid)
 };

--- a/CrazyCanvas/Include/GUI/MultiplayerGUI.h
+++ b/CrazyCanvas/Include/GUI/MultiplayerGUI.h
@@ -31,6 +31,8 @@ class MultiplayerState;
 
 class MultiplayerGUI : public Noesis::Grid
 {
+	friend class MultiplayerState;
+
 public:
 	MultiplayerGUI(MultiplayerState* pMulitplayerState);
 	~MultiplayerGUI();
@@ -68,7 +70,7 @@ private:
 	MultiplayerState* m_pMulitplayerState;
 
 private:
-	void ErrorPopUp(PopUpCode errorCode);
+	void DisplayErrorMessage(const char* error);
 	void NotiPopUP(PopUpCode notificationCode);
 
 	void ErrorPopUpClose();

--- a/CrazyCanvas/Include/Lobby/EServerState.h
+++ b/CrazyCanvas/Include/Lobby/EServerState.h
@@ -1,0 +1,9 @@
+#pragma once
+
+enum EServerState : uint8
+{
+	SERVER_STATE_LOBBY,
+	SERVER_STATE_SETUP,
+	SERVER_STATE_LOADING,
+	SERVER_STATE_PLAYING
+};

--- a/CrazyCanvas/Include/Lobby/ServerInfo.h
+++ b/CrazyCanvas/Include/Lobby/ServerInfo.h
@@ -8,6 +8,8 @@
 
 #include "Networking/API/IPEndPoint.h"
 
+#include "Lobby/EServerState.h"
+
 struct ServerInfo
 {
 	LambdaEngine::String Name;
@@ -19,6 +21,7 @@ struct ServerInfo
 	uint64 ServerUID	= 0;
 	bool IsLAN			= false;
 	bool IsOnline		= false;
+	EServerState State;
 
 	LambdaEngine::IPEndPoint EndPoint;
 	LambdaEngine::Timestamp LastPinged;
@@ -36,6 +39,7 @@ struct ServerInfo
 			ServerUID == other.ServerUID &&
 			IsLAN == other.IsLAN &&
 			IsOnline == other.IsOnline &&
+			State == other.State &&
 			EndPoint == other.EndPoint;
 	}
 
@@ -50,6 +54,7 @@ struct ServerInfo
 			ServerUID != other.ServerUID ||
 			IsLAN != other.IsLAN ||
 			IsOnline != other.IsOnline ||
+			State != other.State ||
 			EndPoint != other.EndPoint;
 	}
 
@@ -65,6 +70,7 @@ struct ServerInfo
 			ServerUID = other.ServerUID;
 			IsLAN = other.IsLAN;
 			IsOnline = other.IsOnline;
+			State = other.State;
 			EndPoint = other.EndPoint;
 			LastPinged = other.LastPinged;
 		}

--- a/CrazyCanvas/Include/States/MultiplayerState.h
+++ b/CrazyCanvas/Include/States/MultiplayerState.h
@@ -37,6 +37,7 @@ private:
 	bool OnServerUpdatedEvent(const ServerUpdatedEvent& event);
 
 	bool ConnectToServer(const LambdaEngine::IPEndPoint& endPoint, bool isManual);
+	bool ConnectToServer(const ServerInfo& serverInfo);
 
 	bool HasHostedServer() const;
 	void StartUpServer();

--- a/CrazyCanvas/Source/GUI/MultiplayerGUI.cpp
+++ b/CrazyCanvas/Source/GUI/MultiplayerGUI.cpp
@@ -55,9 +55,6 @@ MultiplayerGUI::MultiplayerGUI(MultiplayerState* pMultiplayerState) :
 	m_pTextBoxAddress		= FrameworkElement::FindName<TextBox>("IP_ADDRESS");
 	m_pTextBoxName			= FrameworkElement::FindName<TextBox>("IN_GAME_NAME");
 
-	ErrorPopUpClose();
-	NotiPopUpClose();
-
 	// Use Host name as default In Game name
 	const Player* pLocalPlayer = PlayerManagerClient::GetPlayerLocal();
 	LambdaEngine::String nameStr;
@@ -284,7 +281,7 @@ void MultiplayerGUI::OnButtonErrorOKClick(Noesis::BaseComponent* pSender, const 
 	UNREFERENCED_VARIABLE(pSender);
 	UNREFERENCED_VARIABLE(args);
 
-	ErrorPopUpClose();
+	FrameworkElement::FindName<Grid>("ERROR_BOX_CONTAINER")->SetVisibility(Visibility_Collapsed);
 }
 
 void MultiplayerGUI::OnButtonHostGameClick(Noesis::BaseComponent* pSender, const Noesis::RoutedEventArgs& args)
@@ -345,35 +342,15 @@ void MultiplayerGUI::DisplayErrorMessage(const char* error)
 	FrameworkElement::FindName<Grid>("ERROR_BOX_CONTAINER")->SetVisibility(Visibility_Visible);
 }
 
-void MultiplayerGUI::NotiPopUP(PopUpCode notificationCode)
+void MultiplayerGUI::DisplayNotification(const char* error)
 {
 	TextBlock* pTextBox = FrameworkElement::FindName<TextBlock>("NOTIFICATION_BOX_TEXT");
-
-	switch (notificationCode)
-	{
-	case HOST_NOTIFICATION:	pTextBox->SetText("Server Starting...");	break;
-	case JOIN_NOTIFICATION:	pTextBox->SetText("Joining Server...");		break;
-	}
+	pTextBox->SetText(error);
 
 	FrameworkElement::FindName<Grid>("NOTIFICATION_BOX_CONTAINER")->SetVisibility(Visibility_Visible);
 }
 
-void MultiplayerGUI::ErrorPopUpClose()
+void MultiplayerGUI::CloseNotification()
 {
-	FrameworkElement::FindName<Grid>("ERROR_BOX_CONTAINER")->SetVisibility(Visibility_Hidden);
-}
-
-void MultiplayerGUI::NotiPopUpClose()
-{
-	FrameworkElement::FindName<Grid>("NOTIFICATION_BOX_CONTAINER")->SetVisibility(Visibility_Hidden);
-}
-
-bool MultiplayerGUI::CheckServerSettings(const HostGameDescription& serverSettings)
-{
-	if (serverSettings.PlayersNumber == -1)
-		return false;
-	else if (serverSettings.MapNumber == -1)
-		return false;
-
-	return true;
+	FrameworkElement::FindName<Grid>("NOTIFICATION_BOX_CONTAINER")->SetVisibility(Visibility_Collapsed);
 }

--- a/CrazyCanvas/Source/Lobby/PlayerManagerClient.cpp
+++ b/CrazyCanvas/Source/Lobby/PlayerManagerClient.cpp
@@ -145,7 +145,7 @@ void PlayerManagerClient::SetLocalPlayerStateLoading()
 	{
 		ASSERT_MSG(pPlayer->GetState() == GAME_STATE_SETUP, "Player not in SETUP state!");
 
-		ClientHelper::SetTimeout(Timestamp::Seconds(15));
+		ClientHelper::SetTimeout(Timestamp::Seconds(30));
 
 		pPlayer->m_State = GAME_STATE_LOADING;
 

--- a/CrazyCanvas/Source/Lobby/ServerManager.cpp
+++ b/CrazyCanvas/Source/Lobby/ServerManager.cpp
@@ -107,11 +107,23 @@ bool ServerManager::OnServerResponse(const ServerDiscoveredEvent& event)
 	serverInfo.IsLAN		= event.IsLAN;
 	serverInfo.IsOnline		= true;
 
-	pDecoder->ReadUInt8(serverInfo.Players);
-	pDecoder->ReadUInt8(serverInfo.MaxPlayers);
-	pDecoder->ReadString(serverInfo.Name);
-	pDecoder->ReadString(serverInfo.MapName);
-	pDecoder->ReadInt32(serverInfo.ClientHostID);
+	if (!pDecoder->ReadUInt8(serverInfo.Players))
+		return false;
+
+	if (!pDecoder->ReadUInt8(serverInfo.MaxPlayers))
+		return false;
+
+	if (!pDecoder->ReadString(serverInfo.Name))
+		return false;
+
+	if (!pDecoder->ReadString(serverInfo.MapName))
+		return false;
+
+	if (!pDecoder->ReadUInt8((uint8&)serverInfo.State))
+		return false;
+
+	if (!pDecoder->ReadInt32(serverInfo.ClientHostID))
+		return false;
 
 	if (serverInfo.IsLAN)
 		AddOrUpdateServer(s_ServersLAN, serverInfo);

--- a/CrazyCanvas/Source/States/MultiplayerState.cpp
+++ b/CrazyCanvas/Source/States/MultiplayerState.cpp
@@ -96,6 +96,15 @@ bool MultiplayerState::OnClientConnected(const LambdaEngine::ClientConnectedEven
 
 bool MultiplayerState::OnClientDisconnected(const LambdaEngine::ClientDisconnectedEvent& event)
 {
+	if (event.Reason == "Server Currently Not Accepting")
+	{
+		m_MultiplayerGUI->DisplayErrorMessage("The selected server is currently busy playing!");
+	}
+	else if (event.Reason == "Server Full")
+	{
+		m_MultiplayerGUI->DisplayErrorMessage("The selected server is currently full!");
+	}
+
 	return false;
 }
 
@@ -107,7 +116,7 @@ bool MultiplayerState::OnServerOnlineEvent(const ServerOnlineEvent& event)
 	{
 		if (m_ClientHostID == serverInfo.ClientHostID)
 		{
-			ConnectToServer(serverInfo.EndPoint, false);
+			ConnectToServer(serverInfo);
 		}
 		m_MultiplayerGUI->AddServerLAN(serverInfo);
 	}	
@@ -158,6 +167,23 @@ bool MultiplayerState::ConnectToServer(const IPEndPoint& endPoint, bool isManual
 {
 	m_IsManualConnection = isManual;
 	return ClientSystem::GetInstance().Connect(endPoint);
+}
+
+bool MultiplayerState::ConnectToServer(const ServerInfo& serverInfo)
+{
+	if (serverInfo.State == EServerState::SERVER_STATE_LOBBY)
+	{
+		if (serverInfo.Players < serverInfo.MaxPlayers)
+		{
+			return ConnectToServer(serverInfo.EndPoint, false);
+		}
+
+		m_MultiplayerGUI->DisplayErrorMessage("The selected server is currently full!");
+		return false;
+	}
+
+	m_MultiplayerGUI->DisplayErrorMessage("The selected server is currently busy playing!");
+	return false;
 }
 
 bool MultiplayerState::HasHostedServer() const

--- a/CrazyCanvas/Source/States/MultiplayerState.cpp
+++ b/CrazyCanvas/Source/States/MultiplayerState.cpp
@@ -108,6 +108,10 @@ bool MultiplayerState::OnClientDisconnected(const LambdaEngine::ClientDisconnect
 	{
 		m_MultiplayerGUI->DisplayErrorMessage("The server is currently full!");
 	}
+	else
+	{
+		m_MultiplayerGUI->DisplayErrorMessage("Failed to join server!");
+	}
 
 	return false;
 }

--- a/CrazyCanvas/Source/States/ServerState.cpp
+++ b/CrazyCanvas/Source/States/ServerState.cpp
@@ -115,6 +115,7 @@ bool ServerState::OnServerDiscoveryPreTransmit(const LambdaEngine::ServerDiscove
 	pEncoder->WriteUInt8(m_GameSettings.Players);
 	pEncoder->WriteString(m_GameSettings.ServerName);
 	pEncoder->WriteString(m_MapName);
+	pEncoder->WriteUInt8(GetState());
 	pEncoder->WriteInt32(m_ClientHostID);
 
 	return true;

--- a/CrazyCanvas/Source/States/ServerState.cpp
+++ b/CrazyCanvas/Source/States/ServerState.cpp
@@ -289,7 +289,7 @@ bool ServerState::OnServerStateEvent(const ServerStateEvent& event)
 	else if (state == SERVER_STATE_SETUP)
 	{
 		ServerHelper::SetIgnoreNewClients(true);
-		ServerHelper::SetTimeout(Timestamp::Seconds(15));
+		ServerHelper::SetTimeout(Timestamp::Seconds(30));
 	}
 	else if (state == SERVER_STATE_PLAYING)
 	{

--- a/LambdaEngine/Include/Networking/API/BinaryDecoder.h
+++ b/LambdaEngine/Include/Networking/API/BinaryDecoder.h
@@ -16,46 +16,25 @@ namespace LambdaEngine
 		BinaryDecoder(NetworkSegment* pPacket);
 		~BinaryDecoder();
 
-		void ReadInt8(int8& value);
-		void ReadUInt8(uint8& value);
-		void ReadInt16(int16& value);
-		void ReadUInt16(uint16& value);
-		void ReadInt32(int32& value);
-		void ReadUInt32(uint32& value);
-		void ReadInt64(int64& value);
-		void ReadUInt64(uint64& value);
-		void ReadFloat32(float32& value);
-		void ReadFloat64(float64& value);
-		void ReadBool(bool& value);
-		void ReadString(std::string& value);
-		void ReadBuffer(uint8* pBuffer, uint16 bytesToRead);
+		bool ReadInt8(int8& value);
+		bool ReadUInt8(uint8& value);
+		bool ReadInt16(int16& value);
+		bool ReadUInt16(uint16& value);
+		bool ReadInt32(int32& value);
+		bool ReadUInt32(uint32& value);
+		bool ReadInt64(int64& value);
+		bool ReadUInt64(uint64& value);
+		bool ReadFloat32(float32& value);
+		bool ReadFloat64(float64& value);
+		bool ReadBool(bool& value);
+		bool ReadString(std::string& value);
+		bool ReadBuffer(uint8* pBuffer, uint16 bytesToRead);
 
-		void ReadVec2(glm::vec2& value);
-		void ReadVec3(glm::vec3& value);
-		void ReadVec4(glm::vec4& value);
+		bool ReadVec2(glm::vec2& value);
+		bool ReadVec3(glm::vec3& value);
+		bool ReadVec4(glm::vec4& value);
 
-		void ReadQuat(glm::quat& value);
-
-
-		int8		ReadInt8();
-		uint8		ReadUInt8();
-		int16		ReadInt16();
-		uint16		ReadUInt16();
-		int32		ReadInt32();
-		uint32		ReadUInt32();
-		int64		ReadInt64();
-		uint64		ReadUInt64();
-		float32		ReadFloat32();
-		float64		ReadFloat64();
-		bool		ReadBool();
-		std::string ReadString();
-
-		glm::vec2 ReadVec2();
-		glm::vec3 ReadVec3();
-		glm::vec4 ReadVec4();
-
-		glm::quat ReadQuat();
-
+		bool ReadQuat(glm::quat& value);
 
 		NetworkSegment* GetPacket();
 

--- a/LambdaEngine/Include/Networking/API/BinaryEncoder.h
+++ b/LambdaEngine/Include/Networking/API/BinaryEncoder.h
@@ -15,25 +15,25 @@ namespace LambdaEngine
 		BinaryEncoder(NetworkSegment* pPacket);
 		~BinaryEncoder();
 
-		void WriteInt8(int8 value);
-		void WriteUInt8(uint8 value);
-		void WriteInt16(int16 value);
-		void WriteUInt16(uint16 value);
-		void WriteInt32(int32 value);
-		void WriteUInt32(uint32 value);
-		void WriteInt64(int64 value);
-		void WriteUInt64(uint64 value);
-		void WriteFloat32(float32 value);
-		void WriteFloat64(float64 value);
-		void WriteBool(bool value);
-		void WriteString(const std::string& value);
-		void WriteBuffer(const uint8* pBuffer, uint16 size);
+		bool WriteInt8(int8 value);
+		bool WriteUInt8(uint8 value);
+		bool WriteInt16(int16 value);
+		bool WriteUInt16(uint16 value);
+		bool WriteInt32(int32 value);
+		bool WriteUInt32(uint32 value);
+		bool WriteInt64(int64 value);
+		bool WriteUInt64(uint64 value);
+		bool WriteFloat32(float32 value);
+		bool WriteFloat64(float64 value);
+		bool WriteBool(bool value);
+		bool WriteString(const std::string& value);
+		bool WriteBuffer(const uint8* pBuffer, uint16 size);
 
-		void WriteVec2(const glm::vec2& value);
-		void WriteVec3(const glm::vec3& value);
-		void WriteVec4(const glm::vec4& value);
+		bool WriteVec2(const glm::vec2& value);
+		bool WriteVec3(const glm::vec3& value);
+		bool WriteVec4(const glm::vec4& value);
 
-		void WriteQuat(const glm::quat& value);
+		bool WriteQuat(const glm::quat& value);
 
 	private:
 		NetworkSegment* m_pNetworkPacket;

--- a/LambdaEngine/Include/Networking/API/NetworkSegment.h
+++ b/LambdaEngine/Include/Networking/API/NetworkSegment.h
@@ -52,18 +52,18 @@ namespace LambdaEngine
 
 		uint16 GetTotalSize() const;
 
-		NetworkSegment* Write(const void* pBuffer, uint16 bytes);
+		bool Write(const void* pBuffer, uint16 bytes);
 
 		template<typename T>
-		NetworkSegment* Write(const T* pStruct)
+		bool Write(const T* pStruct)
 		{
 			return Write(pStruct, sizeof(T));
 		}
 
-		NetworkSegment* Read(void* pBuffer, uint16 bytes);
+		bool Read(void* pBuffer, uint16 bytes);
 
 		template<typename T>
-		NetworkSegment* Read(T* pStruct)
+		bool Read(T* pStruct)
 		{
 			return Read(pStruct, sizeof(T));
 		}

--- a/LambdaEngine/Source/Networking/API/BinaryDecoder.cpp
+++ b/LambdaEngine/Source/Networking/API/BinaryDecoder.cpp
@@ -15,204 +15,94 @@ namespace LambdaEngine
 
 	}
 
-	void BinaryDecoder::ReadInt8(int8& value)
+	bool BinaryDecoder::ReadInt8(int8& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadUInt8(uint8& value)
+	bool BinaryDecoder::ReadUInt8(uint8& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadInt16(int16& value)
+	bool BinaryDecoder::ReadInt16(int16& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadUInt16(uint16& value)
+	bool BinaryDecoder::ReadUInt16(uint16& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadInt32(int32& value)
+	bool BinaryDecoder::ReadInt32(int32& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadUInt32(uint32& value)
+	bool BinaryDecoder::ReadUInt32(uint32& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadInt64(int64& value)
+	bool BinaryDecoder::ReadInt64(int64& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadUInt64(uint64& value)
+	bool BinaryDecoder::ReadUInt64(uint64& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadFloat32(float32& value)
+	bool BinaryDecoder::ReadFloat32(float32& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadFloat64(float64& value)
+	bool BinaryDecoder::ReadFloat64(float64& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadBool(bool& value)
+	bool BinaryDecoder::ReadBool(bool& value)
 	{
-		ReadBuffer((uint8*)&value, sizeof(value));
+		return ReadBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryDecoder::ReadString(std::string& value)
+	bool BinaryDecoder::ReadString(std::string& value)
 	{
 		uint16 length;
-		ReadUInt16(length);
+		if (!ReadUInt16(length))
+			return false;
+
 		value.resize(length);
-		ReadBuffer((uint8*)value.data(), length);
+		return ReadBuffer((uint8*)value.data(), length);
 	}
 
-	void BinaryDecoder::ReadBuffer(uint8* pBuffer, uint16 bytesToRead)
+	bool BinaryDecoder::ReadBuffer(uint8* pBuffer, uint16 bytesToRead)
 	{
-		m_pNetworkPacket->Read(pBuffer, bytesToRead);
+		return m_pNetworkPacket->Read(pBuffer, bytesToRead);
 	}
 
-	void BinaryDecoder::ReadVec2(glm::vec2& value)
+	bool BinaryDecoder::ReadVec2(glm::vec2& value)
 	{
-		ReadBuffer((uint8*)&value.data, sizeof(glm::vec2));
+		return ReadBuffer((uint8*)&value.data, sizeof(glm::vec2));
 	}
 
-	void BinaryDecoder::ReadVec3(glm::vec3& value)
+	bool BinaryDecoder::ReadVec3(glm::vec3& value)
 	{
-		ReadBuffer((uint8*)&value.data, sizeof(glm::vec3));
+		return ReadBuffer((uint8*)&value.data, sizeof(glm::vec3));
 	}
 
-	void BinaryDecoder::ReadVec4(glm::vec4& value)
+	bool BinaryDecoder::ReadVec4(glm::vec4& value)
 	{
-		ReadBuffer((uint8*)&value.data, sizeof(glm::vec4));
+		return ReadBuffer((uint8*)&value.data, sizeof(glm::vec4));
 	}
 
-	void BinaryDecoder::ReadQuat(glm::quat& value)
+	bool BinaryDecoder::ReadQuat(glm::quat& value)
 	{
-		ReadBuffer((uint8*)&value.data, sizeof(glm::quat));
-	}
-
-	int8 BinaryDecoder::ReadInt8()
-	{
-		int8 value = 0;
-		ReadInt8(value);
-		return value;
-	}
-
-	uint8 BinaryDecoder::ReadUInt8()
-	{
-		uint8 value = 0;
-		ReadUInt8(value);
-		return value;
-	}
-
-	int16 BinaryDecoder::ReadInt16()
-	{
-		int16 value = 0;
-		ReadInt16(value);
-		return value;
-	}
-
-	uint16 BinaryDecoder::ReadUInt16()
-	{
-		uint16 value = 0;
-		ReadUInt16(value);
-		return value;
-	}
-
-	int32 BinaryDecoder::ReadInt32()
-	{
-		int32 value = 0;
-		ReadInt32(value);
-		return value;
-	}
-
-	uint32 BinaryDecoder::ReadUInt32()
-	{
-		uint32 value = 0;
-		ReadUInt32(value);
-		return value;
-	}
-
-	int64 BinaryDecoder::ReadInt64()
-	{
-		int64 value = 0;
-		ReadInt64(value);
-		return value;
-	}
-
-	uint64 BinaryDecoder::ReadUInt64()
-	{
-		uint64 value = 0;
-		ReadUInt64(value);
-		return value;
-	}
-
-	float32 BinaryDecoder::ReadFloat32()
-	{
-		float32 value = 0.0f;
-		ReadFloat32(value);
-		return value;
-	}
-
-	float64 BinaryDecoder::ReadFloat64()
-	{
-		float64 value = 0.0f;
-		ReadFloat64(value);
-		return value;
-	}
-
-	bool BinaryDecoder::ReadBool()
-	{
-		bool value = false;
-		ReadBool(value);
-		return value;
-	}
-
-	std::string BinaryDecoder::ReadString()
-	{
-		std::string value;
-		ReadString(value);
-		return value;
-	}
-
-	glm::vec2 BinaryDecoder::ReadVec2()
-	{
-		glm::vec2 value;
-		ReadVec2(value);
-		return value;
-	}
-
-	glm::vec3 BinaryDecoder::ReadVec3()
-	{
-		glm::vec3 value;
-		ReadVec3(value);
-		return value;
-	}
-
-	glm::vec4 BinaryDecoder::ReadVec4()
-	{
-		glm::vec4 value;
-		ReadVec4(value);
-		return value;
-	}
-
-	glm::quat BinaryDecoder::ReadQuat()
-	{
-		glm::quat value;
-		ReadQuat(value);
-		return value;
+		return ReadBuffer((uint8*)&value.data, sizeof(glm::quat));
 	}
 
 	NetworkSegment* BinaryDecoder::GetPacket()

--- a/LambdaEngine/Source/Networking/API/BinaryEncoder.cpp
+++ b/LambdaEngine/Source/Networking/API/BinaryEncoder.cpp
@@ -15,89 +15,91 @@ namespace LambdaEngine
 
 	}
 
-	void BinaryEncoder::WriteInt8(int8 value)
+	bool BinaryEncoder::WriteInt8(int8 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteUInt8(uint8 value)
+	bool BinaryEncoder::WriteUInt8(uint8 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteInt16(int16 value)
+	bool BinaryEncoder::WriteInt16(int16 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteUInt16(uint16 value)
+	bool BinaryEncoder::WriteUInt16(uint16 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteInt32(int32 value)
+	bool BinaryEncoder::WriteInt32(int32 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteUInt32(uint32 value)
+	bool BinaryEncoder::WriteUInt32(uint32 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteInt64(int64 value)
+	bool BinaryEncoder::WriteInt64(int64 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteUInt64(uint64 value)
+	bool BinaryEncoder::WriteUInt64(uint64 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteFloat32(float32 value)
+	bool BinaryEncoder::WriteFloat32(float32 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteFloat64(float64 value)
+	bool BinaryEncoder::WriteFloat64(float64 value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteBool(bool value)
+	bool BinaryEncoder::WriteBool(bool value)
 	{
-		WriteBuffer((uint8*)&value, sizeof(value));
+		return WriteBuffer((uint8*)&value, sizeof(value));
 	}
 
-	void BinaryEncoder::WriteString(const std::string& value)
+	bool BinaryEncoder::WriteString(const std::string& value)
 	{
-		WriteUInt16((uint16)value.length());
-		WriteBuffer((const uint8*)value.c_str(), (uint16)value.length());
+		if (!WriteUInt16((uint16)value.length()))
+			return false;
+
+		return WriteBuffer((const uint8*)value.c_str(), (uint16)value.length());
 	}
 
-	void BinaryEncoder::WriteBuffer(const uint8* pBuffer, uint16 size)
+	bool BinaryEncoder::WriteBuffer(const uint8* pBuffer, uint16 size)
 	{
-		m_pNetworkPacket->Write(pBuffer, size);
+		return m_pNetworkPacket->Write(pBuffer, size);
 	}
 
-	void BinaryEncoder::WriteVec2(const glm::vec2& value)
+	bool BinaryEncoder::WriteVec2(const glm::vec2& value)
 	{
-		WriteBuffer((const uint8*)&value.data, sizeof(glm::vec2));
+		return WriteBuffer((const uint8*)&value.data, sizeof(glm::vec2));
 	}
 
-	void BinaryEncoder::WriteVec3(const glm::vec3& value)
+	bool BinaryEncoder::WriteVec3(const glm::vec3& value)
 	{
-		WriteBuffer((const uint8*)&value.data, sizeof(glm::vec3));
+		return WriteBuffer((const uint8*)&value.data, sizeof(glm::vec3));
 	}
 
-	void BinaryEncoder::WriteVec4(const glm::vec4& value)
+	bool BinaryEncoder::WriteVec4(const glm::vec4& value)
 	{
-		WriteBuffer((const uint8*)&value.data, sizeof(glm::vec4));
+		return WriteBuffer((const uint8*)&value.data, sizeof(glm::vec4));
 	}
 
-	void BinaryEncoder::WriteQuat(const glm::quat& value)
+	bool BinaryEncoder::WriteQuat(const glm::quat& value)
 	{
-		WriteBuffer((const uint8*)&value.data, sizeof(glm::quat));
+		return WriteBuffer((const uint8*)&value.data, sizeof(glm::quat));
 	}
 }

--- a/LambdaEngine/Source/Networking/API/ClientRemoteBase.cpp
+++ b/LambdaEngine/Source/Networking/API/ClientRemoteBase.cpp
@@ -388,8 +388,8 @@ namespace LambdaEngine
 		{
 			uint64 expectedAnswer = NetworkChallenge::Compute(GetStatistics()->GetSalt(), pPacket->GetRemoteSalt());
 			BinaryDecoder decoder(pPacket);
-			uint64 answer = decoder.ReadUInt64();
-			if (answer == expectedAnswer)
+			uint64 answer;
+			if (decoder.ReadUInt64(answer) && answer == expectedAnswer)
 			{
 				NetworkSegment* pSegment = GetFreePacket(NetworkSegment::TYPE_ACCEPTED);
 				if (pSegment)
@@ -406,6 +406,7 @@ namespace LambdaEngine
 			else
 			{
 				LOG_ERROR("[ClientRemoteBase]: Client responded with %lu, expected %lu, is it a fake client? [%s]", answer, expectedAnswer, GetEndPoint().ToString().c_str());
+				Disconnect("Challenge failed!");
 			}
 		}
 		else if (packetType == NetworkSegment::TYPE_DISCONNECT)

--- a/LambdaEngine/Source/Networking/API/NetworkSegment.cpp
+++ b/LambdaEngine/Source/Networking/API/NetworkSegment.cpp
@@ -54,20 +54,30 @@ namespace LambdaEngine
 		return GetBufferSize() + HeaderSize;
 	}
 
-	NetworkSegment* NetworkSegment::Write(const void* pBuffer, uint16 bytes)
+	bool NetworkSegment::Write(const void* pBuffer, uint16 bytes)
 	{
-		ASSERT(m_SizeOfBuffer + bytes <= MAXIMUM_SEGMENT_SIZE);
+		if (m_SizeOfBuffer + bytes > MAXIMUM_SEGMENT_SIZE)
+		{
+			LOG_ERROR("NetworkSegment::Write() Tried to write out of bounds, WriteHead: %u, ToWrite: %u, Buffer: %u", m_SizeOfBuffer, bytes, MAXIMUM_SEGMENT_SIZE);
+			return false;
+		}
+
 		memcpy(m_pBuffer + m_SizeOfBuffer, pBuffer, bytes);
 		m_SizeOfBuffer += bytes;
-		return this;
+		return true;
 	}
 
-	NetworkSegment* NetworkSegment::Read(void* pBuffer, uint16 bytes)
+	bool NetworkSegment::Read(void* pBuffer, uint16 bytes)
 	{
-		ASSERT(m_ReadHead + bytes <= m_SizeOfBuffer);
+		if (m_ReadHead + bytes > m_SizeOfBuffer)
+		{
+			LOG_ERROR("NetworkSegment::Read() Tried to read out of bounds, ReadHead: %u, ToRead: %u, Buffer: %u", m_ReadHead, bytes, m_SizeOfBuffer);
+			return false;
+		}
+			
 		memcpy(pBuffer, m_pBuffer + m_ReadHead, bytes);
 		m_ReadHead += bytes;
-		return this;
+		return true;
 	}
 
 	uint64 NetworkSegment::GetRemoteSalt() const

--- a/LambdaEngine/Source/Networking/API/UDP/ClientNetworkDiscovery.cpp
+++ b/LambdaEngine/Source/Networking/API/UDP/ClientNetworkDiscovery.cpp
@@ -177,7 +177,8 @@ namespace LambdaEngine
 		if (pPacket->GetType() == NetworkSegment::TYPE_NETWORK_DISCOVERY)
 		{
 			BinaryDecoder decoder(pPacket);
-			if (decoder.ReadString() == m_NameOfGame)
+			String str;
+			if(decoder.ReadString(str) && str == m_NameOfGame)
 			{
 				Timestamp ping = EngineLoop::GetTimeSinceStart() - m_TimeOfLastSearch;
 				std::scoped_lock<SpinLock> lock(m_LockReceivedPackets);
@@ -210,13 +211,20 @@ namespace LambdaEngine
 			m_BufferIndex = (m_BufferIndex + 1) % 2;
 		}
 
+		bool isLAN;
+		uint16 port;
+		uint64 serverUID;
+
 		for (Packet& packet : packets)
 		{
 			BinaryDecoder& decoder = packet.Decoder;
-			bool isLAN = decoder.ReadBool();
-			IPEndPoint endpoint(packet.Sender.GetAddress(), decoder.ReadUInt16());
-			uint64 serverUID = decoder.ReadUInt64();
-			m_pHandler->OnServerFound(decoder, endpoint, serverUID, packet.Ping, isLAN);
+
+			if (decoder.ReadBool(isLAN) && decoder.ReadUInt16(port) && decoder.ReadUInt64(serverUID))
+			{
+				IPEndPoint endpoint(packet.Sender.GetAddress(), port);
+				m_pHandler->OnServerFound(decoder, endpoint, serverUID, packet.Ping, isLAN);
+			}
+
 #ifdef LAMBDA_CONFIG_DEBUG
 			m_SegmentPool.FreeSegment(decoder.GetPacket(), "ClientNetworkDiscovery::HandleReceivedPacketsMainThread");
 #else

--- a/LambdaEngine/Source/Networking/API/UDP/ServerNetworkDiscovery.cpp
+++ b/LambdaEngine/Source/Networking/API/UDP/ServerNetworkDiscovery.cpp
@@ -138,7 +138,9 @@ namespace LambdaEngine
 		if (pPacket->GetType() == NetworkSegment::TYPE_NETWORK_DISCOVERY)
 		{
 			BinaryDecoder decoder(pPacket);
-			if (decoder.ReadString() == m_NameOfGame)
+			String str;
+			bool isLAN;
+			if (decoder.ReadString(str) && str == m_NameOfGame && decoder.ReadBool(isLAN))
 			{
 				std::set<NetworkSegment*, NetworkSegmentUIDOrder> packets;
 				TSet<uint32> reliableUIDs;
@@ -154,7 +156,7 @@ namespace LambdaEngine
 
 				BinaryEncoder encoder(pResponse);
 				encoder.WriteString(m_NameOfGame);
-				encoder.WriteBool(decoder.ReadBool());
+				encoder.WriteBool(isLAN);
 				encoder.WriteUInt16(m_PortOfGameServer);
 				encoder.WriteUInt64(m_ServerUID);
 				m_pHandler->OnNetworkDiscoveryPreTransmit(encoder);


### PR DESCRIPTION
## Purpose
  - A player is now prevented from joining a server that is busy or is full
  - A busy server is now displayed as yellow
  - If using a forced connection, the server will reply with either full or busy.
  - Notifications will be displayed for every error that may occur
  - Notifications are hidden automatically when the event has passed.

## Testing
- [ ] Tested in Sandbox
- [x] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [ ] Tested in Benchmark

