### PR TITLE
Fix benchmark, GUI and validation warning

### DIFF
--- a/CrazyCanvas/Source/GUI/EscapeMenuGUI.cpp
+++ b/CrazyCanvas/Source/GUI/EscapeMenuGUI.cpp
@@ -177,6 +177,8 @@ void EscapeMenuGUI::OnButtonLeaveClick(Noesis::BaseComponent* pSender, const Noe
 	pElement->SetVisibility(Noesis::Visibility_Collapsed);
 	m_ContextStack.pop();
 
+	LambdaEngine::GUIApplication::SetView(nullptr);
+
 	State* pMainMenuState = DBG_NEW MainMenuState();
 	StateManager::GetInstance()->EnqueueStateTransition(pMainMenuState, STATE_TRANSITION::POP_AND_PUSH);
 

--- a/CrazyCanvas/Source/GUI/GameOverGUI.cpp
+++ b/CrazyCanvas/Source/GUI/GameOverGUI.cpp
@@ -39,6 +39,8 @@ bool GameOverGUI::ConnectEvent(BaseComponent* pSource, const char* pEvent, const
 
 void GameOverGUI::OnReturnToLobbyButtonClick(BaseComponent* pSender, const RoutedEventArgs& args)
 {
+	LambdaEngine::GUIApplication::SetView(nullptr);
+
 	const PacketGameSettings& gameSettings = PlaySessionState::GetInstance()->GetGameSettings();
 	State* pLobbyState = DBG_NEW LobbyState(gameSettings, PlayerManagerClient::GetPlayerLocal());
 	StateManager::GetInstance()->EnqueueStateTransition(pLobbyState, STATE_TRANSITION::POP_AND_PUSH);

--- a/CrazyCanvas/Source/GUI/LobbyGUI.cpp
+++ b/CrazyCanvas/Source/GUI/LobbyGUI.cpp
@@ -575,6 +575,8 @@ void LobbyGUI::OnButtonLeaveClick(BaseComponent* pSender, const RoutedEventArgs&
 {
 	ClientHelper::Disconnect("Leaving lobby");
 
+	LambdaEngine::GUIApplication::SetView(nullptr);
+
 	State* pMainMenuState = DBG_NEW MultiplayerState();
 	StateManager::GetInstance()->EnqueueStateTransition(pMainMenuState, STATE_TRANSITION::POP_AND_PUSH);
 }

--- a/CrazyCanvas/Source/GUI/MainMenuGUI.cpp
+++ b/CrazyCanvas/Source/GUI/MainMenuGUI.cpp
@@ -178,6 +178,8 @@ void MainMenuGUI::OnButtonSandboxClick(BaseComponent* pSender, const RoutedEvent
 		return;
 #endif
 
+	LambdaEngine::GUIApplication::SetView(nullptr);
+
 	PacketGameSettings settings;
 	settings.MapID		= 0;
 	settings.GameMode	= EGameMode::CTF_TEAM_FLAG;
@@ -194,6 +196,8 @@ void MainMenuGUI::OnButtonMultiplayerClick(BaseComponent* pSender, const RoutedE
 	if (Input::GetCurrentInputmode() == EInputLayer::DEBUG)
 		return;
 #endif
+
+	LambdaEngine::GUIApplication::SetView(nullptr);
 
 	State* pLobbyState = DBG_NEW MultiplayerState();
 	StateManager::GetInstance()->EnqueueStateTransition(pLobbyState, STATE_TRANSITION::POP_AND_PUSH);

--- a/CrazyCanvas/Source/GUI/MultiplayerGUI.cpp
+++ b/CrazyCanvas/Source/GUI/MultiplayerGUI.cpp
@@ -252,6 +252,8 @@ void MultiplayerGUI::OnButtonBackClick(Noesis::BaseComponent* pSender, const Noe
 	UNREFERENCED_VARIABLE(pSender);
 	UNREFERENCED_VARIABLE(args);
 
+	LambdaEngine::GUIApplication::SetView(nullptr);
+
 	State* pMainMenuState = DBG_NEW MainMenuState();
 	StateManager::GetInstance()->EnqueueStateTransition(pMainMenuState, STATE_TRANSITION::POP_AND_PUSH);
 }

--- a/CrazyCanvas/Source/States/LobbyState.cpp
+++ b/CrazyCanvas/Source/States/LobbyState.cpp
@@ -132,6 +132,8 @@ bool LobbyState::OnPlayerStateUpdatedEvent(const PlayerStateUpdatedEvent& event)
 	{
 		if (pPlayer == PlayerManagerClient::GetPlayerLocal())
 		{
+			LambdaEngine::GUIApplication::SetView(nullptr);
+
 			State* pStartingState = DBG_NEW PlaySessionState(m_GameSettings);
 			StateManager::GetInstance()->EnqueueStateTransition(pStartingState, STATE_TRANSITION::POP_AND_PUSH);
 		}
@@ -182,6 +184,8 @@ bool LobbyState::OnClientDisconnected(const ClientDisconnectedEvent& event)
 	LOG_WARNING("PlaySessionState::OnClientDisconnected(Reason: %s)", reason.c_str());
 
 	PlayerManagerClient::Reset();
+
+	LambdaEngine::GUIApplication::SetView(nullptr);
 
 	State* pMainMenuState = DBG_NEW MainMenuState();
 	StateManager::GetInstance()->EnqueueStateTransition(pMainMenuState, STATE_TRANSITION::POP_AND_PUSH);

--- a/CrazyCanvas/Source/States/MultiplayerState.cpp
+++ b/CrazyCanvas/Source/States/MultiplayerState.cpp
@@ -91,6 +91,8 @@ bool MultiplayerState::OnClientConnected(const LambdaEngine::ClientConnectedEven
 		ServerManager::RegisterNewServer(serverInfo);
 	}
 
+	LambdaEngine::GUIApplication::SetView(nullptr);
+
 	State* pLobbyState = DBG_NEW LobbyState(m_MultiplayerGUI->GetPlayerName(), HasHostedServer());
 	StateManager::GetInstance()->EnqueueStateTransition(pLobbyState, STATE_TRANSITION::POP_AND_PUSH);
 

--- a/CrazyCanvas/Source/States/PlaySessionState.cpp
+++ b/CrazyCanvas/Source/States/PlaySessionState.cpp
@@ -202,6 +202,8 @@ bool PlaySessionState::OnClientDisconnected(const ClientDisconnectedEvent& event
 
 	PlayerManagerClient::Reset();
 
+	LambdaEngine::GUIApplication::SetView(nullptr);
+
 	State* pMainMenuState = DBG_NEW MainMenuState();
 	StateManager::GetInstance()->EnqueueStateTransition(pMainMenuState, STATE_TRANSITION::POP_AND_PUSH);
 

--- a/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
+++ b/LambdaEngine/Source/GUI/Core/GUIRenderer.cpp
@@ -761,7 +761,8 @@ namespace LambdaEngine
 		}
 		else
 		{
-			LOG_ERROR("Setview called with view == nullptr");
+			m_View = nullptr;
+			//LOG_ERROR("Setview called with view == nullptr");
 		}
 	}
 

--- a/LambdaEngine/Source/Rendering/LightRenderer.cpp
+++ b/LambdaEngine/Source/Rendering/LightRenderer.cpp
@@ -263,6 +263,10 @@ namespace LambdaEngine
 				for (uint32 d = 0; d < m_DrawCount; d++)
 				{
 					const DrawArg& drawArg = m_pDrawArgs[d];
+
+					if (drawArg.InstanceCount == 0)
+						continue;
+
 					pCommandList->BindIndexBuffer(drawArg.pIndexBuffer, 0, EIndexType::INDEX_TYPE_UINT32);
 
 					auto* descriptorSet = m_DrawArgsDescriptorSets[d].Get();


### PR DESCRIPTION
## Purpose
  - Benchmark crashed, this fixes that.
  - Validation layers printed out warnings on instance count, this fixes that.

## Changes
  - nullptr is now being set everytime a new view will be set (i.e. before every enqueue state), and the pointer in GUIRenderer is being updated with this value. This fixes the transition crashes that could occur, and might fix other GUI related crashes aswell.
  - Instance Count is now being checked in light renderer to avoid having a draw call with instance count == 0.

## Testing
How have one tested the feature to ensure it works?
- [x] Tested in Sandbox
- [ ] Tested in Multiplayer with 2 clients
- [ ] Tested in Multiplayer with more than 2 clients
- [x] Tested in Benchmark

